### PR TITLE
XEP-0375: Webclients don't need BOSH and websockets

### DIFF
--- a/xep-0375.xml
+++ b/xep-0375.xml
@@ -43,6 +43,14 @@
     &stpeter;
     &sam;
     <revision>
+      <version>0.3</version>
+      <date>2016-07-20</date>
+      <initials>ssw</initials>
+      <remark>
+        <p>Don't require both BOSH and Websockets.</p>
+      </remark>
+    </revision>
+    <revision>
       <version>0.2</version>
       <date>2016-07-11</date>
       <initials>ssw</initials>
@@ -162,9 +170,9 @@
         <tr>
           <td><strong>Web Connection Mechanisms</strong></td>
           <td align='center'>&#10003;&#x2020;</td>
-          <td align='center'>&#10003;</td>
+          <td align='center'>&#10003;&sect;</td>
           <td align='center'>&#10003;&#x2020;</td>
-          <td align='center'>&#10003;</td>
+          <td align='center'>&#10003;&sect;</td>
           <td>&rfc7395;, &xep0124; and &xep0206;</td>
         </tr>
       </table>
@@ -313,6 +321,10 @@
     <p>
       &#x2021; Support for the Entity Use Cases and Occupant Use Cases is
       REQUIRED; support for the remaining use cases is RECOMMENDED.
+    </p>
+    <p>
+      &sect; Only one of the recommended providers must be implemented for
+      compliance.
     </p>
   </section1>
   <section1 topic='Implementation Notes' anchor='impl'>


### PR DESCRIPTION
Adds a footnote to indicate that web clients don't need to implement BOSH and Websockets. It should be an OR.