### PR TITLE
remove PDF build steps from Makefile (fixes #121)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,57 +14,38 @@ help:
 	@echo 'XEP makefile targets:'
 	@echo ' '
 	@echo '                  help  -  (this message)'
-	@echo '                   all  -  build all XEPs (html and pdfs)'
-	@echo '                   pdf  -  build all XEPs'
+	@echo '                   all  -  build all XEPs (same as make html)'
 	@echo '                  html  -  build all XEPs'
 	@echo '                 clean  -  recursively unlink the build tree'
 	@echo '               preview  -  builds html whenever an XEP changes (requires inotify-tools)'
-	@echo '              xep-xxxx  -  build xep-xxxx.html and xep-xxxx.pdf'
+	@echo '              xep-xxxx  -  build xep-xxxx.html'
 	@echo '         xep-xxxx.html  -  build xep-xxxx.html'
-	@echo '          xep-xxxx.pdf  -  build xep-xxxx.html'
 	@echo ' '
 	@echo 'Output directory: "$(OUTDIR)/"'
 
 .PHONY: all
-all: html pdfs
+all: html
 
 .PHONY: html
 html: $(patsubst %.xml, $(OUTDIR)/%.html, $(wildcard *.xml))
 
-.PHONY: pdf
-pdf: $(patsubst %.xml, $(OUTDIR)/%.pdf, $(wildcard *.xml))
-
 .PHONY: xep-%
-xep-%: $(OUTDIR)/xep-%.html $(OUTDIR)/xep-%.pdf ;
+xep-%: $(OUTDIR)/xep-%.html ;
 
 .PHONY: xep-%.html
 xep-%.html: $(OUTDIR)/xep-%.html ;
 
-.PHONY: xep-%.pdf
-xep-%.pdf: $(OUTDIR)/xep-%.pdf ;
+.PHONY: dependencies
+dependencies: $(OUTDIR)/prettify.css $(OUTDIR)/prettify.js $(OUTDIR)/xmpp.css ;
 
-$(OUTDIR)/%.html: %.xml $(XMLDEPS)
+$(OUTDIR)/%.html: %.xml $(XMLDEPS) dependencies
 	xsltproc --path $(CURDIR) xep.xsl "$<" > "$@" && echo "Finished building $@"
 
-$(OUTDIR)/%.pdf: %.xml $(TEMPDIR)/%.xml.texml $(TEMPDIR)/%.xml.texml.tex $(TEXMLDEPS)
-	cd $(TEMPDIR); xelatex $(TEMPDIR)/$<.texml.tex
-	mv $(TEMPDIR)/$<.texml.pdf $(OUTDIR)/$(patsubst %.xml.pdf,%.pdf,$<.pdf)
-	echo "Finished building $(patsubst %.xml.pdf,%.pdf,$<.pdf)"
+$(OUTDIR)/%.js: %.js
+	cp "$<" "$@"
 
-$(TEMPDIR)/%.xml.texml: %.xml $(TEXMLDEPS) $(TEMPDIR)
-	xsltproc -o $(TEMPDIR)/$<.texml xep2texml.xsl "$<"
-
-$(TEMPDIR)/%.xml.texml.tex: $(TEMPDIR)/%.xml.texml $(OUTDIR) $(TEMPDIR)
-	texml -e utf8 $< $<.tex
-	sed -i -e 's|\([\s"]\)\([^"]http\://[^ "]*\)|\1\\path{\2}|g' \
-	       -e 's|\\hyperref\[#\([^}]*\)\]|\\hyperref\[\1\]|g' \
-	       -e 's|\\pageref{#\([^}]*\)}|\\pageref{\1}|g' $<.tex
-
-$(RESOURCESDIR)/xmpp-text.pdf: $(RESOURCESDIR)
-	curl -o $@ $(XMPPIMAGESURL)/xmpp-text.pdf
-
-$(RESOURCESDIR)/xmpp.pdf: $(RESOURCESDIR)
-	curl -o $@ $(XMPPIMAGESURL)/images/xmpp.pdf
+$(OUTDIR)/%.css: %.css
+	cp "$<" "$@"
 
 $(TEMPDIR) $(OUTDIR) $(RESOURCESDIR):
 	mkdir -p $@


### PR DESCRIPTION
It leaves a lot of the other html steps.  Didn't want to cause too much surprise up front, and they can be further collapsed later.