### PR TITLE
s/-storage/-store/ in XEP-0334

### DIFF
--- a/xep-0334.xml
+++ b/xep-0334.xml
@@ -77,13 +77,13 @@
 </section1>
 <section1 topic="Hints" anchor="hints">
   <section2 topic="No permanent storage" anchor="no-permanent-store">
-    <p>The &lt;no-permanent-storage/&gt; hint informs entities that they shouldn't store the message in
+    <p>The &lt;no-permanent-store/&gt; hint informs entities that they shouldn't store the message in
       any permanent or semi-permanent public or private archive (such as described in &xep0136; and &xep0313;)
       or in logs (such as chatroom logs).
     </p>
   </section2>
   <section2 topic="No storage" anchor="no-store">
-    <p>A message containing a &lt;no-storage/&gt; hint should not be stored by a server either permanently (as above)
+    <p>A message containing a &lt;no-store/&gt; hint should not be stored by a server either permanently (as above)
     or temporarily, e.g. for later delivery to an offline client, or to users not currently present in a chatroom.
     </p>
   </section2>


### PR DESCRIPTION
I used the "store" version because it was usec most often, and it was in the schema.