### PR TITLE
add a local helper routine to mimic what getLatestXEPFilename does for a non-mercurial working dir

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -323,9 +323,24 @@ def buildPDF( file, nr ):
 		
 	return True
 
+def getTempContents(filename):
+	try:
+		with open(filename, 'r') as h:
+			content = h.read()
+		(fd, name) = tempfile.mkstemp();
+		handle = os.fdopen(fd, "w+b")
+		handle.write(content)
+		handle.close()
+		return name;
+	except Exception as e:
+		print e
+		return False
+
 def buildXEP( filename ):
 	nr = re.match("xep-(\d\d\d\d).xml", filename).group(1)
-	xepfilepath = getLatestXEPFilename("../", nr);
+	xepfilepath = getLatestXEPFilename("../", nr)
+	if not xepfilepath:
+		xepfilepath = getTempContents(filename)
 	if not xepfilepath:
 		print "getLatestXEPContent (ERROR)"
 		return


### PR DESCRIPTION
work-around for issue #10 

Current gen.py assumes that the parent dir contains a mercurial repo and then walks the revisions to find the latest content for a given filename - this is then copied into a temp directory for the buildXEP() code to process.

This routine reads the contents for the given filename relative to the current working directory because it assumes that it's being called after getLatestXEPFilename() has failed.

This is a very quick work around to the issue, the real fix is to continue the work others have done to get xsf-tools working.