### PR TITLE
XEP-0033: Clarify Reply Handling, add 'ofrom' type and fix examples

### DIFF
--- a/xep-0033.xml
+++ b/xep-0033.xml
@@ -274,6 +274,9 @@
             <section3 topic="Address type='noreply'" anchor='addr-type-noreply'>
                 <p>This address type contains no actual address information.  Instead, it means that the receiver SHOULD NOT reply to the message.  This is useful when broadcasting messages to many receivers.</p>
             </section3>
+            <section3 topic="Address type='ofrom'" anchor='addr-type-ofrom'>
+                <p>This address type is used by &xep0045; services. If a room is non-anonymous, the service MAY include an Extended Stanza Addressing (XEP-0033) [16] element that notes the original full JID of the sender by means of the "ofrom" address type</p>
+            </section3>
         </section2>
 
         <section2 topic="Extensibility" anchor='extensibility'>
@@ -436,6 +439,7 @@
    <addresses xmlns='http://jabber.org/protocol/address'>
      <address type='to' jid='to@header1.org' delivered='true'/>
      <address type='cc' jid='cc@header1.org' delivered='true'/>
+     <address type='bcc' jid='bcc@header1.org'/>
      <address type='to' jid='to@header2.org' delivered='true'/>
      <address type='cc' jid='cc@header2.org' delivered='true'/>
      <address type='to' jid='to@noheader.org' delivered='true'/>
@@ -518,6 +522,7 @@
       <address type='cc' jid='cc@header1.org'  delivered='true'/>
       <address type='to' jid='to@header2.org'  delivered='true'/>
       <address type='cc' jid='cc@header2.org'  delivered='true'/>
+      <address type='bcc' jid='bcc@header2.org'/>
       <address type='to' jid='to@noheader.org' delivered='true'/>
       <address type='cc' jid='cc@noheader.org' delivered='true'/>
    </addresses>
@@ -564,6 +569,7 @@
       <address type='cc' jid='cc@header2.org'  delivered='true'/>
       <address type='to' jid='to@noheader.org' delivered='true'/>
       <address type='cc' jid='cc@noheader.org' delivered='true'/>
+      <address type='bcc' jid='bcc@noheader.org'/>
    </addresses>
    <body>Hello, World!</body>
 </message>]]></example>
@@ -577,15 +583,15 @@
             <li>If a noreply address is
             specified, a reply SHOULD NOT be generated.</li> 
 
-            <li>If a replyroom address is specified, the client SHOULD
-            join the specified chat room instead of replying directly
-            to the specified user.  No further extended address
+            <li>If one or more replyroom addresses are specified, the client SHOULD
+            join the specified chat rooms instead of replying directly
+            to the specified users.  No further extended address
             processing is required.</li>
 
-            <li>If a replyto address is specified, the reply SHOULD go
-            to the specified address.  No further extended address
+            <li>If one or more replyto address are specified, the reply SHOULD go
+            to the specified addresses.  No further extended address
             processing is required.  Any &lt;thread/&gt; element from
-            the initial message MUST be copied into the reply.</li>
+            the initial message MUST be copied into the replies.</li>
 
             <li>Otherwise, an extended-address aware client MUST copy
             the address header from the original message into the reply,
@@ -675,6 +681,7 @@
                 <xs:enumeration value='replyroom'/>
                 <xs:enumeration value='replyto'/>
                 <xs:enumeration value='to'/>
+                <xs:enumeration value='ofrom'/>
               </xs:restriction>
             </xs:simpleType>
           </xs:attribute>


### PR DESCRIPTION
- A stanza can contain multiple replyto and replyroom items (as per §
  4.6.4), make it clear in the reply handling section as well.
- Fix examples. Include the BCC address in the addresses element, when the
  stanza is sent to the BCC addressee.
  This is as per the sentence ' Each 'bcc' recipient MUST receive only the
  <address type='bcc'/> associated with that addressee.'
- Include 'ofrom' attribute as defined in XEP-0045.
