### PR TITLE
XEP-0280: Carbons processing hints update

### DIFF
--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -41,6 +41,14 @@
     <jid>linuxwolf@outer-planes.net</jid>
   </author>
   <revision>
+    <version>0.11</version>
+    <date>2015-09-13</date>
+    <initials>ssw</initials>
+    <remark>
+      <p>Remove &lt;private&gt; in favor of XEP-0334's &lt;no-copy&gt;.</p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.10</version>
     <date>2015-08-24</date>
     <initials>mm (editor)</initials>
@@ -245,7 +253,7 @@
             <li>A &MESSAGE; is eligible for carbons delivery if it is of type "chat".</li>
             <li>A &MESSAGE; is eligible for carbons delivery if it is of type "normal" and it contains a &lt;body&gt; element.</li>
             <li>A &MESSAGE; is eligible for carbons delivery if it is of type "error" and sent in response to a &MESSAGE; that was itself eligible for carbons delivery (Note that as this would require message tracking and correlation on the server, it is unlikely to be generally appropriate for most implementations).</li>
-	    <li>A &MESSAGE; is not eligible for carbons delivery if it is determined to have been sent by a MUC room or service, even if it would be otherwise eligible (this also includes private messages from MUC participants).</li>
+            <li>A &MESSAGE; is not eligible for carbons delivery if it is determined to have been sent by a MUC room or service, even if it would be otherwise eligible (this also includes private messages from MUC participants).</li>
             <li>A &MESSAGE; is not eligible for carbons delivery if it does not meet any of these criteria.</li>
         </ul>
     </p>
@@ -321,34 +329,14 @@
 
   <p>The sending server SHOULD NOT send a forwarded copy to the sending full JID if it is a Carbons-enabled resource.</p>
 
-</section1> 
+</section1>
 <section1 topic='Avoiding Carbons for a single message' anchor='avoiding'>
-  <p>Some clients might want to avoid Carbons on a single message, while still keeping all of the other semantics of Carbon support. This might be useful for clients sending end-to-end encrypted messages, for example. To exclude a &MESSAGE; from being forwarded to other Carbons-enabled resources, the sending client add a &lt;private/&gt; element qualified by the namespace "urn:xmpp:carbons:2" as a child content element to the &MESSAGE; stanza.</p>
+  <p>Some clients might want to avoid Carbons on a single message, while still keeping all of the other semantics of Carbon support. This might be useful for clients sending end-to-end encrypted messages, for example. To exclude a &MESSAGE; from being forwarded to other Carbons-enabled resources, the sending client add a &lt;no-copy/&gt; element as defined in &XEP0334;.</p>
+  <p><strong>Note:</strong> use of the no-copy mechanism might lead to partial conversations on other devices. This is the intended effect.</p>
 
-  <p><strong>Note:</strong> use of the private mechanism might lead to partial conversations on other devices.  This is the intended effect.</p>
-
-  <example caption='Romeo sends to Juliet, excluding Carbons'><![CDATA[
-<message xmlns='jabber:client'
-         from='romeo@montague.example/home'
-         to='juliet@capulet.example/home'
-         type='chat'>
-  <body>Neither, fair saint, if either thee dislike.</body>
-  <thread>0e3141cd80894871a68e6fe6b1ec56fa</thread>
-  <private xmlns='urn:xmpp:carbons:2'/>
-</message>]]></example>
-
-  <example caption='Romeo&apos;s server delivers original message, without creating Carbon copies'><![CDATA[
-<message xmlns='jabber:client'
-         from='romeo@montague.example/home'
-         to='juliet@capulet.example/home'
-         type='chat'>
-  <body>Neither, fair saint, if either thee dislike.</body>
-  <thread>0e3141cd80894871a68e6fe6b1ec56fa</thread>
-  <private xmlns='urn:xmpp:carbons:2'/>
-</message>]]></example>
-  <p>The sending server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resources of the sender. The receiving server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resource of the recipient, and SHOULD remove the &lt;private/&gt; element before delivering to the recipient.</p>
-  <p><strong>Note:</strong> if the private &MESSAGE; stanza is addressed to a bare JID, the receiving server still delivers it according to <cite>RFC 6121</cite>. This might result in a copy being delivered to each resource for the recipient, which effectively negates the behavior of the &lt;private/&gt; element for recipients.</p>
-</section1> 
+  <p>The sending server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resources of the sender. The receiving server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resource of the recipient, and SHOULD remove the &lt;no-copy/&gt; element before delivering to the recipient.</p>
+  <p><strong>Note:</strong> if the no-copy &MESSAGE; stanza is addressed to a bare JID, the receiving server still delivers it according to <cite>RFC 6121</cite>. This might result in a copy being delivered to each resource for the recipient, which effectively negates the behavior of the &lt;no-copy/&gt; element for recipients.</p>
+</section1>
 <section1 topic='Business Rules' anchor='bizrules'>
   <section2 topic='Handling Multiple Enable/Disable Requests' anchor='bizrules-multi'>
     <p>If a client is permitted to enable Carbons during its login session, the server MUST allow the client to enable and disable the protocol multiple times within a session.  The server SHOULD NOT treat multiple enable requests (without an intermediate disable request) as an error; it SHOULD simply return an IQ-result (if the protocol is already enabled) or an IQ-error (if the client is not permitted to enable Carbons) for any subsequent requests after the first. Similarly, the server SHOULD NOT treat multiple disable requests (without an intermediate enable request) as an error; it SHOULD return an IQ-result (if the protocols is already disabled) or an IQ-error (if the client's request failed previously) for any subsequent requests after the first.</p>
@@ -377,7 +365,7 @@
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
   <p>The security model assumed by this document is that all of the resources for a single user are in the same trust boundary. Any forwarded copies received by a Carbons-enabled client MUST be from that user's bare JID; any copies that do not meet this requirement MUST be ignored.</p>
-  <p>Outbound chat messages that are encrypted end-to-end are not often useful to receive on other resources.  As such, they should use the &lt;private/&gt; element specified above to avoid such copying, unless the encryption mechanism is able to accommodate this protocol.</p>
+  <p>Outbound chat messages that are encrypted end-to-end are not often useful to receive on other resources.  As such, they should use the &lt;no-copy/&gt; element specified above to avoid such copying, unless the encryption mechanism is able to accommodate this protocol.</p>
 </section1>
 <section1 topic='IANA Considerations' anchor='iana'>
   <p>This document requires no interaction with &IANA;.</p> 
@@ -405,10 +393,8 @@
     elementFormDefault='qualified'>
 
   <xs:element name='disable' type='empty'/>
-  
-  <xs:element name='enable' type='empty'/>
 
-  <xs:element name='private' type='empty'/>
+  <xs:element name='enable' type='empty'/>
 
   <xs:element name='received' type='forward-container'/>
 
@@ -419,7 +405,7 @@
       <xs:enumeration value=''/>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:complexType name='foward-container' abstract='true'>
     <xs:choice>
       <xs:element name='forwarded'

--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -149,7 +149,7 @@
   </ul>
 </section1>
 <section1 topic='Discovering Support' anchor='disco'>
-  <p>An entity advertises support for this protocol by including the "urn:xmpp:carbons:2" feature in its service discovery information features as specified in &xep0030; or section 6.3 of &xep0115;.</p>
+  <p>An entity advertises support for this protocol by including the "urn:xmpp:carbons:3" feature in its service discovery information features as specified in &xep0030; or section 6.3 of &xep0115;.</p>
   <example caption='Client requests information about its own server'><![CDATA[
 <iq xmlns='jabber:client'
     from='romeo@montague.example/garden'
@@ -166,20 +166,20 @@
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     ...
-    <feature var='urn:xmpp:carbons:2'/>
+    <feature var='urn:xmpp:carbons:3'/>
     ...
   </query>
 </iq>]]></example>
 </section1> 
 
 <section1 topic='Enabling Carbons' anchor='enabling'>
-  <p>When a client wants to participate in the Carbons protocol, it enables the protocol by sending an IQ-set containing a child element &lt;enable/&gt; qualified by the namespace "urn:xmpp:carbons:2":</p>
+  <p>When a client wants to participate in the Carbons protocol, it enables the protocol by sending an IQ-set containing a child element &lt;enable/&gt; qualified by the namespace "urn:xmpp:carbons:3":</p>
   <example caption='Client enables Carbons'><![CDATA[
 <iq xmlns='jabber:client'
     from='romeo@montague.example/garden'
     id='enable1'
     type='set'>
-  <enable xmlns='urn:xmpp:carbons:2'/>
+  <enable xmlns='urn:xmpp:carbons:3'/>
 </iq>]]></example>
     <p>The server will respond with an IQ-result when Carbons are enabled:</p>
     <example caption='Server acknowledges enabling Carbons'><![CDATA[
@@ -210,13 +210,13 @@
 </section1> 
 
 <section1 topic='Disabling Carbons' anchor='disabling'>
-  <p>Some clients might want to disable Carbons.  To disable Carbons, the client sends an IQ-set containing a child element &lt;disable/&gt; qualified by the namespace "urn:xmpp:carbons:2":</p>
+  <p>Some clients might want to disable Carbons.  To disable Carbons, the client sends an IQ-set containing a child element &lt;disable/&gt; qualified by the namespace "urn:xmpp:carbons:3":</p>
   <example caption='Client disables Carbons'><![CDATA[
 <iq xmlns='jabber:client'
     from='romeo@montague.example/garden'
     id='disable1'
     type='set'>
-  <disable xmlns='urn:xmpp:carbons:2'/>
+  <disable xmlns='urn:xmpp:carbons:3'/>
 </iq>]]></example>
   <p>The server will respond with an IQ-result when Carbons are disabled:</p>
   <example caption='Server acknowledges disabling Carbons'><![CDATA[
@@ -264,7 +264,7 @@
 
 <section1 topic='Receiving Messages' anchor='inbound'>
   <p>When the server receives a &MESSAGE; <link url='#which-messages'>eligible for carbons delivery</link> addressed to a client JID (either bare or full), it delivers the &MESSAGE; according to <cite>RFC 6121</cite> § 8.5.3, and then delivers a forwarded copy to each Carbons-enabled resource for the matching bare JID recipient that did not receive it under the RFC 6121 delivery rules.</p>
-  <p>Each forwarded copy is wrapped using &xep0297;. The wrapping message SHOULD maintain the same 'type' attribute value; the 'from' attribute MUST be the Carbons-enabled user's bare JID (e.g., "localpart@domainpart"); and the 'to' attribute MUST be the full JID of the resource receiving the copy. The content of the wrapping message MUST contain a &lt;received/&gt; element qualified by the namespace "urn:xmpp:carbons:2", which itself contains a &lt;forwarded/&gt; element qualified by the namespace "urn:xmpp:forward:0" that contains the original &MESSAGE;.</p>
+  <p>Each forwarded copy is wrapped using &xep0297;. The wrapping message SHOULD maintain the same 'type' attribute value; the 'from' attribute MUST be the Carbons-enabled user's bare JID (e.g., "localpart@domainpart"); and the 'to' attribute MUST be the full JID of the resource receiving the copy. The content of the wrapping message MUST contain a &lt;received/&gt; element qualified by the namespace "urn:xmpp:carbons:3", which itself contains a &lt;forwarded/&gt; element qualified by the namespace "urn:xmpp:forward:0" that contains the original &MESSAGE;.</p>
   
   <example caption='Juliet sends Romeo a directed message'><![CDATA[
 <message xmlns='jabber:client'
@@ -280,7 +280,7 @@
          from='romeo@montague.example'
          to='romeo@montague.example/home'
          type='chat'>
-  <received xmlns='urn:xmpp:carbons:2'>
+  <received xmlns='urn:xmpp:carbons:3'>
     <forwarded xmlns='urn:xmpp:forward:0'>
       <message xmlns='jabber:client'
                from='juliet@capulet.example/balcony'
@@ -298,7 +298,7 @@
 </section1> 
 <section1 topic='Sending Messages' anchor='outbound'>
   <p>When a client sends a &MESSAGE; <link url='#which-messages'>eligible for carbons delivery</link>, its sending server delivers the &MESSAGE; according to <cite>RFC 6120</cite> and <cite>RFC 6121</cite>, and delivers a forwarded copy to each Carbons-enabled resource for the matching bare JID sender, excluding the sending client. Note that this happens irrespective of whether the sending client has carbons enabled.</p>
-  <p>Each forwarded copy is wrapped using &xep0297;. The wrapping message SHOULD maintain the same 'type' attribute value; the 'from' attribute MUST be the Carbons-enabled user's bare JID (e.g., "localpart@domainpart"); and the 'to' attribute SHOULD be the full JID of the resource receiving the copy. The content of the wrapping message MUST contain a &lt;sent/&gt; element qualified by the namespace "urn:xmpp:carbons:2", which itself contains a &lt;forwarded/&gt; qualified by the namespace "urn:xmpp:forward:0" that contains the original &MESSAGE; stanza.</p>
+  <p>Each forwarded copy is wrapped using &xep0297;. The wrapping message SHOULD maintain the same 'type' attribute value; the 'from' attribute MUST be the Carbons-enabled user's bare JID (e.g., "localpart@domainpart"); and the 'to' attribute SHOULD be the full JID of the resource receiving the copy. The content of the wrapping message MUST contain a &lt;sent/&gt; element qualified by the namespace "urn:xmpp:carbons:3", which itself contains a &lt;forwarded/&gt; qualified by the namespace "urn:xmpp:forward:0" that contains the original &MESSAGE; stanza.</p>
   <example caption='Romeo responds to Juliet'><![CDATA[
 <message xmlns='jabber:client'
          from='romeo@montague.example/home'
@@ -314,7 +314,7 @@
         from='romeo@montague.example'
         to='romeo@montague.example/garden'
         type='chat'>
-  <sent xmlns='urn:xmpp:carbons:2'>
+  <sent xmlns='urn:xmpp:carbons:3'>
     <forwarded xmlns='urn:xmpp:forward:0'>
       <message xmlns='jabber:client'
                to='juliet@capulet.example/balcony'
@@ -374,7 +374,7 @@
   <section2 topic='Protocol Namespaces' anchor='registrar-ns'>
     <p>This specification defines the following XML namespace:</p>
     <ul>
-      <li>urn:xmpp:carbons:2</li>
+      <li>urn:xmpp:carbons:3</li>
     </ul>
     <p>Upon advancement of this specification from a status of Experimental to a status of Draft, the &REGISTRAR; shall add the foregoing namespace to the registry located at &NAMESPACES;, as described in Section 4 of &xep0053;.</p>
   </section2>
@@ -388,8 +388,8 @@
 
 <xs:schema
     xmlns:xs='http://www.w3.org/2001/XMLSchema'
-    targetNamespace='urn:xmpp:carbons:2'
-    xmlns='urn:xmpp:carbons:2'
+    targetNamespace='urn:xmpp:carbons:3'
+    xmlns='urn:xmpp:carbons:3'
     elementFormDefault='qualified'>
 
   <xs:element name='disable' type='empty'/>


### PR DESCRIPTION
Remove the `<private/>` element from [XEP-0280][xep0280] in favor of the `<no-copy/>` element defined in [XEP-0334][xep0334].

I wasn't sure if this would require a version bump, so I put that in a second commit. If it's decided that no version bump is needed we can drop that commit from the PR.

[xep0280]: https://xmpp.org/extensions/xep-0280.html
[xep0334]: https://xmpp.org/extensions/xep-0334.html