### PR TITLE
XEP-0156: The XRD host-meta file is REQUIRED and the websocket subprotocol is now RFC 7395

### DIFF
--- a/xep-0156.xml
+++ b/xep-0156.xml
@@ -26,6 +26,12 @@
   &stpeter;
   &lance;
   <revision>
+    <version>1.1.2</version>
+    <date>2016-06-07</date>
+    <initials>XSF Editor: ssw</initials>
+    <remark><p>Clarify that the XML version of the XRD document is required by the RFC and the JSON version is optional.</p></remark>
+  </revision>
+  <revision>
     <version>1.1.1</version>
     <date>2016-06-06</date>
     <initials>XSF Editor: ssw</initials>
@@ -173,6 +179,7 @@ _xmppconnect IN TXT "_xmpp-client-websocket=wss://web.example.com:443/ws"
 
   <section2 topic='Examples' anchor='httpexamples'>
     <p>The following examples show two host-meta link records: the first indicates support for the XMPP Over BOSH connection method defined in <cite>XEP-0124</cite> and <cite>XEP-0206</cite> and the second indicates support for the XMPP Over WebSocket connection method defined in <cite>draft-ietf-xmpp-websocket</cite>.</p>
+    <p>As specified in <cite>RFC 6120</cite> &sect;3, support for the XML encoding of the host-meta resource is REQUIRED while alternative representations such as JSON are OPTIONAL.</p>
     <example caption='Result for /.well-known/host-meta'><![CDATA[<?xml version='1.0' encoding=utf-8'?>
 <XRD xmlns='http://docs.oasis-open.org/ns/xri/xrd-1.0'>
   ...

--- a/xep-0156.xml
+++ b/xep-0156.xml
@@ -29,7 +29,12 @@
     <version>1.1.2</version>
     <date>2016-06-07</date>
     <initials>XSF Editor: ssw</initials>
-    <remark><p>Clarify that the XML version of the XRD document is required by the RFC and the JSON version is optional.</p></remark>
+    <remark>
+      <ul>
+        <li>Clarify that the XML version of the XRD document is required by the RFC and the JSON version is optional.</li>
+        <li>Update references to draft-ietf-xmpp-websocket to point to RFC 7395.</li>
+      </ul>
+    </remark>
   </revision>
   <revision>
     <version>1.1.1</version>
@@ -111,7 +116,7 @@
   </revision>
 </header>
 <section1 topic='Introduction' anchor='intro'>
-  <p>Although &xmppcore; specifies the use of TCP as the method of connecting to an XMPP server, alternative connection methods exist, including the &xep0124; method (for which &xep0206; is the XMPP profile) and &xmppoverwebsocket;. For some of these methods, it is necessary to discover further parameters before connecting, such as the HTTP URL of an alternative connection manager. Without ways to auto-discover alternative connection methods, the relevant information would need to be provided manually by a human user (which is cumbersome and error-prone) or hard-coded into XMPP software applications (which is brittle and not interoperable).</p>
+  <p>Although &xmppcore; specifies the use of TCP as the method of connecting to an XMPP server, alternative connection methods exist, including the &xep0124; method (for which &xep0206; is the XMPP profile) and the websocket subprotocol specified in &rfc7395;. For some of these methods, it is necessary to discover further parameters before connecting, such as the HTTP URL of an alternative connection manager. Without ways to auto-discover alternative connection methods, the relevant information would need to be provided manually by a human user (which is cumbersome and error-prone) or hard-coded into XMPP software applications (which is brittle and not interoperable).</p>
   <p>This document defines two ways to encapsulate information about alternative connection methods for auto-discovery:</p>
   <ol>
     <li>DNS TXT resource records</li>
@@ -147,7 +152,7 @@
   </section2>
 
   <section2 topic='Examples' anchor='dnsexamples'>
-    <p>The following examples show two DNS TXT resource records: the first indicates support for the XMPP Over BOSH connection method defined in <cite>XEP-0124</cite> and <cite>XEP-0206</cite> and the second indicates support for XMPP over WebSocket connections defined in &xmppoverwebsocket;.</p>
+    <p>The following examples show two DNS TXT resource records: the first indicates support for the XMPP Over BOSH connection method defined in <cite>XEP-0124</cite> and <cite>XEP-0206</cite> and the second indicates support for XMPP over WebSocket connections defined in <cite>RFC 7395</cite>;.</p>
     <example caption='TXT Resource Records'><![CDATA[
 _xmppconnect IN TXT "_xmpp-client-xbosh=https://web.example.org:5280/bosh"
 _xmppconnect IN TXT "_xmpp-client-websocket=wss://web.example.com:443/ws"
@@ -259,7 +264,7 @@ _xmppconnect IN TXT "_xmpp-client-websocket=wss://web.example.com:443/ws"
   <syntax>
     The ws: or wss: URL at which to contact the WebSocket connection manager or proxy
   </syntax>
-  <doc>draft-ietf-xmpp-websocket</doc>
+  <doc>RFC 7395</doc>
 </method>
 
 <method>

--- a/xep.ent
+++ b/xep.ent
@@ -45,6 +45,7 @@ THE SOFTWARE.
 <!ENTITY nbsp "&#160;">
 <!ENTITY copy "&#169;">
 <!ENTITY reg "&#174;">
+<!ENTITY sect "&#167;">
 
 <!-- shortcuts for stanza types and children -->
 


### PR DESCRIPTION
Add a business rule clarifying that the XML version of the host-meta file in XRD format is REQUIRED, while the JSON version is OPTIONAL.

This is already specified by the RFC, but for clarity it's worth stating here too.

Also update references to the draft version of the websockets subprotocol to point to RFC 7395.

This change is editorial in nature.