### PR TITLE
XEP-0045: participant should be member

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -2731,7 +2731,7 @@
   </section2>
 
   <section2 topic='Kicking an Occupant' anchor='kick'>
-    <p>A moderator has permissions kick certain kinds of occupants from a room (which occupants are "kickable" depends on service provisioning, room configuration, and the moderator's affiliation -- see below). The kick is performed based on the occupant's room nickname and is completed by setting the role of a participant or visitor to a value of "none".</p>
+    <p>A moderator has permissions to kick certain kinds of occupants from a room (which occupants are "kickable" depends on service provisioning, room configuration, and the moderator's affiliation -- see below). The kick is performed based on the occupant's room nickname and is completed by setting the role of a participant or visitor to a value of "none".</p>
     <example caption='Moderator Kicks Occupant'><![CDATA[
 <iq from='fluellen@shakespeare.lit/pda'
     id='kick1'

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -2782,7 +2782,7 @@
 
 [ ... ]
     ]]></example>
-    <p>A user cannot be kicked by a moderator with a lower affiliation. Therefore, if a moderator who is a participant attempts to kick an admin or a moderator who is a participant or admin attempts to kick an owner, the service MUST deny the request and return a &notallowed; error to the sender:</p>
+    <p>A user cannot be kicked by a moderator with a lower affiliation. Therefore, if a moderator who is a member attempts to kick an admin or a moderator who is a member or admin attempts to kick an owner, the service MUST deny the request and return a &notallowed; error to the sender:</p>
     <example caption='Service Returns Error on Attempt to Kick User With Higher Affiliation'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='kicktest'


### PR DESCRIPTION
I think this sentence is confusing.

A moderator cannot be a participant at the same time, because it can only have one role.
I think the context is referring to an affiliation here, which should be "member" or "member or admin".