### PR TITLE
XEP-0016: Deprecate privacy lists

### DIFF
--- a/xep-0016.xml
+++ b/xep-0016.xml
@@ -10,20 +10,28 @@
   <abstract>This specification defines an XMPP protocol extension for enabling or disabling communication with other entities on a network. The protocol, which was first standardized in Section 10 of RFC 3921, can be used to block communication with unknown or undesirable entities. Blocking can be based on Jabber Identifier, subscription state, or roster group. The blocked stanzas can be messages, IQs, inbound or outbound presence stanzas, or all stanzas. The protocol also enables an entity to create, modify, or delete its privacy lists, apply different lists to different connected resources, define a default list, and decline the use of any privacy list during a particular communications session.</abstract>
   &LEGALNOTICE;
   <number>0016</number>
-  <status>Draft</status>
+  <status>Deprecated</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>
   <supersedes/>
-  <supersededby/>
+  <supersededby>
+    XEP-0191
+  </supersededby>
   <shortname>privacy</shortname>
   <schemaloc>
     <url>http://xmpp.org/schemas/privacy.xsd</url>
   </schemaloc>
   &pgmillard;
   &stpeter;
+  <revision>
+    <version>1.7</version>
+    <date>2015-09-29</date>
+    <initials>ssw</initials>
+    <remark><p>Marked as deprecated in favor of multiple simpler XEPs.</p></remark>
+  </revision>
   <revision>
     <version>1.6</version>
     <date>2007-02-15</date>


### PR DESCRIPTION
Instead, use the blocking command ([XEP-0191](https://xmpp.org/extensions/xep-0191.html)) and the invisibility
command ([XEP-0186]((https://xmpp.org/extensions/xep-0186.html)))

This has been discussed on the list several times and was brought up recently in another thread, but I will go ahead and create a new thread for this PR and then get it on the councils agenda for a vote (assuming the discussion is leaning in this direction).

*EDIT:* Raised on the mailing list: http://mail.jabber.org/pipermail/standards/2015-September/030388.html