### PR TITLE
xep.xsl: Force open and close tags on script

### DIFF
--- a/xep.xsl
+++ b/xep.xsl
@@ -43,7 +43,9 @@ OR OTHER DEALINGS IN THE SOFTWARE.
         <link rel='stylesheet' type='text/css' href='xmpp.css' />
         <link href="prettify.css" type="text/css" rel="stylesheet" />
         <link rel='shortcut icon' type='image/x-icon' href='/favicon.ico' />
-        <script type="text/javascript" src="prettify.js"></script>
+        <script type="text/javascript" src="prettify.js">
+          <xsl:comment></xsl:comment>
+        </script>
         <!-- making things mobile-friendly... -->
         <meta>
           <xsl:attribute name='name'><xsl:text>viewport</xsl:text></xsl:attribute>


### PR DESCRIPTION
XSLT processors are allowed to choose either the self-closing form or
explicit open and close tags when operating in xml mode for elements
that have no text.  Unfortunately, for the script element, this is not
allowed (by the DTD, and conformant browsers will not accept the
self-closing form).

xsltproc, as used by the XSF tooling, will output the open/close tags,
but other processors, such as Xalan, will choose the self-closing form.

This patch adds an empty comment as a child of the script tag. This will
force all XSLT processors into outputting the right form. As browsers
are required to ignore the content if there is a src attribute, this
will not change the behaviour. Should a browser without support for the
script tag open it, all it sees is a comment.

Test-Information:

Transforms XEPs into readable documents in xsltproc and oXygen 9.3.