### PR TITLE
Update OTR Disco's security section

### DIFF
--- a/inbox/otrdisco.xml
+++ b/inbox/otrdisco.xml
@@ -83,7 +83,7 @@
 		<p>
 			Because OTR support is advertised outside of any end-to-end encrypted
 			stream, it may be subject to downgrade attacks (eg. the server operator
-			may remove one or more versions of OTR from the list).
+			may remove OTR from the features list).
 		</p>
 	</section1>
 	<section1 topic='IANA Considerations' anchor='iana'>


### PR DESCRIPTION
Update the security section of OTR Disco to fix an outdated statement that doesn't make sense with the current version of the XEP.