### PR TITLE
Fix otr-info construction section

### DIFF
--- a/inbox/otr-info.xml
+++ b/inbox/otr-info.xml
@@ -147,14 +147,10 @@
 <section1 topic='OTR Messages'>
 	<section2 topic='Construction and Decoding'>
 		<p>
-			When sending a message encrypted with OTR, it is RECOMMENDED to encrypt
-			only the text node of the &lt;body/&gt; element (the message itself).
-			However, there are some clients in the wild which will encrypt the entire
-			contents of the &lt;body/&gt; element, including sub-nodes. Because of
-			this behavior, it is RECOMMENDED that clients decrypt and expand any OTR
-			messages inside of the body element before re-processing the element as a
-			whole. Clients that support OTR MUST tolerate encrypted payloads which
-			expand to XML, and those which expand to plain text messages.
+			Some clients in the wild have been known to insert XML in the
+			&lt;body&gt; node of a message. Clients that support OTR should tolerate
+			encrypted payloads which expand to unescaped XML, and treat it as plain
+			text.
 		</p>
 	</section2>
 	<section2 topic='Routing'>
@@ -270,10 +266,8 @@ xmpp:feste@allfools.lit?otr-fingerprint=AEA4D503298797D4A4FC823BC1D24524B4C54338
 				https://www.schneier.com/blog/archives/2012/10/when_will_we_se.html
 			</link>&gt;
 		</note>.
-		This puts generating SHA-1 collisions well within the reach of governments
-		and well funded criminal organizations. In this authors opinion, there are
-		no theoretical vulnerabilities, and SHA-1 should be treated with extreme
-		caution.
+		This puts generating SHA-1 collisions well within the reach of governments,
+		malicious organizations, and even well-funded individuals.
 	</p>
 </section1>
 <section1 topic='IANA Considerations' anchor='iana'>


### PR DESCRIPTION
Don't work around clients that don't behave properly and stick extra XML in the <body> node.

Also remove a confusing opinion from the security section.