### PR TITLE
XEP-0364: Discourage new implementations of OTR

### DIFF
--- a/xep-0364.xml
+++ b/xep-0364.xml
@@ -74,8 +74,13 @@
 		</note>
 		and will not be redescribed here. Instead, this document aims to describe
 		OTR's usage and best practices within XMPP. It is not intended to be a
-		current standard, or technical specification, as better (albeit, newer and
-		less well tested) methods of end-to-end encryption exist for XMPP.
+		current standard, or technical specification.
+	</p>
+	<p>
+		It should be noted that newer, more secure encryption protocols exist for
+		XMPP, and that new implementations of OTR are discouraged. This document is
+		primarily intended to document and resolve issues with existing
+		implementations of OTR.
 	</p>
 </section1>
 <section1 topic='Overview' anchor='overview'>


### PR DESCRIPTION
Discourage new OTR implementations in XEP-0364 as discussed in the editors MUC.

This is not a technical or protocol change, just a clarification to make an existing statement stand out more.