### PR TITLE
Fix obvious mistakes in the DTD

### DIFF
--- a/xep.dtd
+++ b/xep.dtd
@@ -66,50 +66,54 @@ THE SOFTWARE.
 <!ELEMENT version (#PCDATA)* >
 <!ELEMENT date (#PCDATA)* >
 <!ELEMENT initials (#PCDATA)* >
-<!ELEMENT remark ( p | ul )* >
+<!ELEMENT remark (#PCDATA | p | ul)* >
 <!ELEMENT councilnote (#PCDATA)* >
 <!ELEMENT section1 ( div | p | section2 | example | code | ul | ol | dl | table )* >
 <!ATTLIST section1
-          topic CDATA '' 
+          topic CDATA ''
           anchor CDATA '' >
 <!ELEMENT section2 ( div | p | section3 | example | code | ul | ol | dl | table )* >
 <!ATTLIST section2
-          topic CDATA '' 
+          topic CDATA ''
           anchor CDATA '' >
 <!ELEMENT section3 ( div | p | section4 | example | code | ul | ol | dl | table )* >
 <!ATTLIST section3
-          topic CDATA '' 
+          topic CDATA ''
           anchor CDATA '' >
-<!ELEMENT section4 ( div | p | example | code | ul | ol | dl | table )* >
+<!ELEMENT section4 ( div | p | section5 | example | code | ul | ol | dl | table )* >
 <!ATTLIST section4
-          topic CDATA '' 
+          topic CDATA ''
+          anchor CDATA '' >
+<!ELEMENT section5 ( div | p | example | code | ul | ol | dl | table )* >
+<!ATTLIST section5
+          topic CDATA ''
           anchor CDATA '' >
 <!ELEMENT div ( div | p | example | code | ul | ol | dl | table )* >
-<!ATTLIST div 
+<!ATTLIST div
           class CDATA ''
           style CDATA '' >
 <!ELEMENT p (#PCDATA | br | img | link | note | tt | dfn | em | strong | cite | span)* >
-<!ATTLIST p 
+<!ATTLIST p
           class CDATA ''
           style CDATA '' >
 <!ELEMENT br EMPTY >
 <!ELEMENT ul (li+) >
-<!ATTLIST ul 
-          class CDATA '' 
+<!ATTLIST ul
+          class CDATA ''
           style CDATA '' >
 <!ELEMENT ol (li+) >
-<!ATTLIST ol 
-          class CDATA '' 
-          start CDATA '' 
+<!ATTLIST ol
+          class CDATA ''
+          start CDATA ''
           style CDATA '' >
-<!ELEMENT li (#PCDATA | p | link | note | tt | em | strong | span)* >
-<!ATTLIST li 
-          class CDATA '' 
+<!ELEMENT li (#PCDATA | p | link | note | tt | em | strong | cite | span | code | example | ul | ol)* >
+<!ATTLIST li
+          class CDATA ''
           style CDATA '' >
 <!ELEMENT dl (di+) >
 <!ELEMENT di ( dt, dd ) >
 <!ELEMENT dt (#PCDATA)* >
-<!ELEMENT dd (#PCDATA | p | link | note | tt | em | strong | span)* >
+<!ELEMENT dd (#PCDATA | p | link | note | tt | em | strong | cite | span)* >
 <!ELEMENT img EMPTY>
 <!ATTLIST img src CDATA '' >
 <!ELEMENT link (#PCDATA)* >
@@ -117,25 +121,25 @@ THE SOFTWARE.
 <!ELEMENT note (#PCDATA | link | tt | dfn | em | strong | cite | span)* >
 <!ELEMENT example (#PCDATA)* >
 <!ATTLIST example caption CDATA '' >
-<!ELEMENT code (#PCDATA)* >
+<!ELEMENT code (#PCDATA | span | em)* >
 <!ATTLIST code caption CDATA '' >
 <!ELEMENT table (tr)* >
 <!ATTLIST table caption CDATA '' >
 <!ELEMENT tr ( th | td )* >
 <!ELEMENT th (#PCDATA)* >
-<!ATTLIST th 
+<!ATTLIST th
           colspan CDATA ''
           rowspan CDATA '' >
-<!ELEMENT td (#PCDATA)* >
-<!ATTLIST td 
+<!ELEMENT td (#PCDATA | p | link | note | tt | em | strong | cite | span | code | ul | ol)* >
+<!ATTLIST td
           colspan CDATA ''
           rowspan CDATA '' >
-<!ELEMENT tt (#PCDATA)* >
+<!ELEMENT tt (#PCDATA | link | em | string)* >
 <!ELEMENT dfn (#PCDATA)* >
-<!ELEMENT em (#PCDATA)* >
-<!ELEMENT strong (#PCDATA)* >
+<!ELEMENT em (#PCDATA | link | tt | strong | span | note)* >
+<!ELEMENT strong (#PCDATA | link | tt | em | span | note)* >
 <!ELEMENT cite (#PCDATA)* >
 <!ELEMENT span (#PCDATA | link | tt | dfn | em | strong )* >
-<!ATTLIST span 
+<!ATTLIST span
           class CDATA ''
           style CDATA '' >


### PR DESCRIPTION
Adds a few obvious missing allowed children to various elements in the
DTD.  Before this, 277 XEPs failed to validate, after the change, 'only'
179 fail to validate. It also means a portion of those XEPs contain
things that will never be converted to HTML or PDF, because our XSLT
doesn't know about them.

Test-Information:

Tested the DTD against our current body of XEPs using xmllint 2.9.1.