### PR TITLE
XEP-0045: Don't leak JIDs in anonymous rooms

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -3332,7 +3332,7 @@
   </query>
 </iq>
     ]]></example>
-    <p>Note: A service SHOULD also return the member list to any occupant in a members-only room; i.e., it SHOULD NOT generate a &forbidden; error when a member in the room requests the member list. This functionality can assist clients in showing all the existing members even if some of them are not in the room, e.g. to help a member determine if another user should be invited. A service SHOULD also allow any member to retrieve the member list even if not yet an occupant.</p>
+    <p>Note: A service SHOULD also return the member list to any occupant in a non-anonymous members-only room; i.e., it SHOULD NOT generate a &forbidden; error when a member in the room requests the member list. This functionality can assist clients in showing all the existing members even if some of them are not in the room, e.g. to help a member determine if another user should be invited. A service SHOULD also allow any member to retrieve the member list even if not yet an occupant.</p>
     <p>The service MUST then return the full member list to the admin qualified by the 'http://jabber.org/protocol/muc#admin' namespace; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for each member that is currently an occupant.</p>
     <example caption='Service Sends Member List to Admin'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'


### PR DESCRIPTION
Don't allow occupants of members-only rooms to retrieve the member list unless the room is non-anonymous.