### PR TITLE
XEP-0171: Schema wrongly specifies elements/attributes as required

### DIFF
--- a/xep-0171.xml
+++ b/xep-0171.xml
@@ -416,7 +416,7 @@
 
   <xs:element name='x'>
     <xs:complexType>
-      <xs:element ref='source' use='required'/>
+      <xs:element ref='source' use='optional'/>
       <xs:sequence>
         <xs:element ref='translation' use='required' minOccurs='1'/>
       </xs:sequence>
@@ -439,8 +439,8 @@
         <xs:extension base='empty'>
           <xs:attribute name='charset' type='xs:string' use='optional'/>
           <xs:attribute name='source_lang' type='xs:language' use='optional' />
-          <xs:attribute name='destination_lang' type='xs:string' use='required'/>
-          <xs:attribute name='dictionary' type='xs:string' use='required'/>
+          <xs:attribute name='destination_lang' type='xs:language' use='required'/>
+          <xs:attribute name='dictionary' type='xs:string' use='optional'/>
           <xs:attribute name='engine' type='xs:string' use='optional' />
           <xs:attribute name='reviewed' type='xs:boolean' use='optional' default='false'/>
         </xs:extension>


### PR DESCRIPTION
E.g. Example 1 and 2 have no <source/> element
Many examples have no dictionary attribute.