### PR TITLE
Add <uri /> to XEP-0358

### DIFF
--- a/xep-0358.xml
+++ b/xep-0358.xml
@@ -63,6 +63,7 @@
   <jinglepub xmlns='urn:xmpp:jinglepub:1'
              from='sender-jid'
              id='someid'>
+    [<uri/> element for an alternate or informational URI of the content]
     [<meta/> element(s) for human-friendly information]
     [<description/> element(s) for application format(s)]
   </jinglepub>
@@ -71,6 +72,7 @@
     <p>The 'id' attribute is an opaque identifier. This attribute MUST be present, and MUST be a valid non-empty string. It uniquely identifies the published request at the session owner's JID.</p>
     <p>The &lt;jinglepub/&gt; element MUST contain a &lt;description/&gt; element qualified by the namespace of the relevant Jingle application format (e.g., &lt;description xmlns='urn:xmpp:jingle:apps:file-transfer:4'/&gt; for file transfer).</p>
     <p>The &lt;jinglepub/&gt; element MAY contain one or more &lt;meta/&gt; elements qualified by the jingle-pub namespace; if more than one element is included, each element MUST have a different value for the 'xml:lang' attribute.</p>
+    <p>The &lt;jinglepub/&gt; element MAY contain a &lt;uri/&gt; element which contains a URI for an alternative way to access the content, or other information about the content. The resource provided by the URI SHOULD be meaningful for clients that do not directly support the included Jingle content definitions, and accessing the URI MAY result in a different experience than initiating the published Jingle session. For example, the URI could be to a content landing page of an image hosting service from which an image could be viewed instead of directly downloading the image file.</p>
     <p>The &lt;jinglepub/&gt; information is typically provided via pubsub.</p>
     <p>The following example shows a possible payload for streaming of recorded audio/video sessions, here pushed out via PEP.</p>
     <example caption='Sender advertises session via PEP'><![CDATA[
@@ -251,10 +253,11 @@
 
   <xs:element name='jinglepub'>
     <xs:complexType>
-      <xs:sequence>
-        <xs:any namespace='##other' minOccurs='1' maxOccurs='unbounded'/>
-        <xs:element name='meta' type='metaElementType'/>
-      </xs:sequence>
+      <xs:all>
+        <xs:any namespace='##other' minOccurs='0' maxOccurs='unbounded'/>
+        <xs:element name='meta' type='metaElementType' minOccurs='0' maxOccurs='unbounded' />
+        <xs:element name='uri' type='xs:anyURI' minOccurs='0' maxOccurs='1' />
+      </xs:all>
       <xs:attribute name='description' type='xs:string' use='optional'/>
       <xs:attribute name='from' type='xs:string' use='required'/>
       <xs:attribute name='id' type='xs:string' use='required'/>


### PR DESCRIPTION
Allows including a link to the advertised content or alternatives. For example, an advertisement for a  RTP video stream could include a link to a web page with a video player for the stream.

@stpeter