### PR TITLE
XEP-0357: Add missing type attribute to <x/> element

### DIFF
--- a/xep-0357.xml
+++ b/xep-0357.xml
@@ -279,7 +279,7 @@
         <example caption='Enabling Notifications, with provided publish options'><![CDATA[
 <iq type='set' id='x43'>
   <enable xmlns='urn:xmpp:push:0' jid='push-5.client.example' node='yxs32uqsflafdk3iuqo'>
-    <x xmlns='jabber:x:data'>
+    <x xmlns='jabber:x:data' type='submit'>
       <field var='FORM_TYPE'><value>http://jabber.org/protocol/pubsub#publish-options</value></field>
       <field var='secret'><value>eruio234vzxc2kla-91<value></field>
     </x>


### PR DESCRIPTION
The `<x/>` child of the `<enable/>` element in example 9 of XEP-0357 is missing a `type` attribute (which is mandatory [according to XEP-0004][1]).

[1]: http://xmpp.org/extensions/xep-0004.html#schema