### PR TITLE
XEP-0198: added optional h attribute to failed element on sm resumption

### DIFF
--- a/xep-0198.xml
+++ b/xep-0198.xml
@@ -30,6 +30,16 @@
   &mwild;
   <interim/>
   <revision>
+    <version>1.5</version>
+    <date>2015-09-13</date>
+    <initials>dg</initials>
+    <remark>
+      <ul>
+        <li>Noted that the server MAY include a 'h' attribute when failing to resume a session because it has been timed out</li>
+      </ul>
+    </remark>
+  </revision>
+  <revision>
     <version>1.4rc1</version>
     <date>2015-07-27</date>
     <initials>dc</initials>
@@ -348,7 +358,14 @@ S: <resumed xmlns='urn:xmpp:sm:3'
             h='another-sequence-number'
             previd='some-long-sm-id'/>
   ]]></example>
-  <p>If the server does not support session resumption, it MUST return a &lt;failed/&gt; element, which SHOULD include an error condition of &feature;. If the server does not recognize the 'previd' as an earlier session (e.g., because the former session has timed out), it MUST return a &lt;failed/&gt; element, which SHOULD include an error condition of &notfound;. In both of these failure cases, the server SHOULD allow the client to bind a resource at this point rather than forcing the client to restart the stream negotiation process and re-authenticate.</p>
+  <p>If the server does not support session resumption, it MUST return a &lt;failed/&gt; element, which SHOULD include an error condition of &feature;. If the server does not recognize the 'previd' as an earlier session (e.g., because the former session has timed out), it MUST return a &lt;failed/&gt; element, which SHOULD include an error condition of &notfound;. If the server recogizes the 'previd' as an earlier session that has timed out the server MAY also include a 'h' attribute indicating the number of stanzas received before the timeout. (Note: For this to work the server has to store the SM-ID/sequence number tuple past the time out of the actual session.)</p>
+  <example caption='Stream timed out'><![CDATA[
+S: <failed xml='urn:xmpp:sm:3'
+           h='another-sequence-number'>
+     <item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
+   </failed>
+  ]]></example>
+  <p>In both of these failure cases, the server SHOULD allow the client to bind a resource at this point rather than forcing the client to restart the stream negotiation process and re-authenticate.</p>
   <p>If the former stream is resumed and the server still has the stream for the previously-identified session open at this time, the old stream SHOULD be terminated.</p>
   <p>When a session is resumed, the parties proceed as follows:</p>
   <ul>
@@ -574,6 +591,9 @@ S: <a h='10'/>
                    maxOccurs='1'>
         <xs:group ref='err:stanzaErrorGroup'/>
       </xs:sequence>
+      <xs:attribute name='h' 
+                    type='xs:unsignedInt' 
+                    use='optional'/>
     </xs:complexType>
   </xs:element>
 


### PR DESCRIPTION
as previously discussed on the mailing list: http://mail.jabber.org/pipermail/standards/2015-May/029851.html