### PR TITLE
XEP-0363: Minor fixes

### DIFF
--- a/xep-0363.xml
+++ b/xep-0363.xml
@@ -16,8 +16,8 @@
   <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
-    <spec>XEP-0001</spec>
-    <spec>Etc.</spec>
+    <spec>XEP-0030</spec>
+    <spec>XEP-0128</spec>
   </dependencies>
   <supersedes/>
   <supersededby/>
@@ -133,7 +133,7 @@
     <content-type>image/jpeg</content-type>
   </request>
 </iq>]]></example>
-  <p>The upload service responds with both a PUT and a GET URL wrapped by a &lt;slot&gt; element. The service SHOULD keep the file name and especially the file ending intact. Using the same hostname for PUT and GET is OPTIONAL. The host SHOULD provide Transport Layer Security.</p>
+  <p>The upload service responds with both a PUT and a GET URL wrapped by a &lt;slot&gt; element. The service SHOULD keep the file name and especially the file ending intact. Using the same hostname for PUT and GET is OPTIONAL. The host SHOULD provide Transport Layer Security (&rfc5256;).</p>
   <example caption='The upload service responsd with a slot'><![CDATA[
 <iq from='upload.montague.tld'
     id='step_03'
@@ -158,7 +158,7 @@
   </request>
   <error type='modify'>
     <not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas' />
-    <text xmlns='urn:ietf:params:xml:ns:xmpp-stanzas>file too large. the maximum file size is 20000 bytes</text>
+    <text xmlns='urn:ietf:params:xml:ns:xmpp-stanzas>File too large. The maximum file size is 20000 bytes</text>
     <file-too-large xmlns='urn:xmpp:http:upload'>
       <max-file-size>20000</max-file-size>
     </file-too-large>


### PR DESCRIPTION
Add correct dependencies, cite RFC 5256 and start sentences with an
uppercase character in error messages.