### PR TITLE
XEP-0313: Actually mention <fin/> in text

### DIFF
--- a/xep-0313.xml
+++ b/xep-0313.xml
@@ -163,7 +163,8 @@
         the archive, with a 'query' payload. On receiving the query, the server pushes to the client a
         series of messages from the archive that match the client's given criteria, and finally returns
 				the &IQ; result to indicate that the query is completed.</p>
-	    <p>The final &MESSAGE; response MUST include an RSM &lt;set/&gt; element indicating the
+        <p>The final &IQ; result response MUST include an RSM &lt;set/&gt; element, wrapped into a &lt;fin/&gt;
+        element qualified by the 'urn:xmpp:mam:1' namespace, indicating the
       UID of the first and last message of the (possibly limited) result set. This
       allows clients to accurately page through messages.</p>
     <example caption='A user queries their archive for messages'><![CDATA[
@@ -184,7 +185,14 @@
 </message>]]></example>
 
     <example caption='Server returns the result IQ to signal the end'><![CDATA[
-<iq type='result' id='juliet1'/>]]></example>
+<iq type='result' id='juliet1'>
+  <fin xmlns='urn:xmpp:mam:1'>
+    <set xmlns='http://jabber.org/protocol/rsm'>
+      <first index='0'>28482-98726-73623</first>
+      <last>09af3-cc343-b409f</last>
+    </set>
+  </fin>
+</iq>]]></example>
   <p>To ensure that the client knows when the results are complete, the server MUST send the &IQ; result after the last message retrieved from the archive. The client can optionally include a 'queryid' attribute in their query, which allows the client to match results to their initiating query.</p>
   <p>When querying a pubsub node's archive, the 'node' attribute is added to the &lt;query&gt; element.</p>
   <example caption="A user queries a pubsub node's archive for messages"><![CDATA[
@@ -341,7 +349,7 @@
 </iq>
     ]]></example>
     <p>Note: There is no concept of an "open query", and servers MUST be prepared to receive arbitrary page requests at any time.</p>
-    <p>When the results returned by the server are complete (that is: when they are the last page of the result set), the server MUST include a 'complete' attribute in the &IQ; result, with a value of 'true'. If it is not the last page of the result set, the server MUST either omit the 'complete' attribute, or give it a value of 'false'.</p>
+    <p>When the results returned by the server are complete (that is: when they are the last page of the result set), the server MUST include a 'complete' attribute in the &lt;fin/&gt; element, with a value of 'true'. If it is not the last page of the result set, the server MUST either omit the 'complete' attribute, or give it a value of 'false'.</p>
     <example caption='Server completes a result with the last page of messages'><![CDATA[
 <!-- result messages -->
 <iq type='result' id='u29303'>


### PR DESCRIPTION
Also fix wrong usage of MESSAGE to IQ, fix example 9 and clarify where
the 'complete' attribute is placed.

Should address all issues raised in http://mail.jabber.org/pipermail/standards/2015-December/030730.html