### PR TITLE
add pointer to published schema

### DIFF
--- a/xep-0016.xml
+++ b/xep-0016.xml
@@ -19,6 +19,9 @@
   <supersedes/>
   <supersededby/>
   <shortname>privacy</shortname>
+  <schemaloc>
+    <url>http://xmpp.org/schemas/privacy.xsd</url>
+  </schemaloc>
   &pgmillard;
   &stpeter;
   <revision>


### PR DESCRIPTION
Although lost to the annals of time now, very likely the &lt;schemaloc&gt; was removed when XEP-0016 transitioned from:

1. **Draft** to **Deprecated** (because draft-ietf-xmpp-im included iq:privacy)
2. **Deprecated** to **Retracted** (because RFC 3921 included iq:privacy)
3. **Retracted** to **Draft** (because RFC 6121 removed iq:privacy)

This change is simply adding (back?) the publication pointer for consistency with other XEPs.