### PR TITLE
protocol to negotiate omemo encrypted file tranfers over jingle

### DIFF
--- a/inbox/omemo-filetransfer.xml
+++ b/inbox/omemo-filetransfer.xml
@@ -1,0 +1,182 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY % ents SYSTEM 'xep.ent'>
+%ents;
+]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+<header>
+  <title>OMEMO Encrypted Jingle File Transfer</title>
+  <abstract>This specification defines a Jingle application for transfering encrypted files from one entity to another. The protocol is based on the regular Jingle File Transfer specification and diverges from that only in the description of the file.</abstract>
+  <legal>
+    <copyright>This XMPP Extension Protocol is copyright (c) 1999 - 2014 by the XMPP Standards Foundation (XSF).</copyright>
+    <permissions>Permission is hereby granted, free of charge, to any person obtaining a copy of this specification (the &quot;Specification&quot;), to make use of the Specification without restriction, including without limitation the rights to implement the Specification in a software program, deploy the Specification in a network service, and copy, modify, merge, publish, translate, distribute, sublicense, or sell copies of the Specification, and to permit persons to whom the Specification is furnished to do so, subject to the condition that the foregoing copyright notice and this permission notice shall be included in all copies or substantial portions of the Specification. Unless separate permission is granted, modified works that are redistributed shall not contain misleading information regarding the authors, title, number, or publisher of the Specification, and shall not claim endorsement of the modified works by the authors, any organization or project to which the authors belong, or the XMPP Standards Foundation.</permissions>
+    <warranty>## NOTE WELL: This Specification is provided on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. In no event shall the XMPP Standards Foundation or the authors of this Specification be liable for any claim, damages, or other liability, whether in an action of contract, tort, or otherwise, arising from, out of, or in connection with the Specification or the implementation, deployment, or other use of the Specification. ##</warranty>
+    <liability>In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall the XMPP Standards Foundation or any author of this Specification be liable for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising out of the use or inability to use the Specification (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if the XMPP Standards Foundation or such author has been advised of the possibility of such damages.</liability>
+    <conformance>This XMPP Extension Protocol has been contributed in full conformance with the XSF's Intellectual Property Rights Policy (a copy of which may be found at &lt;<link url='http://xmpp.org/extensions/ipr-policy.shtml'>http://xmpp.org/extensions/ipr-policy.shtml</link>&gt; or obtained by writing to XSF, P.O. Box 1641, Denver, CO 80201 USA).</conformance>
+  </legal>
+  <number>xxxx</number>
+  <status>ProtoXEP</status>
+  <type>Standards Track</type>
+  <sig>Standards</sig>
+  <approver>Council</approver>
+  <dependencies>
+    <spec>XMPP Core</spec>
+    <spec>XEP-0001</spec>
+    <spec>Etc.</spec>
+  </dependencies>
+  <supersedes/>
+  <supersededby/>
+  <shortname>NOT_YET_ASSIGNED</shortname>
+  <author>
+    <firstname>Daniel</firstname>
+    <surname>Gultsch</surname>
+    <email>daniel@gultsch.de</email>
+    <jid>daniel@gultsch.de</jid>
+  </author>
+  <revision>
+    <version>0.0.1</version>
+    <date>2015-09-02</date>
+    <initials>dg</initials>
+    <remark><p>First draft.</p></remark>
+  </revision>
+</header>
+<section1 topic='Introduction' anchor='intro'>
+  <p>&xep0234; describes a very flexible and powerful method for peer-to-peer file transfer with interchangable transports. Unfortunatly only some of those transports can by encrypted (e.g. &xep0261;) and none integrate into existing end-to-end encryption schemes. This specification defines an approach to encrypt the actual file before transferring it by using the OMEMO encryption. Note that the encryption can and should happen on the fly.</p>
+</section1>
+<section1 topic='Requirements' anchor='reqs'>
+  <ul>
+    <li>Keep the protocol flow as close to Jingle File Transfer as possible and only change the file description</li>
+    <li>Keep the required changes for a client that already supports Jingle File Transfer and the OMEMO encryption to a minimum</li>
+  </ul>
+</section1>
+<section1 topic='Use Cases' anchor='usecases'>
+  <p>Remeo and Juliet are already engaged in a private, OMEMO encrypted conversation and want to negotiate a file transfer. The session-initiate stanza of an OMEMO encrypted file tranfer differs from the session-initiate of a regular Jingle File Transfer in that the 'file' element is wrapped in an 'encrypted' element. This reuses the KeyTransportElement from the OMEMO specification.</p>
+   <example caption="Initiator sends session-initiate"><![CDATA[
+<iq from='romeo@montague.lit/orchard'
+    id='nzu25s8'
+    to='juliet@capulet.lit/balcony'
+    type='set'>
+  <jingle xmlns='urn:xmpp:jingle:1'
+          action='session-initiate'
+          initiator='romeo@montague.lit/orchard'
+          sid='851ba2'>
+    <content creator='initiator' name='a-file-offer'>
+      <description xmlns='urn:xmpp:jingle:apps:encrypted:file-transfer:0'>
+        <encrypted xmlns='urn:xmpp:omemo:0'>
+          <header sid='27183'>
+            <key rid='31415'>BASE64ENCODED...</key>
+            <key rid='12321'>BASE64ENCODED...</key>
+            <iv>BASE64ENCODED...</iv>
+          </header>
+          <file>
+            <date>2015-08-30T23:24:05Z</date>
+            <desc>This is a test. If this were a real file...</desc>
+            <media-type>image/png</media-type>
+            <name>omemo.png</name>
+            <range/>
+            <size>51158</size>
+            <hash xmlns='urn:xmpp:hashes:1' algo='sha-1'/>
+        </file>
+        </encrypted>
+      </description>
+      <transport xmlns='urn:xmpp:jingle:transports:s5b:1'
+        	 mode='tcp'
+                 sid='vj3hs98y'>
+        <candidate cid='hft54dqy'
+                   host='192.168.4.1'
+                   jid='romeo@montague.lit/orchard'
+                   port='5086'
+                   priority='8257636'
+                   type='direct'/>
+        <candidate cid='hutr46fe'
+                   host='24.24.24.1'
+                   jid='romeo@montague.lit/orchard'
+                   port='5087'
+                   priority='8258636'
+                   type='direct'/>
+      </transport>
+    </content>
+  </jingle>
+</iq>
+  ]]></example>
+  <p>The rest of the negotiation is analogous to a regular file transfer. The file is then encrypted and decrypted respectively using the key/IV pair extracted from the encryption header in AES-GCM. The crypto operation SHOULD happen on the fly.</p>
+</section1>
+<section1 topic='Communicating the Checksum or Hashing Algorithm' anchor='hash'>
+  <p>Even though AES-GCM comes with build-in integrity protection the hosting entity can—at any time during the lifetime of the session—communicate the checksum of the encrypted file.</p>
+<example caption="Initiator sends checksum in session-info"><![CDATA[
+<iq from='romeo@montague.lit/orchard'
+    id='kqh401b5'
+    to='juliet@capulet.lit/balcony'
+    type='set'>
+  <jingle xmlns='urn:xmpp:jingle:1'
+          action='session-info'
+          initiator='romeo@montague.lit/orchard'
+          sid='a73sjjvkla37jfea'>
+    <checksum xmlns='urn:xmpp:jingle:apps:encrypted:file-transfer:0'>
+      <file>
+        <hash xmlns='urn:xmpp:hashes:1' algo='sha-1'>552da749930852c69ae5d2141d3766b1</hash>
+      </file>
+    </checksum>
+  </jingle>
+</iq>
+  ]]></example>
+</section1>
+<section1 topic='Business Rules' anchor='rules'>
+  <ul>
+    <li>AES-GCM being a block cipher will influence the file size. The file size reported in the session intilization MUST be the encrypted one.</li>
+    <li>The file hash MUST be the hash of encrypted file.</li>
+    <li>An encryption header MUST only be used for one session. However when doing a rangend tranfer on a previously aborted file the key/IV pair MUST be reused and packed into a new header to keep the integrity of the file.</li>
+  </ul>
+</section1>
+<section1 topic='Determining Support' anchor='support'>
+  <p>To advertise its support for the OMEMO Encrypted Jingle File Transfer, when replying to service discovery information ("disco#info") requests an entity MUST return URNs for any version of this protocol that the entity supports -- e.g., 'urn:xmpp:jingle:apps:encrypted:file-transfer:0' for this version &VNOTE;.</p>
+  <example caption="Service discovery information request"><![CDATA[
+<iq from='romeo@montague.lit/orchard'
+    id='uw72g176'
+    to='juliet@capulet.lit/balcony'
+    type='get'>
+  <query xmlns='http://jabber.org/protocol/disco#info'/>
+</iq>
+  ]]></example>
+  <example caption="Service discovery information response"><![CDATA[
+<iq from='juliet@capulet.lit/balcony'
+    id='uw72g176'
+    to='romeo@montague.lit/orchard'
+    type='result'>
+  <query xmlns='http://jabber.org/protocol/disco#info'>
+    <feature var='urn:xmpp:jingle:1'/>
+    <feature var='urn:xmpp:jingle:apps:encrypted:file-transfer:0'/>
+    <feature var='urn:xmpp:jingle:apps:file-transfer:4'/>
+    <feature var='urn:xmpp:jingle:transports:s5b:1'/>
+    <feature var='urn:xmpp:jingle:transports:ibb:1'/>
+  </query>
+</iq>
+  ]]></example>
+  <p>In order for an application to determine whether an entity supports this protocol, where possible it SHOULD use the dynamic, presence-based profile of service discovery defined in &xep0115;. However, if an application has not received entity capabilities information from an entity, it SHOULD use explicit service discovery instead.</p>
+</section1>
+<section1 topic='Implementation Notes' anchor='impl'>
+  <p>Since the OMEMO Encryption does not provide a direct relation between resources and Device ID’s the initiating entity might not the Device ID of the resource it is creating a session with. Thus it MAY include a key for every trusted device of the foreign entity. However it SHOULD omit the keys for its own devices.</p>
+</section1>
+<section1 topic='Security Considerations' anchor='security'>
+  <ul>
+    <li>Being built upon both Jingle File Transfer and OMEMO encryption, the same security considerations apply.</li>
+    <li>Only the raw file is being encrypted. The encryption does not apply for the meta data sent with the session initialization including the content-type and the description</li>
+  </ul>
+</section1>
+<section1 topic='IANA Considerations' anchor='iana'>
+  <p>This document requires no interaction with the Internet Assigned Numbers Authority (IANA).</p>
+</section1>
+<section1 topic='XMPP Registrar Considerations' anchor='registrar'>
+  <section2 topic='Protocol Namespaces' anchor='registrar-ns'>
+    <p>This specification defines the following XML namespace:</p>
+    <ul>
+      <li>urn:xmpp:jingle:apps:encrypted:file-transfer:0</li>
+    </ul>
+    <p>Upon advancement of this specification from a status of Experimental to a status of Draft, the &REGISTRAR; shall add the foregoing namespace to the registry located at &NAMESPACES;, as described in Section 4 of &xep0053;.</p>
+  </section2>
+</section1>
+<section1 topic='XML Schema' anchor='schema'>
+  <p>tbd</p>
+</section1>
+</xep>


### PR DESCRIPTION
Jingle File Transfer (XEP-0234) describes a very flexible and powerful method for peer-to-peer file transfer with interchangable transports. Unfortunatly only some of those transports can by encrypted (e.g. Jingle In-Band Bytestreams Transport Method (XEP-0261)) and none integrate into existing end-to-end encryption schemes. This specification defines an approach to encrypt the actual file before transferring it by using the OMEMO encryption.