### PR TITLE
Add `make preview' to generate HTML on XML save

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ help:
 	@echo '                   pdf  -  build all XEPs'
 	@echo '                  html  -  build all XEPs'
 	@echo '                 clean  -  recursively unlink the build tree'
+	@echo '               preview  -  builds html whenever an XEP changes (requires inotify-tools)'
 	@echo '              xep-xxxx  -  build xep-xxxx.html and xep-xxxx.pdf'
 	@echo '         xep-xxxx.html  -  build xep-xxxx.html'
 	@echo '          xep-xxxx.pdf  -  build xep-xxxx.html'
@@ -70,3 +71,12 @@ $(TEMPDIR) $(OUTDIR) $(RESOURCESDIR):
 .PHONY: clean
 clean:
 	rm -rf $(OUTDIR)
+
+.PHONY: preview
+preview:
+	inotifywait -m -e close_write,moved_to --format '%e %f' . | \
+	while read -r event file; do \
+		if [ "$${file: -4}" == ".xml" ]; then \
+			xsltproc --path $(CURDIR) xep.xsl "$${file}" > "$(OUTDIR)/$${file: :8}.html" && echo "Built $${file: :8}.html $${event}"; \
+		fi \
+	done

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ TEMPDIR?=$(OUTDIR)/xepbuild
 XMLDEPS=xep.xsl xep.xsd xep.ent xep.dtd ref.xsl $(OUTDIR)
 TEXMLDEPS=xep2texml.xsl $(TEMPDIR) $(XMLDEPS) $(RESOURCESDIR)/xmpp.pdf $(RESOURCESDIR)/xmpp-text.pdf
 XMPPIMAGESURL=https://xmpp.org/images
+XEPDIRS=. inbox
 
 
 .PHONY: help
@@ -74,9 +75,9 @@ clean:
 
 .PHONY: preview
 preview:
-	inotifywait -m -e close_write,moved_to --format '%e %f' . | \
-	while read -r event file; do \
+	inotifywait -m -e close_write,moved_to --format '%e %w %f' $(XEPDIRS) | \
+	while read -r event dir file; do \
 		if [ "$${file: -4}" == ".xml" ]; then \
-			xsltproc --path $(CURDIR) xep.xsl "$${file}" > "$(OUTDIR)/$${file: :8}.html" && echo "Built $${file: :8}.html $${event}"; \
+			xsltproc --path $(CURDIR) xep.xsl "$${dir}/$${file}" > "$(OUTDIR)/$${file%.*}.html" && echo "Built $${file%.*}.html $${event}"; \
 		fi \
 	done


### PR DESCRIPTION
Uses inotifywatch to generate an HTML file anytime an XML file is saved.

This probably won't work on OS X, but it would be easy enough to use `fswatch` if someone that actually has a machine running it wants to tweak it to fallback to fsswatch if inotifywait doesn't exist.