### PR TITLE
xep-0339 version 0.2

### DIFF
--- a/xep-0339.xml
+++ b/xep-0339.xml
@@ -21,6 +21,12 @@
   <supersededby/>
   <shortname>NOT_YET_ASSIGNED</shortname>
   <revision>
+    <version>0.2</version>
+    <date>2015-11-09</date>
+    <initials>ph</initials>
+    <remark><p>remove obsolete mslabel and label lines.</p></remark>
+  </revision>
+  <revision>
     <version>0.1</version>
     <date>2014-01-08</date>
     <initials>psa</initials>
@@ -55,31 +61,23 @@ a=ssrc:&lt;ssrc-id&gt; &lt;attribute&gt;:&lt;value&gt;
     <p>An example follows:</p> 
     <code>
 a=ssrc:1656081975 cname:Yv/wvbCdsDW2Prgd
-a=ssrc:1656081975 msid:MLTJKIHilGn71fNQoszkQ4jlPTuS5vJyKVIv MLTJKIHilGn71fNQoszkQ4jlPTuS5vJyKVIva0
-a=ssrc:1656081975 mslabel:MLTJKIHilGn71fNQoszkQ4jlPTuS5vJyKVIv
-a=ssrc:1656081975 label:MLTJKIHilGn71fNQoszkQ4jlPTuS5vJyKVIva0
-    </code>
+a=ssrc:1656081975 msid:MLTJKIHilGn71fNQoszkQ4jlPTuS5vJyKVIv MLTJKIHilGn71fNQoszkQ4jlPTuS5vJyKVIva0</code>
     <code><![CDATA[
 <source ssrc='1656081975' xmlns='urn:xmpp:jingle:apps:rtp:ssma:0'>
     <parameter name='cname' value='Yv/wvbCdsDW2Prgd'/>
     <parameter name='msid' value='MLTJKIHilGn71fNQoszkQ4jlPTuS5vJyKVIv MLTJKIHilGn71fNQoszkQ4jlPTuS5vJyKVIva0'/>
-    <parameter name='mslabel' value='MLTJKIHilGn71fNQoszkQ4jlPTuS5vJyKVIv'/>
-    <parameter name='label' value='MLTJKIHilGn71fNQoszkQ4jlPTuS5vJyKVIva0'/>
-</source> 
-    ]]></code>
+</source>]]></code>
   </section2>
   <section2 topic='The ssrc-group attribute' anchor='sdp-ssrc-group'>
     <p>The SDP format defined in <cite>RFC 5576</cite> is shown below.</p>
     <code>
-a=ssrc-group:&lt;semantics&gt; &lt;ssrc-id&gt; ...
-    </code>
+a=ssrc-group:&lt;semantics&gt; &lt;ssrc-id&gt; ...</code>
     <p>This maps to Jingle as a &lt;ssrc-group/&gt; element qualified by the 'urn:xmpp:jingle:apps:rtp:ssma:0' namespace. Like the &lt;source/&gt; element, this is included as child of the Jingle &lt;description/&gt; element. The SDP 'semantics' parameter is mapped to the semantics attribute (for consistency with &xep0338;) and the list of ssrc-ids is mapped to &lt;source/&gt; elements whole 'ssrc' attribute is set to the ssrc-id.</p>
     <code><![CDATA[
 <ssrc-group xmlns='urn:xmpp:jingle:apps:rtp:ssma:0' semantics='semantics'>
    <source ssrc='ssrc-id'/>
    [...]
-</ssrc-group>
-    ]]></code>
+</ssrc-group>]]></code>
   </section2>
 </section1>
 <section1 topic='Example' anchor='example'>


### PR DESCRIPTION
remove label and mslabel from obsolete version of msid-draft. fix whitespace in code tags

cleaning up things and making them ready for LC. cc @stpeter 