### PR TITLE
Fix typo in XEP-0167: s/PMCA/PCMA/

### DIFF
--- a/xep-0167.xml
+++ b/xep-0167.xml
@@ -469,7 +469,7 @@ Initiator                    Responder
     type='result'/>
   ]]></example>
   <p>Depending on user preferences or client configuration, a user agent controlled by a human user might need to wait for the user to affirm a desire to proceed with the session before continuing. When the user agent has received such affirmation (or if the user agent can automatically proceed for any reason, e.g. because no human intervention is expected or because a human user has configured the user agent to automatically accept sessions with a given entity), it returns a Jingle session-accept message. The session-accept message SHOULD include a subset of the payload types sent by the initiator, i.e., a list of the offered payload types that the responder can send and/or receive. The list that the responder sends SHOULD retain the ID numbers specified by the initiator. The order of the &PAYLOADTYPE; elements indicates the responder's preferences, with the most-preferred type first.</p>
-  <p>In the following example, we imagine that the responder supports Speex at a clockrate of 8000 but not 16000, G729, and PCMA but not PMCU. Therefore the responder returns only two payload types (since PMCA was not offered).</p>
+  <p>In the following example, we imagine that the responder supports Speex at a clockrate of 8000 but not 16000, G729, and PCMA but not PMCU. Therefore the responder returns only two payload types (since PCMA was not offered).</p>
   <example caption="Responder definitively accepts the session"><![CDATA[
 <iq from='juliet@capulet.lit/balcony'
     id='i91fs6d5'
@@ -1918,6 +1918,6 @@ Romeo                         Juliet
   </section2>
 </section1>
 <section1 topic='Acknowledgements' anchor='ack'>
-  <p>Thanks to Milton Chen, Paul Chitescu, Olivier Cr&#234;te, Tim Julien, Steffen Larsen, Jeff Muller, Mike Ruprecht, Sjoerd Simons, Will Thompson, Justin Uberti, Unnikrishnan Vikrama Panicker, and Paul Witty for their feedback.</p>
+  <p>Thanks to Milton Chen, Paul Chitescu, Olivier Cr&#234;te, Tim Julien, Steffen Larsen, Jeff Muller, Mike Ruprecht, Sjoerd Simons, Will Thompson, Justin Uberti, Unnikrishnan Vikrama Panicker, Paul Witty, and Konstantin Kozlov for their feedback.</p>
 </section1>
 </xep>


### PR DESCRIPTION
Thanks to Konstantin Kozlov for reporting this in
http://mail.jabber.org/pipermail/standards/2016-June/031166.html