### PR TITLE
XEP-0071: Update plain version of blockquote example to escape <div/>

### DIFF
--- a/xep-0071.xml
+++ b/xep-0071.xml
@@ -699,7 +699,7 @@ You wrote:
 
    I think we have consensus on the following:
 
-   1. Remove <div/>
+   1. Remove &lt;div/&gt;
    2. Nesting is not recommended
    3. Don't preserve whitespace
 


### PR DESCRIPTION
I'm assuming `<div/>` isn't actually a valid child element for the plain `<body/>`, but that this should have been XML escaped just like it is in the xhtml version.