### PR TITLE
XEP-0329: update to JingleFT:4 and various cosmetic fixes

### DIFF
--- a/xep-0329.xml
+++ b/xep-0329.xml
@@ -201,6 +201,8 @@
         </file>
       </request>
     </description>
+  </content>
+</jingle>
 ]]>
         </example>
     </section2>

--- a/xep-0329.xml
+++ b/xep-0329.xml
@@ -71,19 +71,15 @@
 <section1 topic='Getting Information About Files ' anchor='disco'>
   <section2 topic='Traversing Files' anchor='traver'>
       <p>If a requesting entity wishes to know what files are being shared by an offering entity, it can do so by sending the following query:</p>
-      <example caption='Requester queries the root of the shared folder'>
-<![CDATA[
+      <example caption='Requester queries the root of the shared folder'><![CDATA[
 <iq type='get'
     from='juliet@capulet.com/chamber'
     to='romeo@montague.net/home'
     id='1234'>
   <query xmlns="urn:xmpp:fis:0" />
-</iq>
-]]>
-      </example>
+</iq>]]></example>
       <p> If the offering entity wishes to share files with the requesting entity, it may respond with a list of shared folders. It MUST not include any files in this response.</p>
-      <example caption='The offering entity responds with shared directories'>
-<![CDATA[
+      <example caption='The offering entity responds with shared directories'><![CDATA[
 <iq type='result'
     from='romeo@montague.net/home'
     to='juliet@capulet.com/chamber'
@@ -93,35 +89,26 @@
     <directory name='pics'/>
     <directory name='audio'/>
   </query>
-</iq>
-]]>
-      </example>
+</iq>]]></example>
       <p>if the offering entity has no files to offer</p>
-      <example caption='The offering entity responds with no files'>
-<![CDATA[
+      <example caption='The offering entity responds with no files'><![CDATA[
 <iq type='result'
     from='romeo@montague.net/home'
     to='juliet@capulet.com/chamber'
     id='1234'>
   <query xmlns="urn:xmpp:fis:0" />
-</iq>
-]]>
-      </example>
+</iq>]]></example>
       <p>Requesting the list of files and directories within a directory.</p>
-      <example caption='The requesting entity wants to know about a particular directory'>
-<![CDATA[
+      <example caption='The requesting entity wants to know about a particular directory'><![CDATA[
 <iq type='get'
     from='juliet@capulet.com/chamber'
     to='romeo@montague.net/home'
     id='1234'>
   <query xmlns="urn:xmpp:fis:0" node="documents" />
-</iq>
-]]>
-</example>
+</iq>]]></example>
       <p>When replying with a list of files, the offering entity can choose to either reply with verbose information on the file using the file attributes defined by &xep0234; or it may reply only with the 'name' attribute, which is required and MUST be included in every response.</p>
       <p>It is RECOMENDED, when the list files to be sent is small, that a verbose response be made (in order to avoid going back and forth requesting information), and that a non-verbose reponse be made otherwise. This recomendation is made to save bandwidth.</p>
-      <example caption='The offering entity replies with information about a particular directory'>
-<![CDATA[
+      <example caption='The offering entity replies with information about a particular directory'><![CDATA[
 <iq type='result'
     from='romeo@montague.net/home'
     to='juliet@capulet.com/chamber'
@@ -140,22 +127,16 @@
     </file>
     <directory name="secret docs" />
   </query>
-</iq>
-]]>
-</example>
+</iq>]]></example>
       <p>If the requesting entity wants to get detailed information about a file. It can do so by providing its full path.</p>
-      <example caption='The requesting entity wants to know about a particular file'>
-<![CDATA[
+      <example caption='The requesting entity wants to know about a particular file'><![CDATA[
 <iq type='get'
     from='juliet@capulet.com/chamber'
     to='romeo@montague.net/home'
     id='1234'>
   <query xmlns="urn:xmpp:fis:0" node="documents/test2.txt" />
-</iq>
-]]>
-</example>
-      <example caption='The offering entity responds with more information'>
-<![CDATA[
+</iq>]]></example>
+      <example caption='The offering entity responds with more information'><![CDATA[
 <iq type='result'
     from='romeo@montague.net/home'
     to='juliet@capulet.com/chamber'
@@ -166,9 +147,7 @@
       <size>1000</size>
     </file>
   </query>
-</iq>
-]]>
-</example>
+</iq>]]></example>
   </section2>
 </section1>
 <section1 topic='Bandwidth Considerations' anchor='bandwidth'>
@@ -186,8 +165,7 @@
 <section1 topic='Implementation Notes' anchor='implementation'>
     <section2 topic='File identification' anchor='file_id'>
         <p> As it was previously discussed, when requesting detailed information about a file, only the "name" attribute is required, but it is strongly RECOMMENDED that the hash attribute be included, in order to reduce the chances of sending the wrong file. When requesting the file to be transferred using &xep0234;, the information that must be provided has to identify the file uniquely. It is then RECOMMENDED that when requesting a file, the full path of the file in the shared folder be included in the "name" attribute.</p>
-        <example>
-<![CDATA[
+        <example><![CDATA[
 <jingle xmlns='urn:xmpp:jingle:1'
         action='session-initiate'
         initiator='juliet@capulet.com/chamber'
@@ -202,9 +180,7 @@
       </request>
     </description>
   </content>
-</jingle>
-]]>
-        </example>
+</jingle>]]></example>
     </section2>
     <section2 topic='File Sharing in MUCs' anchor='fis_muc'>
  <p>For the most part, discovering files in a MUC is exactly the same as what has been described in this document. However, it is RECOMMENDED that a participant in a MUC should have a single shared folder associated with the entire room, as opposed to advertise different files to different participants of the room. This is to reduce the complexity of the client software. Also, due to volatile nature of the participants in a room, keeping track of permissions is more trouble than what it is worth.</p>

--- a/xep-0329.xml
+++ b/xep-0329.xml
@@ -77,7 +77,7 @@
     from='juliet@capulet.com/chamber'
     to='romeo@montague.net/home'
     id='1234'>
-    <query xmlns="urn:xmpp:fis:0" />
+  <query xmlns="urn:xmpp:fis:0" />
 </iq>
 ]]>
       </example>
@@ -88,11 +88,11 @@
     from='romeo@montague.net/home'
     to='juliet@capulet.com/chamber'
     id='1234'>
-    <query xmlns="urn:xmpp:fis:0">
-        <directory name='documents'/>
-        <directory name='pics'/>
-        <directory name='audio'/>
-    </query>
+  <query xmlns="urn:xmpp:fis:0">
+    <directory name='documents'/>
+    <directory name='pics'/>
+    <directory name='audio'/>
+  </query>
 </iq>
 ]]>
       </example>
@@ -103,7 +103,7 @@
     from='romeo@montague.net/home'
     to='juliet@capulet.com/chamber'
     id='1234'>
-    <query xmlns="urn:xmpp:fis:0" />
+  <query xmlns="urn:xmpp:fis:0" />
 </iq>
 ]]>
       </example>
@@ -114,7 +114,7 @@
     from='juliet@capulet.com/chamber'
     to='romeo@montague.net/home'
     id='1234'>
-    <query xmlns="urn:xmpp:fis:0" node="documents" />
+  <query xmlns="urn:xmpp:fis:0" node="documents" />
 </iq>
 ]]>
 </example>
@@ -126,20 +126,20 @@
     from='romeo@montague.net/home'
     to='juliet@capulet.com/chamber'
     id='1234'>
-    <query xmlns="urn:xmpp:fis:0" node="documents">
-        <file xmlns='urn:xmpp:jingle:apps:file-transfer:3'>
-            <name>test.txt</name>
-            <date>1969-07-21T02:56:15Z</date>
-            <desc>This is a test. If this were a real file...</desc>
-            <range/>
-            <size>1022</size>
-            <hash xmlns='urn:xmpp:hashes:1' algo='sha-1'>552da749930852c69ae5d2141d3766b1</hash>
-        </file>
-        <file xmlns='urn:xmpp:jingle:apps:file-transfer:3'>
-            <name>test2.txt</name>
-        </file>
-        <directory name="secret docs" />
-    </query>
+  <query xmlns="urn:xmpp:fis:0" node="documents">
+    <file xmlns='urn:xmpp:jingle:apps:file-transfer:3'>
+      <name>test.txt</name>
+      <date>1969-07-21T02:56:15Z</date>
+      <desc>This is a test. If this were a real file...</desc>
+      <range/>
+      <size>1022</size>
+      <hash xmlns='urn:xmpp:hashes:1' algo='sha-1'>552da749930852c69ae5d2141d3766b1</hash>
+    </file>
+    <file xmlns='urn:xmpp:jingle:apps:file-transfer:3'>
+      <name>test2.txt</name>
+    </file>
+    <directory name="secret docs" />
+  </query>
 </iq>
 ]]>
 </example>
@@ -150,7 +150,7 @@
     from='juliet@capulet.com/chamber'
     to='romeo@montague.net/home'
     id='1234'>
-    <query xmlns="urn:xmpp:fis:0" node="documents/test2.txt" />
+  <query xmlns="urn:xmpp:fis:0" node="documents/test2.txt" />
 </iq>
 ]]>
 </example>
@@ -160,12 +160,12 @@
     from='romeo@montague.net/home'
     to='juliet@capulet.com/chamber'
     id='1234'>
-    <query xmlns="urn:xmpp:fis:0" node="test2.txt">
-        <file xmlns='urn:xmpp:jingle:apps:file-transfer:3'>
-            <name>test2.txt</name>
-            <size>1000</size>
-        </file>
-    </query>
+  <query xmlns="urn:xmpp:fis:0" node="test2.txt">
+    <file xmlns='urn:xmpp:jingle:apps:file-transfer:3'>
+      <name>test2.txt</name>
+      <size>1000</size>
+    </file>
+  </query>
 </iq>
 ]]>
 </example>
@@ -188,19 +188,19 @@
         <p> As it was previously discussed, when requesting detailed information about a file, only the "name" attribute is required, but it is strongly RECOMMENDED that the hash attribute be included, in order to reduce the chances of sending the wrong file. When requesting the file to be transferred using &xep0234;, the information that must be provided has to identify the file uniquely. It is then RECOMMENDED that when requesting a file, the full path of the file in the shared folder be included in the "name" attribute.</p>
         <example>
 <![CDATA[
-  <jingle xmlns='urn:xmpp:jingle:1'
-          action='session-initiate'
-          initiator='juliet@capulet.com/chamber'
-          sid='uj3b2'>
-    <content creator='initiator' name='a-file-request'>
-      <description xmlns='urn:xmpp:jingle:apps:file-transfer:3'>
-        <request>
-          <file xmlns='urn:xmpp:jingle:apps:file-transfer:3'>
-                <name>pics/test4.png</name>
-                <size>10740</size>
-          </file>
-        </request>
-      </description>
+<jingle xmlns='urn:xmpp:jingle:1'
+        action='session-initiate'
+        initiator='juliet@capulet.com/chamber'
+        sid='uj3b2'>
+  <content creator='initiator' name='a-file-request'>
+    <description xmlns='urn:xmpp:jingle:apps:file-transfer:3'>
+      <request>
+        <file xmlns='urn:xmpp:jingle:apps:file-transfer:3'>
+          <name>pics/test4.png</name>
+          <size>10740</size>
+        </file>
+      </request>
+    </description>
 ]]>
         </example>
     </section2>

--- a/xep-0329.xml
+++ b/xep-0329.xml
@@ -166,19 +166,24 @@
     <section2 topic='File identification' anchor='file_id'>
         <p> As it was previously discussed, when requesting detailed information about a file, only the "name" attribute is required, but it is strongly RECOMMENDED that the hash attribute be included, in order to reduce the chances of sending the wrong file. When requesting the file to be transferred using &xep0234;, the information that must be provided has to identify the file uniquely. It is then RECOMMENDED that when requesting a file, the full path of the file in the shared folder be included in the "name" attribute.</p>
         <example><![CDATA[
-<jingle xmlns='urn:xmpp:jingle:1'
-        action='session-initiate'
-        initiator='juliet@capulet.com/chamber'
-        sid='uj3b2'>
-  <content creator='initiator' name='a-file-request' senders='responder'>
-    <description xmlns='urn:xmpp:jingle:apps:file-transfer:4'>
-      <file>
-        <name>pics/test4.png</name>
-        <size>10740</size>
-      </file>
-    </description>
-  </content>
-</jingle>]]></example>
+<iq type='get'
+    from='juliet@capulet.com/chamber'
+    to='romeo@montague.net/home'
+    id='1237'>
+  <jingle xmlns='urn:xmpp:jingle:1'
+          action='session-initiate'
+          initiator='juliet@capulet.com/chamber'
+          sid='uj3b2'>
+    <content creator='initiator' name='a-file-request' senders='responder'>
+      <description xmlns='urn:xmpp:jingle:apps:file-transfer:4'>
+        <file>
+          <name>pics/test4.png</name>
+          <size>10740</size>
+        </file>
+      </description>
+    </content>
+  </jingle>
+</iq>]]></example>
     </section2>
     <section2 topic='File Sharing in MUCs' anchor='fis_muc'>
  <p>For the most part, discovering files in a MUC is exactly the same as what has been described in this document. However, it is RECOMMENDED that a participant in a MUC should have a single shared folder associated with the entire room, as opposed to advertise different files to different participants of the room. This is to reduce the complexity of the client software. Also, due to volatile nature of the participants in a room, keeping track of permissions is more trouble than what it is worth.</p>

--- a/xep-0329.xml
+++ b/xep-0329.xml
@@ -114,7 +114,7 @@
     to='juliet@capulet.com/chamber'
     id='1234'>
   <query xmlns="urn:xmpp:fis:0" node="documents">
-    <file xmlns='urn:xmpp:jingle:apps:file-transfer:3'>
+    <file xmlns='urn:xmpp:jingle:apps:file-transfer:4'>
       <name>test.txt</name>
       <date>1969-07-21T02:56:15Z</date>
       <desc>This is a test. If this were a real file...</desc>
@@ -122,7 +122,7 @@
       <size>1022</size>
       <hash xmlns='urn:xmpp:hashes:1' algo='sha-1'>552da749930852c69ae5d2141d3766b1</hash>
     </file>
-    <file xmlns='urn:xmpp:jingle:apps:file-transfer:3'>
+    <file xmlns='urn:xmpp:jingle:apps:file-transfer:4'>
       <name>test2.txt</name>
     </file>
     <directory name="secret docs" />
@@ -142,7 +142,7 @@
     to='juliet@capulet.com/chamber'
     id='1234'>
   <query xmlns="urn:xmpp:fis:0" node="test2.txt">
-    <file xmlns='urn:xmpp:jingle:apps:file-transfer:3'>
+    <file xmlns='urn:xmpp:jingle:apps:file-transfer:4'>
       <name>test2.txt</name>
       <size>1000</size>
     </file>
@@ -170,14 +170,12 @@
         action='session-initiate'
         initiator='juliet@capulet.com/chamber'
         sid='uj3b2'>
-  <content creator='initiator' name='a-file-request'>
-    <description xmlns='urn:xmpp:jingle:apps:file-transfer:3'>
-      <request>
-        <file xmlns='urn:xmpp:jingle:apps:file-transfer:3'>
-          <name>pics/test4.png</name>
-          <size>10740</size>
-        </file>
-      </request>
+  <content creator='initiator' name='a-file-request' senders='responder'>
+    <description xmlns='urn:xmpp:jingle:apps:file-transfer:4'>
+      <file>
+        <name>pics/test4.png</name>
+        <size>10740</size>
+      </file>
     </description>
   </content>
 </jingle>]]></example>

--- a/xep-0329.xml
+++ b/xep-0329.xml
@@ -33,6 +33,12 @@
   </author>
   &lance;
   <revision>
+    <version>0.3</version>
+    <date>2016-08-07</date>
+    <initials>egp</initials>
+    <remark><p>Updated the &xep0234; referenced version to 0.16 or higher.</p></remark>
+  </revision>
+  <revision>
     <version>0.2</version>
     <date>2013-11-19</date>
     <initials>jl</initials>

--- a/xep-0329.xml
+++ b/xep-0329.xml
@@ -103,7 +103,7 @@
 <iq type='get'
     from='juliet@capulet.com/chamber'
     to='romeo@montague.net/home'
-    id='1234'>
+    id='1235'>
   <query xmlns="urn:xmpp:fis:0" node="documents" />
 </iq>]]></example>
       <p>When replying with a list of files, the offering entity can choose to either reply with verbose information on the file using the file attributes defined by &xep0234; or it may reply only with the 'name' attribute, which is required and MUST be included in every response.</p>
@@ -112,7 +112,7 @@
 <iq type='result'
     from='romeo@montague.net/home'
     to='juliet@capulet.com/chamber'
-    id='1234'>
+    id='1235'>
   <query xmlns="urn:xmpp:fis:0" node="documents">
     <file xmlns='urn:xmpp:jingle:apps:file-transfer:4'>
       <name>test.txt</name>
@@ -133,14 +133,14 @@
 <iq type='get'
     from='juliet@capulet.com/chamber'
     to='romeo@montague.net/home'
-    id='1234'>
+    id='1236'>
   <query xmlns="urn:xmpp:fis:0" node="documents/test2.txt" />
 </iq>]]></example>
       <example caption='The offering entity responds with more information'><![CDATA[
 <iq type='result'
     from='romeo@montague.net/home'
     to='juliet@capulet.com/chamber'
-    id='1234'>
+    id='1236'>
   <query xmlns="urn:xmpp:fis:0" node="test2.txt">
     <file xmlns='urn:xmpp:jingle:apps:file-transfer:4'>
       <name>test2.txt</name>


### PR DESCRIPTION
This:
- removes ugly whitespace around examples
- makes indentation consistent
- makes every example look correct
- updates JingleFT dependency to 0.16+ (:4 namespace).