### PR TITLE
ProtoXEP: Message Attaching

### DIFF
--- a/inbox/attachto.xml
+++ b/inbox/attachto.xml
@@ -1,0 +1,179 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY % ents SYSTEM 'xep.ent'>
+%ents;
+]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+<header>
+  <title>Message Attaching</title>
+  <abstract>
+    This specification defines a method for indicating that a message contains
+    content which describes an earlier message in the conversation and should
+    be grouped with the earlier message.
+  </abstract>
+  &LEGALNOTICE;
+  <number>XXXX</number>
+  <status>ProtoXEP</status>
+  <type>Standards Track</type>
+  <sig>Standards</sig>
+  <approver>Council</approver>
+  <dependencies>
+    <spec>XMPP Core</spec>
+  </dependencies>
+  <supersedes/>
+  <supersededby/>
+  <shortname>message-attaching</shortname>
+  &sam;
+  <author>
+    <firstname>Craig</firstname>
+    <surname>Petchell</surname>
+    <email>cpetchell@atlassian.com</email>
+  </author>
+  <revision>
+    <version>0.0.1</version>
+    <date>2015-10-16</date>
+    <initials>ssw</initials>
+    <remark><p>First draft.</p></remark>
+  </revision>
+</header>
+<section1 topic='Introduction' anchor='intro'>
+  <p>
+    Many messaging applications send special messages which include more
+    information about a previous message. For example, when sending a link the
+    service may display the description or an image off the page, or users may
+    respond to a message with a "sticker" or an "emotion" which they wish to
+    display alongside the message, even though the conversation has moved on.
+  </p>
+  <p>
+    This specification defines a way by which one can indicate that a message
+    is logically (and visibly) "attached" to an earlier message in the
+    conversation.
+  </p>
+</section1>
+<section1 topic='Discovering support' anchor='disco'>
+  <p>
+    If a client implements message attaching, it MUST specify the
+    'urn:xmpp:message-attaching:0' feature in its service discovery information
+    features as specified in &xep0030; and the Entity Capabilities profile
+    specified in &xep0115;.
+  </p>
+  <example caption='Client requests information about a chat partner&apos;s client'><![CDATA[
+<iq type='get'
+    from='alonso@naples.lit/ship'
+    id='miuARo9V'>
+  <query xmlns='http://jabber.org/protocol/disco#info'/>
+</iq>]]></example>
+  <example caption='Partner&apos;s client advertises support for attaching'><![CDATA[
+<iq type='result'
+    to='alonso@naples.lit/ship'
+    from='naples.lit'
+    id='miuARo9V'>
+  <query xmlns='http://jabber.org/protocol/disco#info'>
+…
+    <feature var='urn:xmpp:message-attaching:0'/>
+…
+  </query>
+</iq>]]></example>
+</section1>
+<section1 topic='Usage' anchor='usage'>
+  <p>
+    Messages that are attached to other messages MUST contain an
+    &lt;attach-to/&gt; element qualified by the 'urn:xmpp:message-attaching:0'
+    namespace and with an 'id' attribute set to the ID of the message that we
+    want to attach to. Messages MAY be attached to any other message, including
+    those sent by other clients, but clients MAY choose to ignore the attach-to
+    directive and display the message normally.
+  </p>
+  <example caption='User attaches a message'><![CDATA[
+<message to='antonio@milan.lit/ship' from='prospero@milan.lit/island id='RgEGnjqy'>
+  <body>storm.png</body>
+  <attach-to id='oldmessage1' xmlns='urn:xmpp:message-attaching:0'/>
+</message>]]></example>
+  <p>
+    Note that indicating that a message should be "attached" to an earlier
+    message in the conversation is merely a suggestion to the client to display
+    the message next to or below the old message.
+  </p>
+</section1>
+<section1 topic='Business Rules' anchor='rules'>
+  <p>
+    A receiving client MAY choose to show the attached message next to or below
+    the indicated message in whatever display is used for messages or can
+    choose to display the attachment in another way (including as a normal
+    message, completely ignoring the attach-to element).
+  </p>
+  <p>
+    A receiving client SHOULD indicate that the message is an attachment, and
+    not a part of the original message to prevent confusion.
+  </p>
+  <p>
+    &lt;attach-to/&gt; elements MUST NOT be put on any stanza type other than
+    messages.
+  </p>
+  <p>
+    A server may choose to strip some &lt;attach-to/&gt; messages based on
+    local policy (eg. a server might have a policy that only it can create
+    message attachments).
+  </p>
+  <p>Clients MUST send ids on messages if they support attachments.</p>
+  <p>
+    Messages MUST NOT contain more than one &gt;attach-to/&lt; element.
+  </p>
+  <p>
+    Clients and servers MUST NOT include an &lt;attach-to/&gt; element on
+    messages with a non-messaging payload unless they are including it on an
+    error which may be attached to the message that caused the error to be
+    generated.
+  </p>
+</section1>
+<section1 topic='Security Considerations' anchor='security'>
+  Clients that implement message attachments MUST be careful not to display the
+  attachments in such a way that they could be confused with the original
+  message and cause someone viewing the conversation to assume they were sent
+  by the sender of the message being attached to.
+</section1>
+<section1 topic='IANA Considerations' anchor='iana'>
+  <p>This document requires no interaction with &IANA;.</p>
+</section1>
+<section1 topic='XMPP Registrar Considerations' anchor='registrar'>
+	<p>This specification defines the following XML namespaces:</p>
+	<ul>
+		<li>urn:xmpp:message-attaching:0</li>
+	</ul>
+	<p>
+    The &REGISTRAR; shall include the foregoing namespaces in its disco
+    features registry as defined in &xep0030;.
+		<code caption='Registry Submission'><![CDATA[
+<var>
+	<name>urn:xmpp:message-attaching:0</name>
+	<desc>Indicates support for attaching one message to another.</desc>
+	<doc>XEP-xxxx</doc>
+</var>
+		]]></code>
+	</p>
+</section1>
+<section1 topic='XML Schema' anchor='schema'>
+  <code><![CDATA[
+<?xml version='1.0' encoding='UTF-8'?>
+
+<xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='urn:xmpp:message-attaching:0'
+    xmlns='urn:xmpp:message-attaching:0'
+    elementFormDefault='qualified'>
+
+  <xs:element name='attach-to'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='xs:string'>
+          <xs:attribute name='id' type='xs:string' use='required'/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>
+    ]]></code>
+</section1>
+</xep>

--- a/xep.ent
+++ b/xep.ent
@@ -985,6 +985,15 @@ IANA Service Location Protocol, Version 2 (SLPv2) Templates</link></span> <note>
     <email>winfried@tilanus.com</email>
   </author>
 " >
+<!ENTITY sam "
+  <author>
+    <firstname>Sam</firstname>
+    <surname>Whited</surname>
+    <email>sam@samwhited.com</email>
+    <jid>sam@samwhited.com</jid>
+    <uri>https://blog.samwhited.com/</uri>
+  </author>
+" >
 
 <!-- XMPP Extension Protocols -->
 


### PR DESCRIPTION
This proposal adds a new XEP for "attaching" one message to another. Attachments might include information such as a preview of a link in a previous message that was generated by the server, or a "sticker" or "emotion" that a user wants displayed next to a previous message in the conversation (even though that message was not the most recent message sent).

For example, HipChat currently renders messages such as the following image link (and will soon use this spec to do so:

![tempest](https://cloud.githubusercontent.com/assets/512573/10552326/cf9cf93a-7418-11e5-8767-6d95f6ee0ac9.png)

Rendered version: https://blog.samwhited.com/xeps/xep-attachto.html