### PR TITLE
XEP-0156: Fix typo (s/utf-9/utf-8/)

### DIFF
--- a/xep-0156.xml
+++ b/xep-0156.xml
@@ -26,6 +26,12 @@
   &stpeter;
   &lance;
   <revision>
+    <version>1.1.1</version>
+    <date>2016-06-06</date>
+    <initials>XSF Editor: ssw</initials>
+    <remark><p>Fix a small typo in one of the examples (UTF-9 encoding).</p></remark>
+  </revision>
+  <revision>
     <version>1.1</version>
     <date>2014-01-08</date>
     <initials>ls/psa</initials>
@@ -167,7 +173,7 @@ _xmppconnect IN TXT "_xmpp-client-websocket=wss://web.example.com:443/ws"
 
   <section2 topic='Examples' anchor='httpexamples'>
     <p>The following examples show two host-meta link records: the first indicates support for the XMPP Over BOSH connection method defined in <cite>XEP-0124</cite> and <cite>XEP-0206</cite> and the second indicates support for the XMPP Over WebSocket connection method defined in <cite>draft-ietf-xmpp-websocket</cite>.</p>
-    <example caption='Result for /.well-known/host-meta'><![CDATA[<?xml version='1.0' encoding=utf-9'?>
+    <example caption='Result for /.well-known/host-meta'><![CDATA[<?xml version='1.0' encoding=utf-8'?>
 <XRD xmlns='http://docs.oasis-open.org/ns/xri/xrd-1.0'>
   ...
   <Link rel="urn:xmpp:alt-connections:xbosh"


### PR DESCRIPTION
Not sure what the procedure on editorial fixes to Draft XEPs is, but I'm pretty sure the encoding here should be UTF-8, not UTF-9.