### PR TITLE
XEP-0082 errounously states that CCYY has four digits

### DIFF
--- a/xep-0082.xml
+++ b/xep-0082.xml
@@ -80,7 +80,7 @@
     <p>The following acronyms and characters are used herein to represent time-related concepts:</p>
     <table caption='Acronyms and Characters'>
       <tr><th>Term</th><th>Definition</th></tr>
-      <tr><td>CCYY</td><td>four-digit year portion of Date</td></tr>
+      <tr><td>CCYY</td><td>four-or-more digit year portion of Date, possible prefixed with a minus sign</td></tr>
       <tr><td>MM</td><td>two-digit month portion of Date</td></tr>
       <tr><td>DD</td><td>two-digit day portion of Date</td></tr>
       <tr><td>-</td><td>ISO 8601 separator among Date portions</td></tr>


### PR DESCRIPTION
Submitted to editors mailing list:  http://mail.jabber.org/pipermail/editor/2015-April/000330.html