### PR TITLE
XEP-0280: Fix typo in xml schema (s/foward/forward/)

### DIFF
--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -420,7 +420,7 @@
     </xs:restriction>
   </xs:simpleType>
   
-  <xs:complexType name='foward-container' abstract='true'>
+  <xs:complexType name='forward-container' abstract='true'>
     <xs:choice>
       <xs:element name='forwarded'
                   namespace='urn:xmpp:forward:0'


### PR DESCRIPTION
I couldn't find any relevant contribution guidelines but I guess nothing in particular is needed for typo fixes, given previous pull requests.