### PR TITLE
Improve rendering of <example> and div.example HTML

### DIFF
--- a/prettify.css
+++ b/prettify.css
@@ -11,7 +11,6 @@
 .atn { color: #606; }
 .atv { color: #080; }
 .dec { color: #606; }
-pre.prettyprint { padding: 2px; border: 1px solid #888; }
 
 @media print {
   .str { color: #060; }

--- a/xmpp.css
+++ b/xmpp.css
@@ -55,6 +55,9 @@ H1, H2, H3, H4, H5, H6 {
     }
 pre {
     font-family: Courier, monospace;
+    background-color: #e0e9f2;
+    padding: 0.4em;
+    border: 1px solid #369;
     }
 ul {
     list-style: disc outside;
@@ -91,9 +94,10 @@ ul {
     font-style: italic;
     }
 .example {
-    background-color: yellow;
-    margin-left: 5%;
-    margin-right: 25%;
+    background-color: #f2ee6e;
+    margin: 0.4em 5%;
+    border: 1px solid #999633;
+    padding: 0 0.4em;
     }
 .indent {
     padding-left: 5%;


### PR DESCRIPTION
This change unifiess the rendering for &lt;example> and &lt;div class=example>.
The former is rendered as HTML &lt;pre>, the latter is taken over. This
patch does the following:

 * Merge &lt;pre> CSS from prettify.js int xmpp.css
 * Give &lt;pre> a blue-ish background derived from the caption color
 * Make the &lt;pre> border use the caption color
 * Change div.example background color from neon yellow to a colder and lighter tone that matches the overall color theme
 * Add a border to div.example that fits its background color
 * Derive width for div.example from &lt;pre>

Side-by-side comparison:
http://xmpp.org/extensions/xep-0071.html#examples
https://op-co.de/tmp/xep-0071.html#examples

There is also an xmpp.css in the xmpp.org repo. I'm not sure what it is used for and how this change would affect it.

P.S: Don't eat yellow snow!