### PR TITLE
Fix a small typo on XEP-0359

### DIFF
--- a/xep-0359.xml
+++ b/xep-0359.xml
@@ -123,7 +123,7 @@
   </ol>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
-  <p>The value of the 'id' attribute should not provide any further information besides the opaque ID itself. Entities observing the value MUST NOT be able to infer any information from it, e.g. the size of the message archive. The value of 'id' MUST be considered as non-secret value.</p>
+  <p>The value of the 'id' attribute should not provide any further information besides the opaque ID itself. Entities observing the value MUST NOT be able to infer any information from it, e.g. the size of the message archive. The value of 'id' MUST be considered a non-secret value.</p>
 </section1>
 <section1 topic='IANA Considerations' anchor='iana'>
   <p>This document requires no interaction with &IANA;.</p>


### PR DESCRIPTION
Single word (completely editorial) typo fix for EP-0359.

s/as/a/