### PR TITLE
Fix some copypasta problems.

### DIFF
--- a/xep-0373.xml
+++ b/xep-0373.xml
@@ -300,7 +300,7 @@ Standards Foundation.</permissions>
     type='result'
     id='getpub'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-    <publish node='urn:xmpp:openpgp:0'>
+    <items node='urn:xmpp:openpgp:0'>
       <item>
         <pubkeys xmlns='urn:xmpp:openpgp:0'>
           <pubkey>
@@ -308,7 +308,7 @@ Standards Foundation.</permissions>
           </pubkey>
         </pubkeys>
       </item>
-    </publish>
+    </items>
   </pubsub>
   </iq>]]></example>
 
@@ -409,19 +409,19 @@ Standards Foundation.</permissions>
       </section3>
       <section3 topic='PEP Service Success Response'>
 
-  <example caption='Personal Eventing Protocol result containing the requested public key.'><![CDATA[
+  <example caption='Personal Eventing Protocol result containing the requested secret key.'><![CDATA[
 <iq from='juliet@example.org'
     to='romeo@example.org/orchard'
     type='result'
     id='getsecret'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-    <publish node='urn:xmpp:openpgp:secret-key:0'>
+    <items node='urn:xmpp:openpgp:secret-key:0'>
       <item>
         <secretkey xmlns='urn:xmpp:openpgp:0'>
             BASE64_OPENPGP_ENCRYPTED_SECRET_KEY
         </secretkey>
       </item>
-    </publish>
+    </items>
   </pubsub>
 </iq>]]></example>
 


### PR DESCRIPTION
Items returned from a pubsub items request are encapsulated in an
<items/> element, not <publish/>, which is used for publishing items.

Example for requesting the secret key was labelled as requesting the
public key.