### PR TITLE
XEP-0280: Fix bare-JID example to match RFC 6121

### DIFF
--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -244,7 +244,7 @@
   <example caption='Message Forked to each of Romeo&apos;s Carbons-enabled resources'><![CDATA[
 <message xmlns='jabber:client'
          from='juliet@capulet.example/balcony'
-         to='romeo@montague.example/garden'
+         to='romeo@montague.example'
          type='chat'>
   <body>Wherefore art thou, Romeo?</body>
   <thread>0e3141cd80894871a68e6fe6b1ec56fa</thread>
@@ -252,7 +252,7 @@
 
 <message xmlns='jabber:client'
          from='juliet@capulet.example/balcony'
-         to='romeo@montague.example/home'
+         to='romeo@montague.example'
          type='chat'>
   <body>Wherefore art thou, Romeo?</body>
   <thread>0e3141cd80894871a68e6fe6b1ec56fa</thread>


### PR DESCRIPTION
[RFC 6121 § 8.5.2.1.1](https://tools.ietf.org/html/rfc6121#section-8.5.2.1.1) states:

> In all cases, the server MUST NOT rewrite the 'to' attribute (i.e.,
> it MUST leave it as `<localpart@domainpart>` rather than change it to
> `<localpart@domainpart/resourcepart>`).