### PR TITLE
XEP-0045: Various bug fixes:

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -2563,7 +2563,7 @@
       <value>http://jabber.org/protocol/muc#request</value>
     </field>
     <field var='muc#role'
-           type='text-single'
+           type='list-single'
            label='Requested role'>
       <value>participant</value>
     </field>
@@ -2739,6 +2739,7 @@
       <actor nick='Fluellen'/>
       <reason>Avaunt, you cullion!</reason>
     </item>
+    <status code='110'/>
     <status code='307'/>
   </x>
 </presence>
@@ -2985,7 +2986,7 @@
         <value>http://jabber.org/protocol/muc#request</value>
     </field>
     <field var='muc#role'
-           type='text-single'
+           type='list-single'
            label='Requested role'>
       <value>participant</value>
     </field>
@@ -3647,7 +3648,7 @@
       <value>hag66@witchesonline</value>
     </field>
     <field var='muc#register_faqentry'
-           type="text-single"
+           type="text-multi"
            label="FAQ Entry">
       <value>Just another witch.</value>
     </field>
@@ -5038,7 +5039,7 @@
     approval of such requests.
   </desc>
   <field var='muc#role'
-         type='text-single'
+         type='list-single'
          label='Requested role'/>
   <field var='muc#jid'
          type='jid-single'
@@ -5068,11 +5069,11 @@
       label='Maximum Number of History Messages Returned by Room'/>
   <field
       var='muc#roomconfig_allowpm'
-      type='boolean'
+      type='list-single'
       label='Roles that May Send Private Messages'/>
   <field
       var='muc#roomconfig_allowinvites'
-      type='list-single'
+      type='boolean'
       label='Whether to Allow Occupants to Invite Others'/>
   <field
       var='muc#roomconfig_changesubject'
@@ -5093,7 +5094,7 @@
   <field
       var='muc#roomconfig_pubsub'
       type='text-single'
-      label='XMPP URI of Associated Publish-Subcribe Node'/>
+      label='XMPP URI of Associated Publish-Subscribe Node'/>
   <field
       var='muc#roomconfig_maxusers'
       type='list-single'
@@ -5313,6 +5314,14 @@
   <context>Configuration change</context>
   <purpose>
     Inform occupants that the room is now semi-anonymous
+  </purpose>
+</statuscode>
+<statuscode>
+  <number>174</number>
+  <stanza>message</stanza>
+  <context>Configuration change</context>
+  <purpose>
+    Inform occupants that the room is now fully-anonymous
   </purpose>
 </statuscode>
 <statuscode>

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -5317,14 +5317,6 @@
   </purpose>
 </statuscode>
 <statuscode>
-  <number>174</number>
-  <stanza>message</stanza>
-  <context>Configuration change</context>
-  <purpose>
-    Inform occupants that the room is now fully-anonymous
-  </purpose>
-</statuscode>
-<statuscode>
   <number>201</number>
   <stanza>presence</stanza>
   <context>Entering a room</context>


### PR DESCRIPTION
- Example 90 lacks status code 110 (self-presence)
- muc#roomconfig_allowpm is boolean, but should be list-single
- muc#roomconfig_allowinvites is list-single, but should be boolean
- Typo: Publish-Subcribe
- 15.6.2 Initial Submission: Status code 174 is missing.
- muc#role should be list-single
- muc#register_faqentry: mixed occurrences of text-single and text-multi