### PR TITLE
XEP-0320: clarify that holdconn is not used

### DIFF
--- a/xep-0320.xml
+++ b/xep-0320.xml
@@ -303,7 +303,12 @@ a=setup:role
                 <xs:enumeration value='active'/>
                 <xs:enumeration value='passive'/>
                 <xs:enumeration value='actpass'/>
-                <xs:enumeration value='holdconn'/><!-- not used -->
+                <xs:enumeration value='holdconn'/>
+                <xs:annotation>
+                  <xs:documentation>
+                    the 'holdconn' value is not used and included only for completeness.
+                  </xs:documentation>
+                </xs:annotation>
               </xs:restriction>
             </xs:simpleType>
           </xs:attribute>

--- a/xep-0320.xml
+++ b/xep-0320.xml
@@ -33,6 +33,16 @@
   <discuss>jingle</discuss>
   &fippo;
   <revision>
+    <version>0.3</version>
+    <date>2013-09-28</date>
+    <initials>ph</initials>
+    <remark>
+      <ul>
+        <li>Clarified that holdconn setup role is not mapped.</li>
+      </ul>
+    </remark>
+  </revision>
+  <revision>
     <version>0.2</version>
     <date>2013-10-22</date>
     <initials>ph</initials>
@@ -66,7 +76,7 @@
 
 <section1 topic='Protocol' anchor='protocol'>
   <p>&xep0167; recommends the use of the Secure Real-time Transport Protocol (SRTP) for end-to-end encryption of RTP sessions negotiated using &xep0166;. &rfc5763; provides an approach to establish a Secure Real-time Transport Protocol (SRTP) security context using the Datagram Transport Layer Security (DTLS) protocol. A mechanism of transporting the fingerprint attribute that identifies the key that will be presented during the DTLS handshake in Jingle is defined herein. Inclusion of this information is OPTIONAL in both SIP/SDP and Jingle.</p>
-  <p>Note that while this specification only describes the use in the context of DTLS-SRTP, the fingerprint transported can be used in other contexts like for example establishing connections using SCTP over DTLS.</p>
+  <p>Note that while this specification only describes the use in the context of DTLS-SRTP, the fingerprint transported can be used in other contexts like for example establishing connections using SCTP over DTLS as described in &xep0343;.</p>
   <p>The SDP format (defined in &rfc4572;) is shown below.</p>
   <code>
 a=fingerprint:hash-func fingerprint
@@ -79,6 +89,7 @@ a=fingerprint:sha-256 02:1A:CC:54:27:AB:EB:9C:53:3F:3E:4B:65:2E:7D:46:3F:54:42:C
   <code>
 a=setup:role
   </code>
+  <p>Note that no mapping for the 'holdconn' role is defined herein.</p>
   <p>These SDP attributes can be translated into Jingle as a &lt;fingerprint/&gt; element qualified by the 'urn:xmpp:jingle:apps:dtls:0' namespace, as shown below.</p>
   <code><![CDATA[
 <fingerprint xmlns='urn:xmpp:jingle:apps:dtls:0' hash='hash-func' setup='role'>
@@ -248,7 +259,7 @@ a=setup:role
 </section1>
 
 <section1 topic='Acknowledgements' anchor='acks'>
-  <p>Thanks to Justin Uberti and Lance Stout.</p>
+  <p>Thanks to Justin Uberti, Peter Saint-Andre and Lance Stout.</p>
 </section1>
 
 <section1 topic='XMPP Registrar Considerations' anchor='registrar'>
@@ -292,7 +303,7 @@ a=setup:role
                 <xs:enumeration value='active'/>
                 <xs:enumeration value='passive'/>
                 <xs:enumeration value='actpass'/>
-                <xs:enumeration value='holdconn'/>
+                <xs:enumeration value='holdconn'/><!-- not used -->
               </xs:restriction>
             </xs:simpleType>
           </xs:attribute>


### PR DESCRIPTION
based on LC feedback from @stpeter this clarifies that holdconn is not used/defined.

Also adds reference to 0343