### PR TITLE
clarify the no-storage/no-store confusion in XEP-0334 and add a new hint

### DIFF
--- a/xep-0334.xml
+++ b/xep-0334.xml
@@ -22,6 +22,15 @@
   <shortname>NOT_YET_ASSIGNED</shortname>
   &mwild;
   <revision>
+    <version>0.2</version>
+    <date>2015-09-01</date>
+    <initials>dg</initials>
+    <remark>
+      <p>Fixed the wrong use of no-storage instead of no-store</p>
+      <p>Added a message hint &lt;pretty-please-store/&gt;</p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.1</version>
     <date>2013-07-11</date>
     <initials>psa</initials>
@@ -45,6 +54,7 @@
   <ul>
     <li>Whether to store a message (e.g. for archival or as an 'offline message').</li>
     <li>Whether to copy a message to other resources.</li>
+    <li>Whether to store a message that would not have been stored under normal conditions</li>
   </ul>
 </section1>
 <section1 topic='Use Cases' anchor='usecases'>
@@ -74,16 +84,19 @@
     recipient is offline at the time of sending). Such a message can be marked with the &lt;no-permanent-store/&gt; hint.
   </p>
 </section2>
+<section2 topic="Storage-worthy messages" anchor='store-worthy'>
+  <p>Offline storage and &xep0313; can define their own rules on what messages to store and usually only store messages that contain a body element. However a sender may want to indicate that a message is worth storeing even though it might not match those rules (e.g. an encrypted message that carries the payload outside the body element). Such a message can be marked with a &lt;pretty-please-store/&gt; hint.</p>
+</section2>
 </section1>
 <section1 topic="Hints" anchor="hints">
-  <section2 topic="No permanent storage" anchor="no-permanent-store">
-    <p>The &lt;no-permanent-storage/&gt; hint informs entities that they shouldn't store the message in
+  <section2 topic="No permanent store" anchor="no-permanent-store">
+    <p>The &lt;no-permanent-store/&gt; hint informs entities that they shouldn't store the message in
       any permanent or semi-permanent public or private archive (such as described in &xep0136; and &xep0313;)
       or in logs (such as chatroom logs).
     </p>
   </section2>
-  <section2 topic="No storage" anchor="no-store">
-    <p>A message containing a &lt;no-storage/&gt; hint should not be stored by a server either permanently (as above)
+  <section2 topic="No store" anchor="no-store">
+    <p>A message containing a &lt;no-store/&gt; hint should not be stored by a server either permanently (as above)
     or temporarily, e.g. for later delivery to an offline client, or to users not currently present in a chatroom.
     </p>
   </section2>
@@ -94,6 +107,9 @@
       defined in &xmppim; for handling messages to bare JIDs, which may involve copying to multiple resources, or multiple
       occupants in a &xep0045; room.
     </p>
+  </section2>
+  <section2 topic="Pretty please store">
+    <p>A message containing the &lt;pretty-please-store/&gt; hint that is not of type 'error' SHOULD be stored by the entity.</p>
   </section2>
 </section1>
 <section1 topic='Business Rules' anchor='rules'>
@@ -122,6 +138,7 @@
   <xs:element name='no-permanent-store' type='empty'/>
   <xs:element name='no-store' type='empty'/>
   <xs:element name='no-copy' type='empty'/>
+  <xs:element name='pretty-please-store' type='empty'/>
 
   <xs:simpleType name='empty'>
     <xs:restriction base='xs:string'>

--- a/xep-0334.xml
+++ b/xep-0334.xml
@@ -27,7 +27,7 @@
     <initials>dg</initials>
     <remark>
       <p>Fixed the wrong use of no-storage instead of no-store</p>
-      <p>Added a message hint &lt;pretty-please-store/&gt;</p>
+      <p>Added a message hint &lt;store/&gt;</p>
     </remark>
   </revision>
   <revision>
@@ -85,7 +85,7 @@
   </p>
 </section2>
 <section2 topic="Storage-worthy messages" anchor='store-worthy'>
-  <p>Offline storage and &xep0313; can define their own rules on what messages to store and usually only store messages that contain a body element. However a sender may want to indicate that a message is worth storeing even though it might not match those rules (e.g. an encrypted message that carries the payload outside the body element). Such a message can be marked with a &lt;pretty-please-store/&gt; hint.</p>
+  <p>Offline storage and &xep0313; can define their own rules on what messages to store and usually only store messages that contain a body element. However a sender may want to indicate that a message is worth storeing even though it might not match those rules (e.g. an encrypted message that carries the payload outside the body element). Such a message can be marked with a &lt;store/&gt; hint.</p>
 </section2>
 </section1>
 <section1 topic="Hints" anchor="hints">
@@ -108,8 +108,8 @@
       occupants in a &xep0045; room.
     </p>
   </section2>
-  <section2 topic="Pretty please store">
-    <p>A message containing the &lt;pretty-please-store/&gt; hint that is not of type 'error' SHOULD be stored by the entity.</p>
+  <section2 topic="Store">
+    <p>A message containing the &lt;store/&gt; hint that is not of type 'error' SHOULD be stored by the entity.</p>
   </section2>
 </section1>
 <section1 topic='Business Rules' anchor='rules'>
@@ -138,7 +138,7 @@
   <xs:element name='no-permanent-store' type='empty'/>
   <xs:element name='no-store' type='empty'/>
   <xs:element name='no-copy' type='empty'/>
-  <xs:element name='pretty-please-store' type='empty'/>
+  <xs:element name='store' type='empty'/>
 
   <xs:simpleType name='empty'>
     <xs:restriction base='xs:string'>


### PR DESCRIPTION
the message hints XEP confusingly talks about no-storage and no-permanent-storage in one place even though no-store was meant
added a new message hint to ask the server to store messages even though they do not contain a body. like encrypted messages