### PR TITLE
Fix escaping in entity versioning cdata

### DIFF
--- a/inbox/entityversioning.xml
+++ b/inbox/entityversioning.xml
@@ -529,7 +529,7 @@ anne@shakespeare.lit:VIZSVF0D,bill@shakespeare.lit:25P2A7H8
   </listdef>
   <doc>
     The document in which the EV profile for the list is specified (may be the
-    same as &lt;listdev/&gt;).
+    same as <listdev/>).
   </doc>
 </profile>
     ]]></code>


### PR DESCRIPTION
Fix a minor escaping issue which was just pointed out. This change is purely editorial.