### PR TITLE
XEP-0363: Announce maximum file size by means of XEP-0128

### DIFF
--- a/xep-0363.xml
+++ b/xep-0363.xml
@@ -29,6 +29,12 @@
     <jid>daniel@gultsch.de</jid>
   </author>
   <revision>
+    <version>0.2</version>
+    <date>2016-03-07</date>
+    <initials>dg</initials>
+    <remark><p>Announce maximum file size by means of &xep0128;</p></remark>
+  </revision>
+  <revision>
     <version>0.1.2</version>
     <date>2016-02-16</date>
     <initials>XEP Editor (mam)</initials>
@@ -66,7 +72,8 @@
   </ul>
 </section1>
 <section1 topic='Discovering Support' anchor='disco'>
-  <p>An entity advertises support for this protocol by including the "urn:xmpp:http:upload" in its service discovery information features as specified in &xep0030; or section 6.3 of &xep0115;. A users server SHOULD include any known entities that provide such services into its service discovery items.</p>
+  <p>An entity advertises support for this protocol by including the "urn:xmpp:http:upload" in its service discovery information features as specified in &xep0030; or section 6.3 of &xep0115;. To avoid unnecessary round trips an entity SHOULD also include the maximum file size as specified in &xep0128; if such a limitation exisits. The field name MUST be "max-file-size" and the value MUST be in bytes.</p>
+  <p>A users server SHOULD include any known entities that provide such services into its service discovery items.</p>
   <example caption='Client sends service discovery request to server'><![CDATA[
 <iq from='romeo@montague.tld/garden'
     id='step_01'
@@ -91,7 +98,7 @@
     type='get'>
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>]]></example>
-  <example caption='Upload service replies to service discovery request'><![CDATA[
+  <example caption='Upload service replies to service discovery request and reports a maximum file size of 5MiB'><![CDATA[
 <iq from='upload.montague.tld'
     id='step_02'
     to='romeo@montague.tld/garden'
@@ -101,6 +108,14 @@
               type='file'
               name='HTTP File Upload' />
     <feature var='urn:xmpp:http:upload' />
+    <x type='result' xmlns='jabber:x:data'>
+      <field var='FORM_TYPE' type='hidden'>
+        <value>urn:xmpp:http:upload</value>
+      </field>
+      <field var='max-file-size'>
+        <value>5242880</value>
+      </field>
+    </x>
   </query>
 </iq>]]></example>
 </section1>
@@ -145,7 +160,7 @@
     <not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas' />
     <text xmlns='urn:ietf:params:xml:ns:xmpp-stanzas>file too large. the maximum file size is 20000 bytes</text>
     <file-too-large xmlns='urn:xmpp:http:upload'>
-      <max-size>20000</max-size>
+      <max-file-size>20000</max-file-size>
     </file-too-large>
   </error>
 </iq>]]></example>


### PR DESCRIPTION
A small addition to XEP-0363 HTTP Upload that lets an entity report the maximum file size.