### PR TITLE
xep-0234: update wrong reference to ice-tcp

### DIFF
--- a/xep-0234.xml
+++ b/xep-0234.xml
@@ -220,7 +220,7 @@
     <li><p>Define a file description format that, unlike <cite>XEP-0096</cite>, enables hash agility (via &xep0300;).</p></li>
     <li><p>Define a clear upgrade path from SI File Transfer to Jingle File Transfer.</p></li>
   </ul>
-  <p>Note that Jingle file transfer is only as reliable as the transports on which it depends. In particular, SOCKS5 Bytestreams ("S5B") does not always result in NAT or firewall traversal. To work around that problem, this specification requires all implementations to support as a fallback mechanism In-Band Bytestreams ("IBB"), which usually results in a successful (if slow) file transfer. A more robust and adaptable option is ICE-TCP (RFC 6455); at the time of writing &xep0176; is being updated to include the ability to negotiate ICE-TCP candidates.</p>
+  <p>Note that Jingle file transfer is only as reliable as the transports on which it depends. In particular, SOCKS5 Bytestreams ("S5B") does not always result in NAT or firewall traversal. To work around that problem, this specification requires all implementations to support as a fallback mechanism In-Band Bytestreams ("IBB"), which usually results in a successful (if slow) file transfer. A more robust and adaptable option is ICE-TCP (RFC 6544); at the time of writing &xep0176; is being updated to include the ability to negotiate ICE-TCP candidates.</p>
 </section1>
 
 <section1 topic='Terminology' anchor='terms'>
@@ -891,7 +891,7 @@ a=file-range:1024-*]]></code>
 
 <section1 topic='Implementation Notes' anchor='impl'>
   <section2 topic='Mandatory to Implement Technologies' anchor='impl-mti'>
-    <p>All implementations MUST support the Jingle In-Band Bytestreams Transport Method (<cite>XEP-0261</cite>) as a reliable method of last resort. An implementation SHOULD support other transport methods as well, especially ICE-TCP (RFC 6455) and the Jingle SOCKS5 Bytestreams Transport Method (<cite>XEP-0260</cite>).</p>
+    <p>All implementations MUST support the Jingle In-Band Bytestreams Transport Method (<cite>XEP-0261</cite>) as a reliable method of last resort. An implementation SHOULD support other transport methods as well, especially ICE-TCP (RFC 6544) and the Jingle SOCKS5 Bytestreams Transport Method (<cite>XEP-0260</cite>).</p>
   </section2>
   <section2 topic='Preference Order of Transport Methods' anchor='impl-pref'>
     <p>An application MAY present transport methods in any order, except that the Jingle In-Band Bytestreams Transport Method MUST be the lowest preference.</p>
@@ -929,7 +929,7 @@ a=file-range:1024-*]]></code>
     <p>Caution needs to be exercised when using the &lt;name/&gt; of a file offer or request to control any interaction with a file system. For example, a malicious user could request a file with &lt;name&gt;/etc/passwd&lt;/name&gt; or include file system specific control patterns such as &lt;name&gt;../../private.txt&lt;/name&gt; to try and access a sensitive file outside of the set of files intended to be shared. Or a malicious user could offer a file named "/etc/passwd" to try and trick the receiver into overwriting that or other sensitive files. Therefore, implementations SHOULD escape any file system path separators in the &lt;name/&gt; before using that value in any file system calls.</p>
   <p>It is RECOMMENDED for implementations to use the strongest hashing algorithm available to both parties. See <cite>XEP-0300</cite> for further discussion.</p>
   <p>In order to secure the data stream, implementations SHOULD use encryption methods appropriate to the transport method being used. For example, end-to-end encryption can be negotiated over either SOCKS5 Bytestreams or In-Band Bytestreams as described in <cite>XEP-0260</cite> and <cite>XEP-0261</cite>.</p>
-  <p>Refer to <cite>XEP-0047</cite>, <cite>XEP-0065</cite>, <cite>XEP-0096</cite>, <cite>XEP-0176</cite>, <cite>XEP-0260</cite>, <cite>XEP-0261</cite>, and <cite>RFC 6455</cite> for related security considerations.</p>
+  <p>Refer to <cite>XEP-0047</cite>, <cite>XEP-0065</cite>, <cite>XEP-0096</cite>, <cite>XEP-0176</cite>, <cite>XEP-0260</cite>, <cite>XEP-0261</cite>, and <cite>RFC 6544</cite> for related security considerations.</p>
 </section1>
 
 <section1 topic='IANA Considerations' anchor='iana'>


### PR DESCRIPTION
ICE-TCP is RFC 6544. RFC 6455 is an important too and authored by someone familiar but not related to filetransfers ;-)