### PR TITLE
XEP-0369: Remove circular definition

### DIFF
--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -229,7 +229,7 @@
     </section3>
     <section3 topic="JID Map Node" anchor="jid-map-node">
 
-      <p>The JID Map node is used to map from proxy bare JID to real bare JID.
+      <p>The JID Map node is used to associate a proxy bare JID to its corresponding real bare JID.
        Each item is identified by proxy bare JID, mapping to the real bare JID.  This node is used to give administrator access to real JIDs and participant access to real JIDs in jid-visible channels.
         In JID visible channels, all participants may subscribe to this node.  In JID hidden channels, only administrators can subscribe.  </p>
       <example caption="Value of JID Map Node"><![CDATA[


### PR DESCRIPTION
Nit pick: The definition of the map node is somewhat circular. This tweaks the language to remove the circular definition using a synonym.

/cc @stevekille @Kev @stpeter 