### PR TITLE
Add 'jingle' XMPP URI querytype to XEP-0358

### DIFF
--- a/xep-0358.xml
+++ b/xep-0358.xml
@@ -144,6 +144,20 @@
     ]]></example>
   </section2>
   <section2 topic='Triggering the Stream Initiation Request' anchor='usecase.trigger'>
+    <p>In general, the process to trigger a stream initiation request is as follows:</p>
+    <code><![CDATA[
+Initiator                    Responder
+   |                             |
+   |   <start/>                  |
+   |---------------------------->|
+   |   <starting/>               |
+   |<----------------------------|
+   |   session-initiate          |
+   |<----------------------------|
+   |   [further jingle           |
+   |    negotiation]             |
+   |<--------------------------->|
+   |                             |]]></code>
     <p>A potential receiver requests initiation of the session by sending an IQ-get to the sender, using the &lt;start xmlns='urn:xmpp:jinglepub:1'/&gt; element. This element contains the 'id' attribute to specify which published stream to retrieve:</p>
     <example caption='Receiver requests start of session'><![CDATA[
   <iq type='get'

--- a/xep-0358.xml
+++ b/xep-0358.xml
@@ -146,18 +146,18 @@
   <section2 topic='Triggering the Stream Initiation Request' anchor='usecase.trigger'>
     <p>In general, the process to trigger a stream initiation request is as follows:</p>
     <code><![CDATA[
-Initiator                    Responder
-   |                             |
-   |   <start/>                  |
-   |---------------------------->|
-   |   <starting/>               |
-   |<----------------------------|
-   |   session-initiate          |
-   |<----------------------------|
-   |   [further jingle           |
-   |    negotiation]             |
-   |<--------------------------->|
-   |                             |]]></code>
+Requester                   Publisher
+    |                           |
+    |   <start/>                |
+    |-------------------------->|
+    |   <starting/>             |
+    |<--------------------------|
+    |   session-initiate        |
+    |<--------------------------|
+    |   [further jingle         |
+    |    negotiation]           |
+    |<------------------------->|
+    |                           |]]></code>
     <p>A potential receiver requests initiation of the session by sending an IQ-get to the sender, using the &lt;start xmlns='urn:xmpp:jinglepub:1'/&gt; element. This element contains the 'id' attribute to specify which published stream to retrieve:</p>
     <example caption='Receiver requests start of session'><![CDATA[
   <iq type='get'

--- a/xep-0358.xml
+++ b/xep-0358.xml
@@ -81,7 +81,7 @@
   </jinglepub>
     ]]></example>
     <p>The 'from' attribute MUST be present and MUST be the valid JID for the session owner.</p>
-    <p>The 'id' attribute is an opaque identifier. This attribute MUST be present, and MUST be a valid non-empty string. It uniquely identifies the published request at the session owner's JID.</p>
+    <p>The 'id' attribute is an opaque identifier, called the "jinglepub identifier". This attribute MUST be present, and MUST be a valid non-empty string. It uniquely identifies the published request at the session owner's JID.</p>
     <p>The &lt;jinglepub/&gt; element MUST contain a &lt;description/&gt; element qualified by the namespace of the relevant Jingle application format (e.g., &lt;description xmlns='urn:xmpp:jingle:apps:file-transfer:4'/&gt; for file transfer).</p>
     <p>The &lt;jinglepub/&gt; element MAY contain one or more &lt;meta/&gt; elements qualified by the jingle-pub namespace; if more than one element is included, each element MUST have a different value for the 'xml:lang' attribute.</p>
     <p>The &lt;jinglepub/&gt; element MAY contain a &lt;uri/&gt; element which contains a URI for an alternative way to access the content, or other information about the content. The resource provided by the URI SHOULD be meaningful for clients that do not directly support the included Jingle content definitions, and accessing the URI MAY result in a different experience than initiating the published Jingle session. For example, the URI could be to a content landing page of an image hosting service from which an image could be viewed instead of directly downloading the image file.</p>
@@ -258,14 +258,13 @@ Initiator                    Responder
 
     <p>This document defines the 'jingle' XMPP URI/IRI querytype,
     which MUST posses an 'id' key/value pair, whose value is the
-    'jinglepub' identifier (the &lt;jinglepub/&gt; 'id'
-    attribute).</p>
+    "jinglepub identifier".</p>
 
     <example caption='Jingle Action: IRI/URI'><![CDATA[
 xmpp:files.montague.net?jingle;id=9559976B-3FBF-4E7E-B457-2DAA225972BB]]></example>
 
     <p>The information found in such an URI, an XMPP address and a
-    'jinglepub' identifier, can be used to trigger an an Jingle
+    "jinglepub identifier", can be used to trigger an an Jingle
     session initation request as specified in <cite>§ 2.2</cite>. This
     Jingle session can be used to transfer files (&xep0234;), audio
     and video streams (&xep0167;) and other Jingle application

--- a/xep-0358.xml
+++ b/xep-0358.xml
@@ -65,7 +65,7 @@
   </revision>
 </header>
 <section1 topic='Introduction' anchor='intro'>
-  <p>This document defines a way for an entity that can initiate a Jingle session (often for the purpose of file transfer as specified in &xep0234;) to advertise that session, thus enabling a receiver to then request initiation of the session by the sender. In essence, this document defines the Jingle equivalent of &xep0137; (previously defined for &xep0095;).</p>
+  <p>This document defines a way for an entity that can initiate a &xep0166; session (often for the purpose of file transfer as specified in &xep0234;) to advertise that session, thus enabling a receiver to then request initiation of the session by the sender. In essence, this document defines the Jingle equivalent of &xep0137; (previously defined for &xep0095;).</p>
 </section1>
 <section1 topic='Use Cases' anchor='usecase'>
   <section2 topic='Publishing a Jingle Session Request' anchor='usecase.publish'>

--- a/xep-0358.xml
+++ b/xep-0358.xml
@@ -26,6 +26,12 @@
   &lance;
   &stpeter;
   <revision>
+    <version>0.3</version>
+    <date>2016-05-24</date>
+    <initials>fs</initials>
+    <remark><p>Add Jingle query type and XMPP registrar submission.</p></remark>
+  </revision>
+  <revision>
       <version>0.2</version>
       <date>2015-08-11</date>
       <initials>ls</initials>
@@ -234,6 +240,25 @@
   </iq>
     ]]></example>
   </section2>
+  <section2 topic='Jingle Session XMPP URI/IRI Query Type' anchor='jingle-uri-query-types'>
+
+    <p>This document defines the 'jingle' XMPP URI/IRI querytype,
+    which MUST posses an 'id' key/value pair, whose value is the
+    'jinglepub' identifier (the &lt;jinglepub/&gt; 'id'
+    attribute).</p>
+
+    <example caption='Jingle Action: IRI/URI'><![CDATA[
+xmpp:files.montague.net?jingle;id=9559976B-3FBF-4E7E-B457-2DAA225972BB]]></example>
+
+    <p>The information found in such an URI, an XMPP address and a
+    'jinglepub' identifier, can be used to trigger an an Jingle
+    session initation request as specified in <cite>§ 2.2</cite>. This
+    Jingle session can be used to transfer files (&xep0234;), audio
+    and video streams (&xep0167;) and other Jingle application
+    formats.</p>
+
+  </section2>
+
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
   <p>This document introduces no security concerns beyond those specified in <cite>XEP-0060</cite> and the relevant Jingle application format in use.</p>
@@ -244,6 +269,27 @@
 <section1 topic='XMPP Registrar Considerations' anchor='registrar'>
   <section2 topic='Protocol Namespaces' anchor='registrar.namespaces'>
     <p>The &REGISTRAR; will be requested to include 'urn:xmpp:jinglepub:1' in its registry of protocol namespaces.</p>
+  </section2>
+  <section2 topic='XMPP URI/IRI Querytype registration' anchor='uri-iri-registration'>
+    <p>As authorized by &xep0147;, the XMPP Registrar maintains a
+    registry of queries and key-value pairs for use in XMPP URIs (see
+    &QUERYTYPES;).The following submission registers the 'jingle'
+    querytype.</p>
+
+    <code><![CDATA[
+<querytype>
+  <name>jingle</name>
+  <proto>urn:xmpp:jinglepub:1</proto>
+  <desc>enables retrieving Jingle sessions (file transfer, etc.)</desc>
+  <doc>XEP-0358</doc>
+  <keys/>
+    <key>
+      <name>id</name>
+      <desc>The 'jinglepub' identifier</desc>
+    </key>
+  <keys/>
+</querytype>]]></code>
+
   </section2>
 </section1>
 <section1 topic='XML Schema' anchor='schema'>


### PR DESCRIPTION
In order to allow users to share files via XMPP URIs, Jingle and XEP-0358. But this is not only limited to file sharing, e.g. links Audio/Video conferences could be shared too.

If this get's the accepted, then the registry should be updated to. But http://xmpp.org/registrar/querytypes.html is currently a 404 and I've no idea where the registry is maintained.