### PR TITLE
XEP-0370: Mark as experimental

### DIFF
--- a/xep-0370.xml
+++ b/xep-0370.xml
@@ -10,7 +10,7 @@
     <abstract>This specification defines two Jingle transport methods for establishing HTTP connections for either uploading or downloading data.</abstract>
     &LEGALNOTICE;
     <number>0370</number>
-    <status>ProtoXEP</status>
+    <status>Experimental</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
     <approver>Council</approver>


### PR DESCRIPTION
XEP-0370 is experimental, not a protoxep (it's already been accepted by the council and assigned a number)