### PR TITLE
XEP-0045: Define option name for enabling/disabling MAM

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -3808,6 +3808,12 @@
           type='text-single'
           var='muc#roomconfig_lang'/>
       <field
+          label='Enable Room Archiving?'
+          type='boolean'
+          var='muc#roomconfig_mam'>
+        <value>1</value>
+      </field>
+      <field
           label='Enable Public Logging?'
           type='boolean'
           var='muc#roomconfig_enablelogging'>
@@ -3986,6 +3992,9 @@
       <field var='muc#roomconfig_roomdesc'>
         <value>The place for all good witches!</value>
       </field>
+      <field var='muc#roomconfig_mam'>
+        <value>1</value>
+      </field>
       <field var='muc#roomconfig_enablelogging'>
         <value>0</value>
       </field>
@@ -4119,6 +4128,12 @@
           type='text-single'
           var='muc#roomconfig_roomdesc'>
         <value>The place for all good witches!</value>
+      </field>
+      <field
+          label='Enable Room Archiving?'
+          type='boolean'
+          var='muc#roomconfig_mam'>
+        <value>1</value>
       </field>
       <field
           label='Enable Public Logging?'
@@ -5095,6 +5110,10 @@
       var='muc#roomconfig_changesubject'
       type='boolean'
       label='Whether to Allow Occupants to Change Subject'/>
+  <field
+      var='muc#roomconfig_mam'
+      type='boolean'
+      label='Whether to Enable Message Archive Management'/>
   <field
       var='muc#roomconfig_enablelogging'
       type='boolean'


### PR DESCRIPTION
Specify a room configuration option for enabling/disabling [Message Archive Management](https://xmpp.org/extensions/xep-0313.html).  This allows clients that don't want to present the full configuration form to offer a knob for that.

This has been [discussed](http://mail.jabber.org/pipermail/standards/2016-July/thread.html#31189) on the `standards@` list.
