### PR TITLE
Fix a few things in obsolete compliance suites, and make XEP-0270 obsolete

### DIFF
--- a/xep-0242.xml
+++ b/xep-0242.xml
@@ -24,8 +24,13 @@
     <spec>XEP-0115</spec>
     <spec>XEP-0191</spec>
   </dependencies>
-  <supersedes/>
-  <supersededby/>
+  <supersedes>
+    <spec>XEP-0211</spec>
+    <spec>XEP-0213</spec>
+  </supersedes>
+  <supersededby>
+    <spec>XEP-0270</spec>
+  </supersededby>
   <shortname>N/A</shortname>
   &stpeter;
   <revision>

--- a/xep-0243.xml
+++ b/xep-0243.xml
@@ -21,13 +21,17 @@
     <spec>XEP-0045</spec>
     <spec>XEP-0054</spec>
     <spec>XEP-0124</spec>
-    <spec>XEP-0138</spec>
     <spec>XEP-0163</spec>
     <spec>XEP-0191</spec>
     <spec>XEP-0206</spec>
   </dependencies>
-  <supersedes/>
-  <supersededby/>
+  <supersedes>
+    <spec>XEP-0212</spec>
+    <spec>XEP-0216</spec>
+  </supersedes>
+  <supersededby>
+    <spec>XEP-0270</spec>
+  </supersededby>
   <shortname>N/A</shortname>
   &stpeter;
   <revision>

--- a/xep-0270.xml
+++ b/xep-0270.xml
@@ -21,8 +21,10 @@
     <spec>XEP-0045</spec>
     <spec>XEP-0054</spec>
     <spec>XEP-0114</spec>
+    <spec>XEP-0115</spec>
     <spec>XEP-0124</spec>
     <spec>XEP-0163</spec>
+    <spec>XEP-0178</spec>
     <spec>XEP-0191</spec>
     <spec>XEP-0206</spec>
   </dependencies>


### PR DESCRIPTION
I know XEP-0001 doesn’t have any direct path from draft standard to obsolete, but I think XEP-0270 has been implicitely deprecated since XEP-0302 was made.

The other changes are just fixing small mistakes.