### PR TITLE
XEP-0138: Update security recommendations

### DIFF
--- a/xep-0138.xml
+++ b/xep-0138.xml
@@ -31,6 +31,12 @@
     &hildjj;
     &stpeter;
     <revision>
+      <version>2.1</version>
+      <date>2015-09-28</date>
+      <initials>ssw</initials>
+      <remark><p>Specify that implementations should perform a full flush on stanza boundaries.</p></remark>
+    </revision>
+    <revision>
       <version>2.0</version>
       <date>2009-05-27</date>
       <initials>psa</initials>
@@ -157,6 +163,7 @@
       <li>If stream compression is negotiated, it MUST be used in both directions.</li>
       <li>TLS compression and stream compression SHOULD NOT be used simultaneously.</li>
       <li>Stream compression MAY be offered after TLS negotiation if TLS compression is not used.</li>
+      <li>Servers and clients implementing this standard SHOULD perform a full flush on stanza boundaries to prevent leaking information.</li>
     </ul>
     <p>For detailed recommendations regarding the order of stream feature negotiation, refer to &xep0170;.</p>
   </section1>


### PR DESCRIPTION
This change to `XEP-0138: Stream Compression` does not invalidate existing implementations (although I was very tempted to make it REQUIRED), but merely states that implementations SHOULD perform a full flush on stanza boundaries to prevent CRIME and BREACH like attacks.

This is fairly common knowledge, but I thought the XEP should really encourage it.