### PR TITLE
XEP-0080: Add altaccuracy element

### DIFF
--- a/xep-0080.xml
+++ b/xep-0080.xml
@@ -26,6 +26,12 @@
   &hildjj;
   &stpeter;
   <revision>
+    <version>1.9</version>
+    <date>2015-12-01</date>
+    <initials>ls</initials>
+    <remark><p>Added &lt;altaccuracy/&gt; element.</p></remark>
+  </revision>
+  <revision>
     <version>1.8</version>
     <date>2014-05-07</date>
     <initials>ls</initials>
@@ -173,6 +179,12 @@
       <td>xs:decimal</td>
       <td>Altitude in meters above or below sea level</td>
       <td>1609</td>
+    </tr>
+    <tr>
+      <td>altaccuracy</td>
+      <td>xs:decimal</td>
+      <td>Vertical GPS error in meters</td>
+      <td>10</td>
     </tr>
     <tr>
       <td>area</td>
@@ -518,6 +530,7 @@
       <xs:sequence minOccurs='0'>
         <xs:element name='accuracy' minOccurs='0' type='xs:decimal'/>
         <xs:element name='alt' minOccurs='0' type='xs:decimal'/>
+        <xs:element name='altaccuracy' minOccurs='0' type='xs:decimal'/>
         <xs:element name='area' minOccurs='0' type='xs:string'/>
         <xs:element name='bearing' minOccurs='0' type='xs:decimal'/>
         <xs:element name='building' minOccurs='0' type='xs:string'/>


### PR DESCRIPTION
This allows XEP-0080 to capture all of the information from the
W3C Geolocation API (http://www.w3.org/TR/geolocation-API/).