### PR TITLE
XEP-0369: Fix revision 0.2.1 XML

### DIFF
--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -45,10 +45,8 @@
   <revision>
     <version>0.2.1</version>
     <date>2016-08-25</date>
-    <initials>sek</initials>
-    <remark><p>Include Link Mauve editorial changes</p></remark>
-    <initials>egp</initials>
-    <remark><p>Link Mauve (Emmanuel Gil PEYROT) editorial changes</p></remark>
+    <initials>sek, egp</initials>
+    <remark><p>Includes Link Mauve (Emmanuel Gil PEYROT) editorial changes</p></remark>
   </revision>
   <revision>
     <version>0.2</version>


### PR DESCRIPTION
Revision 0.2.1 of xep-0369.xml had two <initials/> and two <remark/>
elements, both of which are illegal. Merged them, as I think it's the
least ungraceful recovery from the dual 0.2.1 revision issue.

Test-Information:

xep-0369.xml now validates according to the DTD using xmllint.