### PR TITLE
XEP-0033: Multicast service MUST track directed presence broadcast

### DIFF
--- a/xep-0033.xml
+++ b/xep-0033.xml
@@ -27,6 +27,13 @@
         &stpeter;
 
         <revision>
+            <version>1.2</version>
+            <date>2015-09-22</date>
+            <initials>mre</initials>
+            <remark>Clarification: Multicast service MUST track directed presence broadcast to later ensure broadcast of subsequent unvailable presence to the same receiving parties.</remark>
+        </revision>
+
+        <revision>
             <version>1.1</version>
             <date>2004-09-15</date>
             <initials>psa</initials>
@@ -287,18 +294,28 @@
     <section1 topic='Business Rules' anchor='rules'>
       <section2 topic='Directed Presence' anchor='presence'>
 
-        <p>The multicast service MUST keep track of the entities it
-        sent a presence with an absent 'type' attribute (i.e. an
-        'available' presence) to and the originating entity of that
-        presence. If the multicast service receives an unavailable
-        presence from one of the tracked originating entities, it MUST
-        broadcast this presence to all tracked entities which have not
-        yet received an unavailable presence from the originating
-        entity, even if the presence does not contain explicit
-        broadcast addresses. Thus the multicast service ensures that
-        all entities, which have received an (directed) 'available'
-        presence over it, receive the related 'unavailable'
-        presence.</p>
+        <p>This specification can be used to, in effect, send directed
+        presence (see Section 4.6 of &rfc6121;). In order to ensure
+        that entities that have received directed available presence
+        through the service also are informed when the originating
+        entity sends unavailable presence, the multicast service MUST
+        do the following:</p>
+
+
+        <ol>
+          <li>Keep track of the entities to which it sends available
+          presence (i.e., presence stanzas with no 'type' attribute)
+          along with the originating entity of that presence.</li>
+
+          <li>Upon receiving a presence stanza of type "unavailable"
+          from an originating entity, broadcast that unavailable
+          presence to all entities to which it has send available
+          presence.</li>
+        </ol>
+
+        <p>In this way, the multicast service ensures that all
+        entities which have received available presence through the
+        service also receive the associated unavailable presence.</p>
       </section2>
     </section1>
     

--- a/xep-0033.xml
+++ b/xep-0033.xml
@@ -284,6 +284,25 @@
         </section2>
     </section1>
 
+    <section1 topic='Business Rules' anchor='rules'>
+      <section2 topic='Directed Presence' anchor='presence'>
+        <p>To ensure that entities that have received directed
+        presence through a multicast service will get the unvailable
+        presence when the originating client closes the its session,
+        the multicast service should also relay unvailable presence
+        stanzas.</p>
+        <p>When transferring an extended addressing presence stanza,
+        the multicast service MUST keep track of the entities that
+        have received the individual directed presence packets.</p>
+        <p>When the multicast service receive an unavailable presence
+        stanza without extended addresses, it MUST broadcast the
+        updated presence to all the entities that have received a
+        directed presence previously (if the multicast service has not
+        yet sent unavailable presence to a precise entity through a
+        previous extended stanza presence).</p>
+      </section2>
+    </section1>
+    
     <section1 topic='Multicast Usage' anchor='multicast'>
         <p>The following usage scenario shows how messages flow through both address-enabled and non-address-enabled portions of the Jabber network.</p>
     

--- a/xep-0033.xml
+++ b/xep-0033.xml
@@ -29,7 +29,7 @@
         <revision>
             <version>1.2</version>
             <date>2015-09-22</date>
-            <initials>mre</initials>
+            <initials>mre/psa</initials>
             <remark>Clarification: Multicast service MUST track directed presence broadcast to later ensure broadcast of subsequent unvailable presence to the same receiving parties.</remark>
         </revision>
 

--- a/xep-0033.xml
+++ b/xep-0033.xml
@@ -286,20 +286,19 @@
 
     <section1 topic='Business Rules' anchor='rules'>
       <section2 topic='Directed Presence' anchor='presence'>
-        <p>To ensure that entities that have received directed
-        presence through a multicast service will get the unvailable
-        presence when the originating client closes the its session,
-        the multicast service should also relay unvailable presence
-        stanzas.</p>
-        <p>When transferring an extended addressing presence stanza,
-        the multicast service MUST keep track of the entities that
-        have received the individual directed presence packets.</p>
-        <p>When the multicast service receive an unavailable presence
-        stanza without extended addresses, it MUST broadcast the
-        updated presence to all the entities that have received a
-        directed presence previously (if the multicast service has not
-        yet sent unavailable presence to a precise entity through a
-        previous extended stanza presence).</p>
+
+        <p>The multicast service MUST keep track of the entities it
+        sent a presence with an absent 'type' attribute (i.e. an
+        'available' presence) to and the originating entity of that
+        presence. If the multicast service receives an unavailable
+        presence from one of the tracked originating entities, it MUST
+        broadcast this presence to all tracked entities which have not
+        yet received an unavailable presence from the originating
+        entity, even if the presence does not contain explicit
+        broadcast addresses. Thus the multicast service ensures that
+        all entities, which have received an (directed) 'available'
+        presence over it, receive the related 'unavailable'
+        presence.</p>
       </section2>
     </section1>
     


### PR DESCRIPTION
This is to ensure entity will not stay permanently seen as online after a multicasted directed presence.