### PR TITLE
Mix

### DIFF
--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -44,7 +44,7 @@
     <version>0.4</version>
     <date>2016-09-21</date>
     <initials>sek</initials>
-    <remark><p>Clarification of MIX Proxy concept; Clarify node definitions; Make all nodes optional; Merge ACL node into configuration node; Add information node including avatar; Resolve 4.1 question by accepting provisional answer; Add discovery examples; setting and sharing Subject; Protocol to request channel information and participants;  vCard Request;  Private Messages; Set user preferences with XEP-0004</p></remark>
+    <remark><p>Clarification of MIX Proxy concept; Clarify node definitions; Make all nodes optional; Merge ACL node into configuration node; Add information node including avatar; Resolve 4.1 question by accepting provisional answer; Add discovery examples; setting and sharing Subject; Protocol to request channel information and participants;  vCard Request;  Private Messages; Set user preferences with XEP-0004; Remove references to member and occupant;  Add Role Definition;  Add Banned and Allowed Nodes;  Update Configuration Definition;Add information on original id to message reflected back to sender  Add XEP-0372 mechanism to reference channel and informal invite;  Channel Invitations </p></remark>
   </revision>
   <revision>
     <version>0.3.1</version>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -678,8 +678,8 @@
   </join>
 </iq>
 ]]></example>
-      <p>The channel responds with an IQ-result. This stanza includes the nodes to which the user has been successfully subscribed, as well as the bare JID that will be used for the user in this channel and added to the participant list.  If a user cannot be subscribed to one or more of the requested nodes (e.g., because the node does not exist), but can be subscribed to some the response simply lists the nodes successfully subscribed.    If none of the nodes requested are successfully subscribed to, an error response is sent indicating the reason that the first node requested was not subscribed to.   This response will also include other nodes requested where subscription failed for the same reason.  A user may subsequently request subscription to nodes in a channel to which the user was not initially subscribed, by repeating the join operation.  If the user is already joined to a channel, the join operation simply modifies the channel subscriptions and settings to new values.</p>
-      <example caption="Channel Successfully Processes Join"><![CDATA[
+      <p>The channel responds with an IQ-result. This stanza includes the nodes to which the user has been successfully subscribed, as well as the bare JID that will be used for the user in this channel and added to the participant list.  The following example shows the result of the above request when the request is completed in full. </p>
+      <example caption="Channel Processes Join Request in Full"><![CDATA[
 <iq type='result'
     from='coven@mix.shakespeare.example'
     to='hag66@shakespeare.example'
@@ -693,8 +693,14 @@
   </join>
 </iq>
 ]]></example>
-      <p>As noted, the participant might not be subscribed to all nodes associated with the channel (in this case only messages, participants, and subject).</p>
-      <example caption="Channel Processes Join With Modifications"><![CDATA[
+      
+      
+      
+      
+      <p>
+        If a user cannot be subscribed to one or more of the requested nodes (e.g., because the node does not exist), but can be subscribed to some the response simply lists the nodes successfully subscribed.    If none of the nodes requested are successfully subscribed to, an error response is sent indicating the reason that the first node requested was not subscribed to.   This response will also include other nodes requested where subscription failed for the same reason. The following response example shows a response to the initial request example where 
+the participant is not be subscribed to all nodes associated with the channel (in this case only messages, participants, and subject).</p>
+      <example caption="Channel Processes Join With Some Nodes Not Subscribed To"><![CDATA[
 <iq type='result'
     from='hag66@shakespeare.example'
     to='coven@mix.shakespeare.example'
@@ -706,7 +712,7 @@
   </join>
 </iq>
 ]]></example>
-      <p>The channel also adds the user to the participants node and sends a notification.</p>
+      <p>The channel also adds the user to the participants node and sends a notification to subscribers to the participants node.</p>
       <example caption="Channel Adds User to Participants Node"><![CDATA[
 <message from='coven@mix.shakespeare.example'
          to='hecate@shakespeare.example'
@@ -725,6 +731,30 @@
       <p>
         Following the MIX server side processing, the user's server will usually add the MIX channel to the user's roster using one way presence.   This means that the MIX channel will get presence information from the user.  This roster entry will lead to correct handling of the user's presence in the MIX channel.   If the user does not wish to publish presence and the channel permits this, then this roster addition does not happen.  If the channel requires presence and the user removes the channel from the user's roster, the channel MAY remove the user as a channel participant.
       </p>
+      
+      <p>
+        A user may subsequently modify subscription to nodes in a channel by sending a subscription modification request, as shown in the following example.
+      </p>
+      
+      <example caption="User Modifies Subscription Request"><![CDATA[
+<iq type='set'
+    from='hag66@shakespeare.example'
+    to='coven@mix.shakespeare.example'
+    id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
+  <update-subscription xmlns='urn:xmpp:mix:0'>
+    <subscribe node='urn:xmpp:mix:nodes:messages'/>
+  </update-subscription>
+</iq>
+
+<iq type='result'
+    from='hag66@shakespeare.example'
+    to='coven@mix.shakespeare.example'
+    id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
+  <update-subscription xmlns='urn:xmpp:mix:0' jid='hag66@shakespeare.example'>
+    <subscribe node='urn:xmpp:mix:nodes:messages'/>
+  </update-subscription>
+</iq>
+]]></example>
     </section3>
 
    <section3 topic="User Preferences and Additional Information" anchor="usecase-visibilty-pref">
@@ -784,7 +814,7 @@
   <join xmlns='urn:xmpp:mix:0' jid='hag66@shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
-    <x xmlns='jabber:x:data' type='submit'>
+    <x xmlns='jabber:x:data' type='result'>
         <field var='FORM_TYPE' type='hidden'>
              <value>urn:xmpp:mix:0</value>
         </field>
@@ -804,6 +834,56 @@
      
      <p>The client may also query the channel in order to find out which user preferences are supported and the options available.  This will allow users to set options not specified in the standard.   The result is a form template.</p>
      <example caption="User Requests and Recieves Preferences Template Form"><![CDATA[
+<iq type='set'
+    from='hag66@shakespeare.example'
+    to='coven@mix.shakespeare.example'
+    id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
+    <user-preference xmlns='urn:xmpp:mix:0'/>
+     <x xmlns='jabber:x:data' type='submit'>
+        <field var='FORM_TYPE' type='hidden'>
+             <value>urn:xmpp:mix:0</value>
+        </field>
+        <field var='JID Visibility'>
+            <value>Never</value>
+        </field>
+        <field var='Private Messages'>
+           <value>Allow</value>
+         </field>
+        <field var='vCard'>
+          <value>Block</value>
+         </field>
+     </x>
+</iq>
+
+<iq type='result'
+    from='coven@mix.shakespeare.example'
+    to='hag66@shakespeare.example'
+    id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
+    <user-preference xmlns='urn:xmpp:mix:0'>
+    <x xmlns='jabber:x:data' type='result'>
+        <field var='FORM_TYPE' type='hidden'>
+             <value>urn:xmpp:mix:0</value>
+        </field>
+        <field var='JID Visibility'>
+            <value>Never</value>
+        </field>
+        <field var='Private Messages'>
+           <value>Allow</value>
+         </field>
+        <field var='vCard'>
+          <value>Block</value>
+         </field>
+     </x>
+  </user-preference>
+</iq>
+]]></example>
+     
+     <p>
+       A user may modify preferences using the corresponding set operation.
+     </p>
+     
+     
+     <example caption="User Updates Preferences"><![CDATA[
 <iq type='get'
     from='hag66@shakespeare.example'
     to='coven@mix.shakespeare.example'
@@ -833,7 +913,6 @@
   </user-preference>
 </iq>
 ]]></example>
-     
    </section3>
 
     <section3 topic='Leaving a Channel' anchor='usecase-user-leaving'>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -41,6 +41,12 @@
   &stpeter;
   
   <revision>
+    <version>0.4</version>
+    <date>2016-09-21</date>
+    <initials>sek</initials>
+    <remark><p>Clarification of MIX Proxy concept; Clarify node definitions; Make all nodes optional; Merge ACL node into configuration node; Add information node including avatar; Resolve 4.1 question by accepting provisional answer; Add discovery examples; setting and sharing Subject; Protocol to request channel information and participants;  vCard Request;  Private Messages </p></remark>
+  </revision>
+  <revision>
     <version>0.3.1</version>
     <date>2016-09-07</date>
     <initials>sek</initials>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -279,7 +279,8 @@
     
   
     <p>
-      jidmap is the only node that will always be present for a MIX channel and all other nodes are optional.   All channels will have either a message node, a presence node or both, because a channel will always share messages and/or presence.   MIX provides mechanisms to allow users to conveniently subscribe to a chosen set of nodes and to unsubscribe to all nodes with a single operation.
+      All of the standard nodes are optional.   A channel providing a service similar to MUC will typically use all of the standard nodes.
+      MIX provides mechanisms to allow users to conveniently subscribe to a chosen set of nodes and to unsubscribe to all nodes with a single operation.
     </p>
     <p>
       The structure of each of the standard nodes is now considered in more detail
@@ -302,6 +303,7 @@
       <p>Each channel participant is represented as an item of the 'urn:xmpp:mix:nodes:participants' channel node. Each item is named by the bare proxy JID of the participant. For example 'coven+123456@mix.shakespeare.example' might name the node item associated with participant 'hag66@shakespeare.example'. The nick associated with the user is mandatory and is stored in the item.  The nick for each channel participant MUST be different to the nick of other participants.
       This node may be subscribed to for jid-visible channels that permit subscription to this node - this will allow users to see changes to channel membership.
       </p>
+      <p>If the Participants Node is not used, information on channel participants is not shared.</p>
       <example caption="Value of Participants Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:participants'>
   <item id='coven+123456@mix.shakespeare.example/8765'>
@@ -313,7 +315,7 @@
     </section3>
     <section3 topic="JID Map Node" anchor="jid-map-node">
 
-      <p>The JID Map node is used to associate a proxy bare JID to its corresponding real bare JID.
+      <p>The JID Map node is used to associate a proxy bare JID to its corresponding real bare JID.  The JID Map node MUST have one entry for each entry in the Participants node.
        Each item is identified by proxy bare JID, mapping to the real bare JID.  This node is used to give administrator access to real JIDs and participant access to real JIDs in jid-visible channels.
         In JID visible channels, all participants may subscribe to this node.  In JID hidden channels, only administrators can subscribe.  </p>
       <example caption="Value of JID Map Node"><![CDATA[
@@ -329,9 +331,9 @@
       <p>
         The presence node contains the presence value for clients belonging to participants that choose to publish presence to the channel. A MIX channel MAY require that all participants publish presence.  Each item in the presence node is identified by the full proxy JID, and contains the current presence value for that JID.  The presence is encoded in the same way as data that would be sent in a presence stanza. The full JID is always used in this node. In MIX it is possible to have a 'presence-less channel' by not using this node. Access Control may be set to enforce that for each of the full JIDs in this list, the bare JID MUST be in the participants list.
       </p>
-      <p>QUESTION:  The current specification allows channels to be configured so that node subscription is not restricted to participants (although this restriction is the default).  Is this flexibility desirable, or should we restrict to participants?</p>
+
       <p>
-        This node may be subscribed to by users using bare JID.  So presence of online clients is sent to all users subscribed to this node, noting that presence is always sent using standard presence protocol.
+        This node may be subscribed to by users and this subscription MUST use the users bare JID.  So presence of online clients is sent to the MIX Proxy for each user subscribed to this node. Presence is always sent using standard presence protocol.
       </p>
       <example caption="Value of Presence Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:presence'>
@@ -411,6 +413,12 @@
 
     </section3>
 
+  </section2>
+  
+  <section2 topic="Non-Standard Nodes" anchor="non-standard-nodes">
+    <p>
+      The MIX standard allows channels to use non-standard nodes, using names that do no conflict with the standard nodes.   The capabilities of these nodes may be specified in a future XEP or be for private agreement.   Non-Standard nodes MUST NOT duplicate or otherwise provide capability that can be provided by standard nodes.
+    </p>
   </section2>
 </section1>
 

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -166,9 +166,13 @@
        The MIX Proxy provides a number of functions.
      </p>
     <ol>
-      <li>Each MIX client will register with the MIX proxy.  A key benefit of this approach is that MIX messages will only be sent to clients that support MIX.   This enables use of clients that do not use MIX in conjunction with the MIX proxy.</li>
+      <li>Each MIX client will register with the MIX Proxy when it comes online.  A key benefit of this approach is that MIX messages will only be sent to clients that support MIX.   This enables use of clients that do not use MIX in conjunction with the MIX proxy.</li>
       
-      <li>MIX Service and Channel subscription and management is handled by the MIX proxy.   This means that all messages to MIX from the user use bare JID.   Because the MIX Proxy is aware of subscription information, it can provide integrated support to a set of MIX clients.</li>
+      <li>MIX Service and Channel subscription and management is handled through the MIX proxy so that the MIX Proxy can track all subscription changes and share subscription information between MIX clients.   To achieve this, a MIX client sends these MIX management queries to the MIX Proxy using the clients full JID and receives responses back from the MIX Proxy.   The MIX Proxy will communicate these requests to a MIX channel from the MIX using the user's bare JID.   Because the MIX Proxy is aware of subscription information, it can provide integrated support to a set of MIX clients.</li>
+      
+      <li>Messages from a MIX client to a MIX channel will go direct to the MIX service and not through the MIX Proxy.</li>
+      
+      <li>Messages from a MIX channel to a MIX client MUST be handled by a MIX Proxy.</li>
       
       <li>The MIX Proxy will only send messages to online clients and will discard messages if no clients are online.
         This means that a MIX client needs to resynchronize with the MIX service when it comes online.  This synchronization will happen directly between the MIX client and MIX channel.</li>
@@ -177,10 +181,10 @@
       
       <li>The MIX Proxy will manage channel registration and de-registration in the user's roster.</li>
       
-      <li>Different clients may wish to access different channels (e.g., a mobile client may only access a subset of the channels in which a user is interested).   The MIX Proxy will handle sending messages only to the clients that wish for them.</li>
+      <li>Different clients may wish to access different channels (e.g., a mobile client may only access a subset of the channels in which a user is interested).   The MIX Proxy will handle sending messages only to the clients that wish for them using a profile mechanism.</li>
     </ol>
     <p>
-   Arriving MIX messages (which will be of type=groupchat)  and presence information are sent to the bare JID.  This means that the MIX Proxy will use a modification of the standard &rfc6121; rules.
+   Messages being sent from MIX channel to MIX Proxy (which will be of type=groupchat)  and presence information are sent to the bare JID.  This means that the MIX Proxy will use a modification of the standard &rfc6121; rules.
     </p>
  
     <p>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -452,9 +452,7 @@
 </iq>
 ]]></example>
     <p>The MIX service then MUST return its identity and the features it supports, which MUST include the 'urn:xmpp:mix:0' feature, and the identity MUST have a category of 'conference' and a type of 'text'. </p>
-    <p>
-      QUESTION: Is there a need for a different type than text?    Provisional answer: no.
-    </p>
+   
     <example caption="Service responds with Disco Info result" ><![CDATA[
 <iq from='mix.shakespeare.example'
     id='lx09df27'

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -44,7 +44,7 @@
     <version>0.4</version>
     <date>2016-09-21</date>
     <initials>sek</initials>
-    <remark><p>Clarification of MIX Proxy concept; Clarify node definitions; Make all nodes optional; Merge ACL node into configuration node; Add information node including avatar; Resolve 4.1 question by accepting provisional answer; Add discovery examples; setting and sharing Subject; Protocol to request channel information and participants;  vCard Request;  Private Messages </p></remark>
+    <remark><p>Clarification of MIX Proxy concept; Clarify node definitions; Make all nodes optional; Merge ACL node into configuration node; Add information node including avatar; Resolve 4.1 question by accepting provisional answer; Add discovery examples; setting and sharing Subject; Protocol to request channel information and participants;  vCard Request;  Private Messages; Set user preferences with XEP-0004</p></remark>
   </revision>
   <revision>
     <version>0.3.1</version>
@@ -754,17 +754,24 @@
        <tr><td>'vCard'</td><td>'Allow', 'Block'</td> <td>'Block'</td></tr>
      </table>
      
-     <p>When joining a channel, the client may specify one or more preference options.   In the response, the  server MUST specify all of the user preferences supported by the server, with default values if the user has not requested a different value.  The following example shows joining a channel and setting a preference.</p>
+     <p>When joining a channel, the client may specify one or more preference options as a &xep0004; form.   In the response, the  server MUST specify all of the user preferences supported by the server, with default values if the user has not requested a different value.  The following example shows joining a channel and setting a preference.</p>
      
      <example caption="User Joins a Channel and Specifies a preference"><![CDATA[
 <iq type='set'
     from='hag66@shakespeare.example'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <join xmlns='urn:xmpp:mix:0'>
+    <join xmlns='urn:xmpp:mix:0'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
-    <user-preference key='JID Visibility' value='Never Show JID'/>
+    <x xmlns='jabber:x:data' type='submit'>
+        <field var='FORM_TYPE' type='hidden'>
+             <value>urn:xmpp:mix:0</value>
+        </field>
+        <field var='JID Visibility'>
+            <value>Never Show JID</value>
+        </field>
+     </x>
   </join>
 </iq>
 ]]></example>
@@ -777,13 +784,55 @@
   <join xmlns='urn:xmpp:mix:0' jid='hag66@shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
-    <user-preference key='JID Visibility' value='Never Show JID'/>
-    <user-preference key='Private Messages' value='Allow'/>
-    <user-preference key='vCard' value='Block'/>
+    <x xmlns='jabber:x:data' type='submit'>
+        <field var='FORM_TYPE' type='hidden'>
+             <value>urn:xmpp:mix:0</value>
+        </field>
+        <field var='JID Visibility'>
+            <value>Never Show JID</value>
+        </field>
+        <field var='Private Messages'>
+           <value>Allow</value>
+         </field>
+        <field var='vCard'>
+          <value>Block</value>
+         </field>
+     </x>
   </join>
 </iq>
 ]]></example>
      
+     <p>The client may also query the channel in order to find out which user preferences are supported and the options available.  This will allow users to set options not specified in the standard.   The result is a form template.</p>
+     <example caption="User Requests and Recieves Preferences Template Form"><![CDATA[
+<iq type='get'
+    from='hag66@shakespeare.example'
+    to='coven@mix.shakespeare.example'
+    id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
+    <get-preference-template xmlns='urn:xmpp:mix:0'/>
+</iq>
+
+<iq type='result'
+    from='coven@mix.shakespeare.example'
+    to='hag66@shakespeare.example'
+    id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
+    <get-preference-template xmlns='urn:xmpp:mix:0'>
+    <x xmlns='jabber:x:data' type='form'>
+        <field var='FORM_TYPE' type='hidden'>
+             <value>urn:xmpp:mix:0</value>
+        </field>
+        <field type='list-single' label='Preference for JID Visibility' var='JID Visibility'>
+            <option label='JID Never Shown'><value>Never Show JID</value></option>
+            <option label='Default Behaviour'><value>Use Channel Default</value></option>
+            <option label='Try not to show JID'><value>Prefer Not Show JID</value></option>
+         </field>
+         <field type='list-single' label='Example Custom Preference' var='Custom Preference'>
+            <option label='One Option'><value>A</value></option>
+            <option label='Another Option'><value>B</value></option>
+         </field>  
+     </x>
+  </get-preference-template>
+</iq>
+]]></example>
      
    </section3>
 

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -678,7 +678,7 @@
   </join>
 </iq>
 ]]></example>
-      <p>The channel responds with an IQ-result. This stanza includes the nodes to which the user has been successfully subscribed, as well as the bare JID that will be used for the user in this channel and added to the participant list.  If a user cannot be subscribed to one or more of the requested nodes (e.g., because the node does not exist), but can be subscribed to some the response simply lists the nodes successfully subscribed.    If none of the nodes requested are successfully subscribed to, an error response is sent indicating the reason that the first node requested was not subscribed to.   This response will also include other nodes requested where subscription failed for the same reason.  A user may subsequently request subscription to nodes in a channel to which the user was not initially subscribed.  </p>
+      <p>The channel responds with an IQ-result. This stanza includes the nodes to which the user has been successfully subscribed, as well as the bare JID that will be used for the user in this channel and added to the participant list.  If a user cannot be subscribed to one or more of the requested nodes (e.g., because the node does not exist), but can be subscribed to some the response simply lists the nodes successfully subscribed.    If none of the nodes requested are successfully subscribed to, an error response is sent indicating the reason that the first node requested was not subscribed to.   This response will also include other nodes requested where subscription failed for the same reason.  A user may subsequently request subscription to nodes in a channel to which the user was not initially subscribed, by repeating the join operation.  If the user is already joined to a channel, the join operation simply modifies the channel subscriptions and settings to new values.</p>
       <example caption="Channel Successfully Processes Join"><![CDATA[
 <iq type='result'
     from='coven@mix.shakespeare.example'
@@ -734,9 +734,9 @@
        A user  JID visibility preference have the following values:
      </p>
      <ol>
-       <li>'Use Channel Default'.   In this setting, the channel default value will be used.  This value is used if another value is not explicitly set.</li>
-       <li>'Never Show JID'.  If this is set, JID will never be shared and user will be removed from the channel if its mode changes to JID-visible-mandatory.</li>
-       <li>'Prefer Not Show JID'.   If this is set, JID will only be shared if mode is JID-visible-mandatory.</li>
+       <li>'Default'.   In this setting, the channel default value will be used.  This value is used if another value is not explicitly set.</li>
+       <li>'Never'.  If this is set, JID will never be shared and user will be removed from the channel if its mode changes to JID-visible-mandatory.</li>
+       <li>'Prefer Not'.   If this is set, JID will only be shared if mode is JID-visible-mandatory.</li>
      </ol>
      <p>
       The user may specify that no Private Messages are to be sent from the channel, and allow vCard retrieval.
@@ -747,7 +747,7 @@
      <table caption="Standard User Preference Options">
        <tr><th>Option</th> <th>Values</th><th>Default</th></tr>
        
-       <tr><td>'JID Visibility'</td> <td>'Use Channel Default', 'Never Show JID',  'Prefer Not Show JID'</td>  <td>'Use Channel Default'</td></tr>
+       <tr><td>'JID Visibility'</td> <td>'Default', 'Never',  'Prefer Not'</td>  <td>'Use Channel Default'</td></tr>
        
        <tr><td>'Private Messages'</td><td>'Allow', 'Block'</td> <td>'Allow'</td></tr>
        
@@ -769,7 +769,7 @@
              <value>urn:xmpp:mix:0</value>
         </field>
         <field var='JID Visibility'>
-            <value>Never Show JID</value>
+            <value>Never</value>
         </field>
      </x>
   </join>
@@ -789,7 +789,7 @@
              <value>urn:xmpp:mix:0</value>
         </field>
         <field var='JID Visibility'>
-            <value>Never Show JID</value>
+            <value>Never</value>
         </field>
         <field var='Private Messages'>
            <value>Allow</value>
@@ -808,29 +808,29 @@
     from='hag66@shakespeare.example'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-    <get-preference-template xmlns='urn:xmpp:mix:0'/>
+    <user-preference xmlns='urn:xmpp:mix:0'/>
 </iq>
 
 <iq type='result'
     from='coven@mix.shakespeare.example'
     to='hag66@shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-    <get-preference-template xmlns='urn:xmpp:mix:0'>
+    <user-preference xmlns='urn:xmpp:mix:0'>
     <x xmlns='jabber:x:data' type='form'>
         <field var='FORM_TYPE' type='hidden'>
              <value>urn:xmpp:mix:0</value>
         </field>
         <field type='list-single' label='Preference for JID Visibility' var='JID Visibility'>
-            <option label='JID Never Shown'><value>Never Show JID</value></option>
-            <option label='Default Behaviour'><value>Use Channel Default</value></option>
-            <option label='Try not to show JID'><value>Prefer Not Show JID</value></option>
+            <option label='JID Never Shown'><value>Never</value></option>
+            <option label='Default Behaviour'><value>Default</value></option>
+            <option label='Try not to show JID'><value>Prefer Not</value></option>
          </field>
          <field type='list-single' label='Example Custom Preference' var='Custom Preference'>
             <option label='One Option'><value>A</value></option>
             <option label='Another Option'><value>B</value></option>
          </field>  
      </x>
-  </get-preference-template>
+  </user-preference>
 </iq>
 ]]></example>
      

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -183,11 +183,11 @@
       <li>The MIX Proxy will only send messages to online clients and will discard messages if no clients are online.
         This means that a MIX client needs to resynchronize with the MIX service when it comes online.  This synchronization will happen directly between the MIX client and MIX channel.</li>
       
-      <li>The MIX Proxy will know which channels are subscribed to, and so can provide a bookmark service to the MIX clients.</li>
+      <li>The MIX Proxy will know which channels are subscribed to, and so can send this list to a MIX client.  Because channel subscriptions are long term, this information will be used instead of the bookmark approach used with MUC.</li>
       
       <li>The MIX Proxy will manage channel registration and de-registration in the user's roster.</li>
       
-      <li>Different clients may wish to access different channels (e.g., a mobile client may only access a subset of the channels in which a user is interested).   The MIX Proxy will handle sending messages only to the clients that wish for them using a profile mechanism.</li>
+      <li>Different clients may wish to access different channels (e.g., a mobile client may only access a subset of the channels in which a user is interested).   The MIX Proxy MAY handle sending messages only to the clients that wish for them, perhaps using a profile mechanism.</li>
     </ol>
     <p>
    Messages being sent from MIX channel to MIX Proxy (which will be of type=groupchat)  and presence information are sent to the bare JID.  This means that the MIX Proxy will use a modification of the standard &rfc6121; rules.

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -309,7 +309,7 @@
       <p>If the Participants Node is not used, information on channel participants is not shared.</p>
       <example caption="Value of Participants Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:participants'>
-  <item id='coven+123456@mix.shakespeare.example/8765'>
+  <item id='coven+123456@mix.shakespeare.example'>
     <participant xmlns='urn:xmpp:mix:0'
                  nick='thirdwitch'/>
   </item>
@@ -562,14 +562,66 @@
   </section2>
   
   <section2 topic="Determining Information about a Channel" anchor="find-channel-info">
-    <p>The Information Node contains various information about the channel that may be useful to the user.   This can be read by the user.</p>
-    <p>AUTHOR'S NOTE:  Define new protocol. Add example</p>   
+    <p>The Information Node contains various information about the channel that may be useful to the user.   This can be read by the XMPP Client directly or by a MIX Proxy.</p>
+  
+    
+    <example caption='MIX Proxy Requests Channel Information'><![CDATA[
+<iq from='hag66@shakespeare.lit'
+    id='kl2fax27'
+    to='coven@mix.shakespeare.lit'
+    type='get'>
+  <query xmlns='urn:xmpp:mix:0#channel-info'/>
+</iq>
+]]></example>
+    <example caption='MIX Service Returns Channel Information'><![CDATA[
+<iq from='coven@mix.shakespeare.lit'
+    id='kl2fax27'
+    to='hag66@shakespeare.lit'
+    type='result'>
+  <query xmlns='urn:xmpp:mix:0#channel-info'>
+        <name>Witches Coven</name>
+        <description>A location not far from the blasted heath where the three witches meet</description>
+        <administrator>
+           <vCard xmlns='vcard-temp'>
+              <FN>Hecate</FN>
+              <TITLE>Chief Witch</TITLE>
+           </vCard>
+        </administrator>
+        <avatar>
+             <data xmlns='urn:xmpp:avatar:data'>
+          qANQR1DBwU4DX7jmYZnncm...
+            </data>
+        </avatar>
+</iq>
+]]></example>
+    
   </section2>
   <section2 topic='Determining the Participants in a Channel' anchor='find-channel-participants'>
     <p>
       
-      Online clients in the channel are determined from the presence node.   Participants in the channel are determined from the "urn:xmpp:mix:nodes:participants" node which will give proxy JID and nick. The jidmap node is used to map to real JIDs.  </p>
-    <p>AUTHOR'S NOTE:  Define new protocol. Add example</p>
+      Online clients in the channel are determined from the presence node.   Participants in the channel are determined from the Participants Node which will give proxy JID and nick. The jidmap node is used to map to real JIDs.  An operation is provided to list channel participants.   For JID Hidden channels, only the nicks are returned.  For JID Visible channels, nicks and real JIDs are returned.</p>
+    
+    <example caption='MIX Proxy Requests Participant List'><![CDATA[
+<iq from='hag66@shakespeare.lit'
+    id='kl2fax27'
+    to='coven@mix.shakespeare.lit'
+    type='get'>
+  <query xmlns='urn:xmpp:mix:0#get-participants'/>
+</iq>
+]]></example>
+    <example caption='MIX Service Returns Participant List for JID Visible Room'><![CDATA[
+<iq from='coven@mix.shakespeare.lit'
+    id='kl2fax27'
+    to='hag66@shakespeare.lit'
+    type='result'>
+  <query xmlns='urn:xmpp:mix:0#get-participants'> 
+  <items>
+      <item jid='hag66@shakespeare.lit' nick='thirdwitch'>
+      <item jid='hag01@shakespeare.lit' nick='top witch'> 
+</items>
+</iq>
+]]></example>
+    
   </section2>
   
   
@@ -725,9 +777,10 @@
 </message>
 ]]></example>
 
+
     </section3>
 
-    <section3 topic="Setting a Nick" anchor="usecase-setting-nick"></section3>
+    <section3 topic="Setting a Nick" anchor="usecase-setting-nick">
     <p>
       Each member of a channel may have a nick, which is how other users in the channel will see the user.  In some cases a nick is not needed, for example where a user reads messages in a channel but does not send messages or share presence information.    A nick MUST be present for a user to send a message to a channel or for a user's presence to be shared on a channel.   There are four ways that a user's nick can be obtained.   The choice of mechanism or mechanisms is dependent on channel policy:
     </p>
@@ -766,6 +819,7 @@
   </query>
 </iq>
 ]]></example>
+    </section3>
     <section3 topic='Registering a Nick' anchor='usecase-user-register'>
       <p>A user can register a nick with the MIX service.  Nick registration can be used ensure that a user is able to use the same nick in all channels in the service and to prevent other users from using a registered nick.   This can help achieve a consistent experience across a set of channels and prevent user confusion.  Support for nick registration by a MIX service is optional.  Where nick registration is supported, nick registration may be optional or mandatory.
         Where a user has registered a Nick with the MIX service, it may be used by each channel according to policy for the channel. A nick is associated with the user's bare JID.

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -278,9 +278,13 @@
       
       <tr><td>Presence</td><td>'urn:xmpp:mix:nodes:presence'</td><td>For publishing information about the availability status of online participants, which may include multiple clients for a single participant.</td></tr>
       
-      <tr><td>Configuration</td><td>'urn:xmpp:mix:nodes:config'</td><td>For storing channel configuration. This information will generally be restricted to authorized users.</td></tr>
-      
       <tr><td>Information</td><td>'urn:xmpp:mix:nodes:info'</td><td>For storing general channel information, such as description and avatar. </td></tr>
+      
+      <tr><td>Allowed</td><td>'urn:xmpp:mix:nodes:allowed'</td><td>For storing JIDs that are allowed to be channel participants.</td></tr>
+      
+      <tr><td>Banned</td><td>'urn:xmpp:mix:nodes:banned'</td><td>For storing JIDs that are not allowed to be channel participants. </td></tr>
+      
+      <tr><td>Configuration</td><td>'urn:xmpp:mix:nodes:config'</td><td>For storing channel configuration. This information will generally be restricted to the channel owners.</td></tr>
     </table>
     
   
@@ -289,8 +293,31 @@
       MIX provides mechanisms to allow users to conveniently subscribe to a chosen set of nodes and to unsubscribe to all nodes with a single operation.
     </p>
     <p>
-      The structure of each of the standard nodes is now considered in more detail
+      The structure of each of the standard nodes is now considered in more detail in the rest of this section, after explaining roles.
     </p>
+    <section3 topic="Roles" anchor="roles">
+      <p>
+        There are a number of MIX roles for each channel, listed in the following table.   Rights will be assigned to the various roles in the channel configuration node.
+      </p>
+      <table caption="Channel Roles">
+        <tr><th>Role</th><th>Membership and Rights</th></tr>
+        
+        <tr><td>Owners</td><td>These are owners of the list, as specified in the channel configuration node.  Only owners are allowed to modify the channel configuration node.</td></tr>
+        
+        <tr><td>Administrators</td><td>Administrators are defined in the channel configuration node.  Administrators have update rights to the Allowed Node and Banned Node, so can control which users may participate in a channel.  Administrators will usually be granted additional rights, such as the ability to kick users from a channel. </td></tr>
+        
+        <tr><td>Participants</td><td>Participants are users listed by JID in the participants node.</td></tr>
+        
+        <tr><td>Allowed</td><td>Allowed is the set of JIDs that are participants or may be allowed to become participants.  A JID is allowed if it does not match entry in the banned node and either it matches an entry in the allowed node or the allowed node is not present. </td></tr>
+        
+        <tr><td>Anyone</td><td>Any user, including users in the banned node.</td></tr>
+        
+      </table>
+      <p>
+        There will always be at lease one owner and "anyone" will always have role occupants.   Other roles may not have any role occupants.  Rights are defined in a strictly hierarchical manner, so that for example Owners will always have rights that Administrators have.
+      </p>
+    </section3>
+    
     <section3 topic="Messages Node" anchor="messages-node">
       <p>Items in this node will contain a message identified by a unique ID.  A MIX implementation SHOULD NOT make messages available for retrieval from this node using pubsub.  The recommended approach is that zero history is held in the messages node, and that this node is used for publication only.   The recommended approach to retrieve message history is MAM. Users subscribe to this node to receive messages.</p>
       <p>Private Messages are not stored in the messages node.</p>
@@ -393,8 +420,40 @@
   </item>
 </items>
 ]]></example>
-      
     </section3>
+    
+      <section3 topic="Allowed" anchor="allowed-node">
+        <p>
+          This node represents a list of JIDs that are allowed to become participants.   If the allowed node is not present, all JIDs are allowed.  The allowed list is always considered in conjunction with the banned list, stored in the banned node.  Only Administrators and Owners have write permission to the allowed node and are also the only roles that are allows to subscribe to this node.    Each item contains a real bare JID.  The following example shows how the allowed list can specify single JIDs and domains.
+        </p>
+      
+        <example caption="Allowed Node"><![CDATA[
+<items node='urn:xmpp:mix:nodes:allowed'>
+  <item id='@shakespeare.lit'>
+  <item id='alice@wonderland.lit'>
+  </item>
+</items>
+]]></example>
+      </section3>
+      
+      
+      <section3 topic="Banned" anchor="banned-node">
+        <p>
+          This node represents a list of JIDs that are explicitly not allowed to become participants.   The values in this list take priority over values in the allowed node.  Only Administrators and Owners have write permission to the allowed node and are also the only roles that are allows to subscribe to this node.    Each item contains a real bare JID.  
+          
+        </p>
+       
+        <example caption="Banned Node"><![CDATA[
+<items node='urn:xmpp:mix:nodes:banned'>
+  <item id='lear@shakespeare.lit'>
+  <item id='macbeth@shakespeare.lit'>
+  </item>
+</items>
+]]></example>
+      </section3>  
+      
+      
+   
     <section3 topic="Configuration Node" anchor="config-node">
       <p>
         The Configuration node holds the configuration of the channel as a single item, named by the date-time of the last update to the configuration.  A single item is stored in the node at a time, with previous configuration history accessed by MAM.  Users MAY subscribe to the configuration node to get notification of configuration change.  The configuration node is optional for a MIX channel.  For example, configuration choices could be fixed and not exposed.   A subset of the defined configuration options may be used and additional non-standard configuration options may be added.   If configuration options to control functionality of the nature described here are provided, the options defined in this standard MUST be used. The following configuration options are provided:
@@ -406,17 +465,17 @@
         <li>'Owners'.  List of bare JIDs with Owner rights as defined in ACL node.  When a list is created, the JID creating the list is configured as an owner, unless this attribute is explicitly configured to another value.  Owners will generally have full rights to make changes to channel configuration and access control.</li>
         <li>'Administrators'.  List of bare JIDs with Administrator rights.  An Administrator has rights to make changes to channel access control and configuration as defined in ACL node.  An Administrator also has operational right on a channel, such a kicking users out of the channel. These rights are analogous to moderator rights defined in &xep0045;.</li>
       
-        <li>'Outcast'.  List of JIDs banned from subscribing to any nodes in the MIX channel.  </li>
         <li>'End of Life'.  The date and time at which the channel will be automatically removed by the server.   If this is not set, the channel is permanent.</li>
-        <li>'Nodes Present'.  Specifies which nodes are present: "participants"; "presence"; "subject"; "acl".  Note that "config" is implicit,  and "jidmap" is implied by "participants". </li>
-        <li>'Message Node Subscription'.  Controls who can subscribe to messages node:  "participants-only"; "anyone".  Users with banned affiliation may not subscribe.  Default "participants-only".</li>
-        <li>'Participants Node Subscription'.  Controls who can subscribe to participants node: "participants-only"; "anyone"; "nobody".  Users with banned affiliation may not subscribe.  Default "participants-only".</li>
-        <li>'Participants Node Subscription'.  Controls who can subscribe to participants node:  "participants-only"; "anyone"; admins-and-owners" "nobody".  Users with banned affiliation may not subscribe.  Default "participants-only".   Note that this value needs to be restricted to "admins-and-owners" for channels with JID visibility set to a value other than "jid-mandatory-visible".</li>
-        <li>'Presence Node Subscription'.  Controls who can subscribe to presence node:  "participants-only"; "anyone"; "nobody".  Users with banned affiliation may not subscribe.  Default "participants-only".</li>
-        <li>'Subject Node Subscription'.  Controls who can subscribe to subject node: "participants-only"; "anyone"; "nobody".  Users with banned affiliation may not subscribe.  Default "participants-only".</li>
-        <li>'Configuration Node Access'.  Controls who can subscribe to and has read access configuration node:  "participants-only"; "admins-and-owners"; "owners-only"; "anyone"; "nobody". Default "admins-and-owners".</li>
-        <li>'Information Node Access'.  Controls who can subscribe to and has read access acl node:  "participants-only"; "admins-and-owners"; "owners-only"; "anyone"; "nobody". Default "participants-only".</li>
-        <li>'Configuration Node Update'.  Controls who can modify configuration node: "owners-only"; "admins-and-owners". Default "admins-and-owners".</li>
+        <li>'Nodes Present'.  Specifies which nodes are present: "participants"; "presence"; "subject"; "information"; "allowed"; "banned".  Note that "config" is implicit,  and "jidmap" is implied by "participants". </li>
+        
+        <li>'Message Node Subscription'.  Controls who can subscribe to messages node:  "participants"; "allowed"; "anyone".   Default "participants".</li>
+        <li>'Participants Node Subscription'.  Controls who can subscribe to participants node: "participants"; "allowed"; "anyone"; "nobody".   Default "participants".</li>
+        
+        <li>'Presence Node Subscription'.  Controls who can subscribe to presence node:  "participants"; "allowed"; "anyone"; "nobody".   Default "participants".</li>
+        <li>'Subject Node Subscription'.  Controls who can subscribe to subject node: "participants"; "allowed"; "anyone"; "nobody".   Default "participants".</li>
+        <li>'Configuration Node Access'.  Controls who can subscribe to and has read access configuration node:  "participants"; "admins"; "owners"; "nobody". Default "admins".</li>
+      
+        <li>'Kick Rights'.  Controls who can kick users from the channel:   "admins"; "owners"; "nobody". Default "admins".</li>
         
         <li>'JID Visibility'. Choice of "jid-hidden", "jid-optionally-visible", "jid-mandatory-visible". </li>
         <li>'Open Presence'.  If selected, any client may register presence.  If not selected, only clients with bare JID in the participants list may register presence.</li>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -1292,6 +1292,13 @@ the participant is not be subscribed to all nodes associated with the channel (i
         When a new Participant joins a channel and subscribes to the Subject Node, the channel MUST send to the user's MIX Proxy a message with the current subject.   An XMPP Client MAY directly read the Subject node using &xep0060;.
       </p>
     </section3>
+    
+    <section3 topic='Telling another user about a Channel' anchor='usecase-user-tell'>
+      <p>
+        A convenient way to reference another channel is to use &xep0372; which enables the JID of a channel to be shared.  This might be used simply to inform the message recipient about the channel or as mechanism to invite the user to join the channel.   This is useful as an invitation mechanism to a channel that any user can join or where the invitee knows that the user may join (e.g., because the channel is for all users in an organization).   
+      </p>
+    </section3>
+    
     <section3 topic='Inviting another user to join a Channel' anchor='usecase-user-invite'>
       <p>When a channel participant invites another user to join a channel, a sequence of steps are followed.
 

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -102,7 +102,7 @@
   </revision>
 </header>
 <section1 topic='Introduction' anchor='intro'>
-  <p>The Mediated Information eXchange (MIX) protocol is intended as a replacement for Multi-User Chat (MUC). MUC is a major application of XMPP that was developed in 2002 and standardized in &xep0045;. MIX implements the same basic MUC patterns in a more flexible and extensible way in order to address requirements that have emerged since MUC was developed. MIX supports all of the core chatroom features that are familiar from MUC, such as discussion topics and invitations. Like MUC, it also defines a strong access control model, including the ability to kick and ban users, to name administrators, and to require membership in order to participate in channels.</p>
+  <p>The Mediated Information eXchange (MIX) protocol is intended as a replacement for Multi-User Chat (MUC). MUC is a major application of XMPP that was developed in 2002 and standardized in &xep0045;. MIX implements the same basic MUC patterns in a more flexible and extensible way in order to address requirements that have emerged since MUC was developed. MIX supports all of the core chatroom features that are familiar from MUC, such as discussion topics and invitations. Like MUC, it also defines a strong access control model, including the ability to kick and ban users, to name administrators, and to provide controls as to which users can participate in channels.</p>
   <p>Several reasons exist for replacing MUC:</p>
   <ul>
     <li>A number of use cases for group communication have emerged since MUC was first published.</li>
@@ -153,7 +153,7 @@
     <li>A user's participation in a channel outlives their client sessions. A client which is offline will not share presence within the channel, but the associated user will still be listed as an participant. </li>
     <li>Presence is sent to all participants using bare JID, whether or not the user has an online client. </li>
     <li>Online clients MAY register presence, which is then shared with participants who have subscribed to presence.</li>
-    <li>MIX decouples addressing of occupants from their nicknames, so that nickname changes do not affect addressing.</li>
+    <li>MIX decouples addressing of channel participants from their nicknames, so that nickname changes do not affect addressing.</li>
     <li>Each participant is addressable by a single bare JID, which is a proxy JID (not the user's real JID) to make it straightforward to hide the user's real JID from other channel participants. Full JIDs comprised of this bare JID plus a resource (also anonymized) are then constructed, allowing visibility into the number of online resources participating in a channel.</li>
     <li>MIX requires client support and server support from the server providing the MIX service.  Although some protocol is shared with MUC, MUC clients are not interoperable with MIX servers.  This means that where a user chooses to use MIX, all of the users clients need to support MIX.</li>
   </ol>
@@ -239,13 +239,13 @@
     </p>
     <table caption="JID Visibility Modes">
       <tr><th>Mode</th><th>Description</th></tr>
-      <tr><td>'JID Visible'</td><td>In these channels, some or all participant JIDs are visible to all channel members.</td></tr>
+      <tr><td>'JID Visible'</td><td>In these channels, some or all participant JIDs are visible to all channel participants.</td></tr>
       
-      <tr><td>'JID&nbsp;Hidden'</td><td>In these channels, no participant JIDs are visible to channel members, but they are visible to channel administrators.</td></tr>
+      <tr><td>'JID&nbsp;Hidden'</td><td>In these channels, no participant JIDs are visible to channel participants, but they are visible to channel administrators.</td></tr>
     </table>
    
     <p>
-      A channel member may specify their preferences for JID visibility, with one of the following values:
+      A channel participant may specify their preferences for JID visibility, with one of the following values:
     </p>
     <table caption="JID Visibility Preference Options">
       <tr><th>Preference</th><th>Description</th></tr>
@@ -310,7 +310,7 @@
     </section3>
     <section3 topic="Participants Node" anchor="participants-node">
       <p>Each channel participant is represented as an item of the 'urn:xmpp:mix:nodes:participants' channel node. Each item is named by the bare proxy JID of the participant. For example 'coven+123456@mix.shakespeare.example' might name the node item associated with participant 'hag66@shakespeare.example'. The nick associated with the user is mandatory and is stored in the item.  The nick for each channel participant MUST be different to the nick of other participants.
-      This node MAY be subscribed to for jid-visible channels that permit subscription to this node - this will allow users to see changes to channel membership.
+      This node MAY be subscribed to for jid-visible channels that permit subscription to this node - this will allow users to see changes to the channel participants.
       </p>
       <p>If the Participants Node is not used, information on channel participants is not shared.</p>
       <example caption="Value of Participants Node"><![CDATA[
@@ -405,23 +405,23 @@
         <li>'Last Change Made By'.  Bare JID of the user making the last change.</li>
         <li>'Owners'.  List of bare JIDs with Owner rights as defined in ACL node.  When a list is created, the JID creating the list is configured as an owner, unless this attribute is explicitly configured to another value.  Owners will generally have full rights to make changes to channel configuration and access control.</li>
         <li>'Administrators'.  List of bare JIDs with Administrator rights.  An Administrator has rights to make changes to channel access control and configuration as defined in ACL node.  An Administrator also has operational right on a channel, such a kicking users out of the channel. These rights are analogous to moderator rights defined in &xep0045;.</li>
-        <li> 'Members'.  List of JIDs with member rights.  The rights of members are configured in the configuration node.  </li>
+      
         <li>'Outcast'.  List of JIDs banned from subscribing to any nodes in the MIX channel.  </li>
         <li>'End of Life'.  The date and time at which the channel will be automatically removed by the server.   If this is not set, the channel is permanent.</li>
         <li>'Nodes Present'.  Specifies which nodes are present: "participants"; "presence"; "subject"; "acl".  Note that "config" is implicit,  and "jidmap" is implied by "participants". </li>
-        <li>'Message Node Subscription'.  Controls who can subscribe to messages node: "members-only"; "participants-only"; "anyone".  Users with banned affiliation may not subscribe.  Default "participants-only".</li>
-        <li>'Participants Node Subscription'.  Controls who can subscribe to participants node: "members-only"; "participants-only"; "anyone"; "nobody".  Users with banned affiliation may not subscribe.  Default "participants-only".</li>
-        <li>'Participants Node Subscription'.  Controls who can subscribe to participants node: "members-only"; "participants-only"; "anyone"; admins-and-owners" "nobody".  Users with banned affiliation may not subscribe.  Default "participants-only".   Note that this value needs to be restricted to "admins-and-owners" for channels with JID visibility set to a value other than "jid-mandatory-visible".</li>
-        <li>'Presence Node Subscription'.  Controls who can subscribe to presence node: "members-only"; "participants-only"; "anyone"; "nobody".  Users with banned affiliation may not subscribe.  Default "participants-only".</li>
-        <li>'Subject Node Subscription'.  Controls who can subscribe to subject node: "members-only"; "participants-only"; "anyone"; "nobody".  Users with banned affiliation may not subscribe.  Default "participants-only".</li>
-        <li>'Configuration Node Access'.  Controls who can subscribe to and has read access configuration node: "members-only"; "participants-only"; "admins-and-owners"; "owners-only"; "anyone"; "nobody". Default "admins-and-owners".</li>
-        <li>'Information Node Access'.  Controls who can subscribe to and has read access acl node: "members-only"; "participants-only"; "admins-and-owners"; "owners-only"; "anyone"; "nobody". Default "participants-only".</li>
+        <li>'Message Node Subscription'.  Controls who can subscribe to messages node:  "participants-only"; "anyone".  Users with banned affiliation may not subscribe.  Default "participants-only".</li>
+        <li>'Participants Node Subscription'.  Controls who can subscribe to participants node: "participants-only"; "anyone"; "nobody".  Users with banned affiliation may not subscribe.  Default "participants-only".</li>
+        <li>'Participants Node Subscription'.  Controls who can subscribe to participants node:  "participants-only"; "anyone"; admins-and-owners" "nobody".  Users with banned affiliation may not subscribe.  Default "participants-only".   Note that this value needs to be restricted to "admins-and-owners" for channels with JID visibility set to a value other than "jid-mandatory-visible".</li>
+        <li>'Presence Node Subscription'.  Controls who can subscribe to presence node:  "participants-only"; "anyone"; "nobody".  Users with banned affiliation may not subscribe.  Default "participants-only".</li>
+        <li>'Subject Node Subscription'.  Controls who can subscribe to subject node: "participants-only"; "anyone"; "nobody".  Users with banned affiliation may not subscribe.  Default "participants-only".</li>
+        <li>'Configuration Node Access'.  Controls who can subscribe to and has read access configuration node:  "participants-only"; "admins-and-owners"; "owners-only"; "anyone"; "nobody". Default "admins-and-owners".</li>
+        <li>'Information Node Access'.  Controls who can subscribe to and has read access acl node:  "participants-only"; "admins-and-owners"; "owners-only"; "anyone"; "nobody". Default "participants-only".</li>
         <li>'Configuration Node Update'.  Controls who can modify configuration node: "owners-only"; "admins-and-owners". Default "admins-and-owners".</li>
         
         <li>'JID Visibility'. Choice of "jid-hidden", "jid-optionally-visible", "jid-mandatory-visible". </li>
         <li>'Open Presence'.  If selected, any client may register presence.  If not selected, only clients with bare JID in the participants list may register presence.</li>
         <li>'Allow Message Retraction'.  If this option is selected users will be able to retract messages sent to the MIX channel.</li>
-        <li>'Membership Extension by Invitation'.  This option extends a members only channel so that an invitation from a channel member will add the invited user to the members list.
+        <li>'Participation Extension by Invitation'.  This option extends a channel  so that an invitation from a channel participant will add the invited user to the allowed list.
         </li>
         <li>'No Private Messages'.  If this option is selected, private messages may not be used with the channel.</li>
 
@@ -916,7 +916,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
    </section3>
 
     <section3 topic='Leaving a Channel' anchor='usecase-user-leaving'>
-      <p>Users generally remain in a channel for an extended period of time.  In particular membership of the channel does not change when the user goes offline as happens with &xep0045;. So, leaving the channel is a permanent action for a user across all clients, not just a matter of telling the channel that the user is not currently available or for a single client.  In order to  leave a channel, a user sends a MIX "leave" command to the channel. When a user leaves the channel, the user's client will remove the channel from the user's roster.</p>
+      <p>Users generally remain in a channel for an extended period of time.  In particular the user remains as a participant the channel does not change when the user goes offline as happens with &xep0045;. So, leaving the channel is a permanent action for a user across all clients, not just a matter of telling the channel that the user is not currently available or for a single client.  In order to  leave a channel, a user sends a MIX "leave" command to the channel. When a user leaves the channel, the user's client will remove the channel from the user's roster.</p>
       <example caption="User Leaves a Channel"><![CDATA[
 <iq type='set'
     from='hag66@shakespeare.example'
@@ -928,7 +928,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
       <p>When the user leaves the channel, the MIX service is responsible for unsubscribing the user from all nodes in the channel and for removing the user from the participants and presence list.  If the user has online presence when the user leaves the channel, the change of presence status caused by removing the user's entry or entries from the presence node will ensure that subscribers to the presence node are correctly updated on presence status.
 
 
-        Deletion from the participants and presence functions as if the item (channel member) had been deleted using the PubSub retract mechanism with notification set to true.    Notification of the deletion is sent to clients subscribed to the participants  PubSub nodes, as shown in the example below.
+        Deletion from the participants and presence functions as if the item (channel participant) had been deleted using the PubSub retract mechanism with notification set to true.    Notification of the deletion is sent to clients subscribed to the participants  PubSub nodes, as shown in the example below.
         </p>
       <example caption="Reporting when User Leaves a Channel"><![CDATA[
 <message from='coven@mix.shakespeare.example' to='hecate@shakespeare.example' id='foo'>
@@ -953,7 +953,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
     <section3 topic="Setting a Nick" anchor="usecase-setting-nick">
     <p>
-      Each member of a channel may have a nick, which is how other users in the channel will see the user.  In some cases a nick is not needed, for example where a user reads messages in a channel but does not send messages or share presence information.    A nick MUST be present for a user to send a message to a channel or for a user's presence to be shared on a channel.   There are four ways that a user's nick can be obtained.   The choice of mechanism or mechanisms is dependent on channel policy:
+      Each participant of a channel may have a nick, which is how other users in the channel will see the user.  In some cases a nick is not needed, for example where a user reads messages in a channel but does not send messages or share presence information.    A nick MUST be present for a user to send a message to a channel or for a user's presence to be shared on a channel.   There are four ways that a user's nick can be obtained.   The choice of mechanism or mechanisms is dependent on channel policy:
     </p>
     <ol>
       <li>The nick is registered with the user account in some way, for example as part of user provisioning with nick configured as an attribute in a directory service.   This may be chosen by corporate services that wish to ensure consistent nick values for a set of users and channels.</li>
@@ -1056,7 +1056,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     <section3 topic='Setting User Presence' anchor='usecase-user-presence'>
       <p>
 
-        A user joins a channel over an extended period, and membership in a channel does not generally change when user goes online or offline.   The users  membership of the channel is reflected by the user's bare JID in the participant node.   All messages to the channel are sent to this JID.
+        A user joins a channel over an extended period, and participation in a channel does not generally change when user goes online or offline.   The user's  participation in a channel is reflected by the user's bare JID in the participant node.   All messages to the channel are sent to this JID.
 
       </p>
       <p>
@@ -1064,7 +1064,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         A user may share presence information with the channel, for one or more online clients.   Where a user shares presence information with a channel, the channel is entered by the user's server into the user's roster when the user subscribes to the channel.  When an XMPP client comes online or changes presence status, this will be communicated by the user to the user's server using broadcast presence.  The user's XMPP server is then responsible to share this presence information to each entry in the roster and in particular to each MIX channel in the roster.  The MIX channel will update the "urn:xmpp:mix:nodes:presence" node with any change of status and the updated presence information and then share this updated presence with users subscribed to this node, as described below.   When the user sets an explicit status, this is used to modify the presence node in the channel.   When a client being used by the user goes offline, the associated server will send presence status "unavailable" to the MIX channel, which will cause the full JID for that client to be removed from the presence node.
       </p>
       <p>
-        A channel may require that all channel members share presence information with the channel, which is represented in the "urn:xmpp:mix:nodes:presence" node.   If sharing presences is required by the channel, an XMPP client conforming to this specification SHALL share presence with the channel by including the channel in the user's roster. Note that the MIX server cannot generally enforce this, but it can require and enforce that when a message is sent to the channel, that the sender of the message is in the presence list.
+        A channel may require that all channel participants share presence information with the channel, which is represented in the "urn:xmpp:mix:nodes:presence" node.   If sharing presences is required by the channel, an XMPP client conforming to this specification SHALL share presence with the channel by including the channel in the user's roster. Note that the MIX server cannot generally enforce this, but it can require and enforce that when a message is sent to the channel, that the sender of the message is in the presence list.
       </p>
       <p>
       Presence status and availability is set in a MIX channel by standard presence stanzas sent to the MIX channel by the user's server.   User's wishing to receive presence updates will subscribe to the MIX channel presence node.   Presence updates are sent out to subscribing using standard XEP-0045 compatible presence stanzas.
@@ -1214,26 +1214,26 @@ the participant is not be subscribed to all nodes associated with the channel (i
       </p>
     </section3>
     <section3 topic='Inviting another user to join a Channel' anchor='usecase-user-invite'>
-      <p>When a channel member invites another user to join a channel, a sequence of steps are followed.
+      <p>When a channel participant invites another user to join a channel, a sequence of steps are followed.
 
       </p>
       <ol>
-        <li>The channel member sends to the channel requesting an invite for the user.</li>
+        <li>The channel participant sends to the channel requesting an invite for the user.</li>
         <li>The channel sends an invitation to the user requesting the invite.</li>
-        <li>The channel member sends the invitation to the invitee.</li>
+        <li>The channel participant sends the invitation to the invitee.</li>
         <li>The invitee uses the invitation to construct a request to join the channel.</li>
       </ol>
       <p> AUTHOR'S NOTES AND QUESTION:   Need to consider including declines.   To be expanded considerably and perhaps modified based on the following:  Dave Cridland notes: 
-        > There are three actors - the Member (who is the inviter), the Invitee, and
+        > There are three actors - the participant (who is the inviter), the Invitee, and
         > the Channel.
         > 
-        > A) The Member obtains an Invitation (containing a verifiable token) from the
+        > A) The participant obtains an Invitation (containing a verifiable token) from the
         > Channel. This allows the Channel to reject attempts to invite users who
         > should not be able to join the channel, but it might provide the token anyway
         > to avoid probes discovering who is allowed to join the room. This is your step
         > 1.
         > 
-        > B) The Member sends this Invitation (including the token) to the Invitee.
+        > B) The participant sends this Invitation (including the token) to the Invitee.
         > (Step 2)
         > 
         > C) The Invitee can optionally request from the Channel the validity of the
@@ -1242,8 +1242,8 @@ the participant is not be subscribed to all nodes associated with the channel (i
         > D) The Invitee can use the Invitation. (Step 3)
         > 
         > The idea behind my step C is that it allows a client to validate that the entity
-        > sending an invitation really is a member of the channel, and could
-        > legitimately act as a Member. This could be folded into (D), although it
+        > sending an invitation really is a participant of the channel, and could
+        > legitimately act as a participant. This could be folded into (D), although it
         > depends on whether we want to present the Invitation without knowing its
         > validity.
         > 
@@ -1493,7 +1493,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     
     <li>Fully integrated MIX and MUC implementation, with MIX and MUC sharing a single domain and rooms/channels equivalent.</li>
     
-    <li>Partially integrated MIX and MUC implementation, with MIX and MUC using separate domains, but rooms/channel are common.  This means that each MIX channel will have MUC room of the same name and common membership.</li>
+    <li>Partially integrated MIX and MUC implementation, with MIX and MUC using separate domains, but rooms/channel are common.  This means that each MIX channel will have MUC room of the same name and same participants.</li>
   </ol>
   
   <p>The fully integrated approach would be transparent to clients.    Disco of a room or channel would show support for both MUC and MIX, which would enable a client to choose whether to use MUC or MIX.  The following example shows how a MIX service that also supported MUC would respond:</p>
@@ -1602,7 +1602,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
    <p>This section lists a number of capabilities not specified in this version of MIX which were provided in &xep0045;.   </p>
    <section2 topic="Password Controlled Channels" anchor="password-control">
      <p>
-       &xep0045; provides a mechanism to control access to MUC rooms using passwords.  An equivalent mechanism is not included in MIX, as it has a number of security issues.  Control of access to channels is better achieved using an explicit members list.
+       &xep0045; provides a mechanism to control access to MUC rooms using passwords.  An equivalent mechanism is not included in MIX, as it has a number of security issues.  Control of access to channels is better achieved using an explicit list of participants.
      </p>
    </section2>
 

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -1086,16 +1086,99 @@
     <section3 topic='Sending Private Messages' anchor='usecase-user-private-messages'>
 
       <p>
-        A user may add a proxy JID from the participants node of a MIX channel to the user's roster.  This will enable convenient communication with the user through the MIX channel, without the user knowing the real JID of the channel participant.
+       Private Messages are used to provide communication with another channel participant through the MIX channel, without the initiating  user knowing the real JID of the channel participant.  A channel MAY support use of Private Messages.  Private messages are standard XMPP messages.   A message goes through a number of stages with different addressing.  This is set out in the following table.
       </p>
-      <p> AUTHOR'S NOTE:   To be expanded considerably. </p>
+      
+      <table>
+        <tr><th>Message</th><th>From</th><th>To</th></tr>
+        
+        <tr><td>First Message from Client to MIX Channel</td><td>Full JID of initiator's client</td><td>Proxy bare JID of responder</td></tr>
+        <tr><td>First Message from MIX Channel to responder's MIX Proxy</td><td>Proxy full JID of initiator's client</td><td>Bare JID of responder</td></tr>
+        <tr><td>First Message from responder's MIX Proxy to one or more of the responder's clients</td><td>Proxy full JID of initiator</td><td>Full JID of responder's client</td></tr>
+        
+        <tr><td>Messages from responder's client to MIX Channel</td><td>Full JID of responder's client</td><td>Proxy full JID of initiator's client</td></tr>
+        <tr><td>Messages from MIX channel to initiator's client</td><td>Proxy full JID of responder's client</td><td>Full JID of initiator's client</td></tr>
+        
+        <tr><td>Messages from initiator's client to MIX Channel</td><td>Full JID of initiator's client</td><td>Proxy full JID of responder's client</td></tr>
+        <tr><td>Message from MIX Channel to responder's client</td><td>Proxy full JID of initiator's client</td><td>Full JID of responder's client</td></tr>
+        
+      </table>
+      <p>Private Messages MAY be archived using MAM by the XMPP servers associated with initiator and responder.   Private Messages MUST NOT be archived by the MIX channel.</p>
     </section3>
 
 
 
     <section3 topic="Requesting vCard" anchor="usecase-vcard">
-      <p>A user may request the vCard of a channel participant by sending a request through the channel.</p>
-      <p> AUTHOR'S NOTES:   To be expanded considerably. ( is essentially "send the vCard request to the bare Proxy JID")</p>
+      <p>A user may request the vCard of a channel participant by sending a request through the channel.  The request may be sent directly by the client or through a MIX Proxy.  The MIX channel MAY pass this request on or may block it.  In the following example, the requesting client sends a message to the anonymized bare JID of the channel participant for which the vCard is desired.</p>
+      
+      
+      
+      
+      <example caption="Client directly requests vCard through channel" ><![CDATA[
+<iq from='hag66@shakespeare.example/intibo24'
+    id='lx09df27'
+    to='coven+989898@mix.shakespeare.example'
+    type='get'>
+  <vCard xmlns='vcard-temp'/>
+</iq>
+]]></example>
+      <p>The MIX channel MAY pass on the vCard request or may reject with an error, dependent on channel policy.  The MIX service will then address the vCard request to the MIX proxy (bare JID) using an anonymous full proxy JID to hide the requester.  </p>
+      
+      <example caption="Channel passes on vCard request to MIX Proxy" ><![CDATA[
+<iq from='coven+123456@mix.shakespeare.example/6789'
+    id='lx09df27'
+    to='peter@shakespeare.lit'
+    type='get'>
+  <vCard xmlns='vcard-temp'/>
+</iq>
+]]></example>    
+      
+    <p>
+      The MIX Proxy, on behalf of the user, MAY send a response or reject with an error.   The MIX Proxy will send the vCard back to the channel.
+    </p>  
+      <example caption="Service responds with Disco Info result" ><![CDATA[
+<iq from='peter@shakespeare.lit'
+    id='lx09df27'
+    to='coven+123456@mix.shakespeare.example/6789'
+    type='result'>
+    <vCard xmlns='vcard-temp'>
+    <FN>Peter Saint-Andre</FN>
+    <N>
+      <FAMILY>Saint-Andre</FAMILY>
+      <GIVEN>Peter</GIVEN>
+      <MIDDLE/>
+    </N>
+    <NICKNAME>stpeter</NICKNAME>
+    <URL>http://www.xmpp.org/xsf/people/stpeter.shtml</URL>
+  </vCard>
+    
+  <query xmlns='http://jabber.org/protocol/disco#info'>
+</iq>
+]]></example>
+      
+      <p>
+        The MIX channel will then send the vCard response to the requesting client on behalf of the client sending the response.
+      </p>
+      
+      <example caption="Service responds with Disco Info result" ><![CDATA[
+<iq from='coven+989898@mix.shakespeare.example'
+    id='lx09df27'
+    to='hag66@shakespeare.example/intibo24'
+    type='result'>
+ <vCard xmlns='vcard-temp'>
+    <FN>Peter Saint-Andre</FN>
+    <N>
+      <FAMILY>Saint-Andre</FAMILY>
+      <GIVEN>Peter</GIVEN>
+      <MIDDLE/>
+    </N>
+    <NICKNAME>stpeter</NICKNAME>
+    <URL>http://www.xmpp.org/xsf/people/stpeter.shtml</URL>
+  </vCard>   
+</iq>
+]]></example>
+      
+     
     </section3>
   </section2>
 

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -260,21 +260,21 @@
     <p>The standard nodes are as follows (although note that not every channel will necessarily use each node):</p>
     
     <table caption="Standard Nodes">
-      <tr><th>Node</th><th>Description</th></tr>
+      <tr><th>Name</th><th>Node</th><th>Description</th></tr>
       
-      <tr><td>'urn:xmpp:mix:nodes:messages'</td><td>For publishing messages. Each item of this node will contain a message sent to the channel.</td></tr>
+      <tr><td>Messages</td><td>'urn:xmpp:mix:nodes:messages'</td><td>For publishing messages. Each item of this node will contain a message sent to the channel.</td></tr>
       
-      <tr><td>'urn:xmpp:mix:nodes:subject'</td><td>For publishing the subject of the channels</td></tr>
+      <tr><td>Subject</td><td>'urn:xmpp:mix:nodes:subject'</td><td>For publishing the subject of the channels</td></tr>
       
-      <tr><td>'urn:xmpp:mix:nodes:participants'</td><td>For publishing the list of participants (identified by anonymized bare proxy JID), and identifying the nick.  This is a list of users who would receive messages (by subscription to the messages node) and/or would receive presence (by subscription to the presence node).</td></tr>
+      <tr><td>Participants</td><td>'urn:xmpp:mix:nodes:participants'</td><td>For publishing the list of participants (identified by anonymized bare proxy JID), and identifying the nick.  This is a list of users who would receive messages (by subscription to the messages node) and/or would receive presence (by subscription to the presence node).</td></tr>
       
-      <tr><td>'urn:xmpp:mix:nodes:jidmap'</td><td>For publishing a list of anonymized bare JIDs from the participants node with a 1:1 mapping to the corresponding real JIDs.</td></tr>
+      <tr><td>JID Map</td><td>'urn:xmpp:mix:nodes:jidmap'</td><td>For publishing a list of anonymized bare JIDs from the participants node with a 1:1 mapping to the corresponding real JIDs.</td></tr>
       
-      <tr><td>'urn:xmpp:mix:nodes:presence'</td><td>For publishing information about the availability status of online participants, which may include multiple clients for a single participant.</td></tr>
+      <tr><td>Presence</td><td>'urn:xmpp:mix:nodes:presence'</td><td>For publishing information about the availability status of online participants, which may include multiple clients for a single participant.</td></tr>
       
-      <tr><td>'urn:xmpp:mix:nodes:config'</td><td>For storing configuration information.</td></tr>
+      <tr><td>Configuration</td><td>'urn:xmpp:mix:nodes:config'</td><td>For storing channel configuration. This information will generally be restricted to authorized users.</td></tr>
       
-      <tr><td>'urn:xmpp:mix:nodes:acl'</td><td>For storing information about access control lists (such as the list of owners and administrators). This information will generally be restricted to authorized users.</td></tr>
+      <tr><td>Information</td><td>'urn:xmpp:mix:nodes:info'</td><td>For storing general channel information, such as description and avatar. </td></tr>
     </table>
     
   
@@ -346,39 +346,58 @@
 </items>
 ]]></example>
     </section3>
-    <section3 topic="Configuration Node" anchor="config-node">
+    <section3 topic="Information Node" anchor="info-node">
 
-      <p>The Configuration node holds the configuration of the channel as a single item, named by the date-time of the last update to the configuration.  A single item is stored in the node at a time, with previous configuration history accessed by MAM.  Users subscribed to the configuration node will enable notification of configuration change.  The configuration node is optional for a MIX channel.  For example, configuration choices could be fixed and not exposed.   A subset of the defined configuration options may be used and additional non-standard configuration options may be added.   If configuration options to control functionality of the nature described here are provided, the options defined in this standard MUST be used. The following configuration options are provided:</p>
+      <p>The Information node holds information about the channel.   The information node is named by the name of the node, which must be present.  Other elements of the information node are optional. Information history is stored in MAM.  The name and description values MUST contain a "text" element and MAY contain additional text elements. Where multiple text elements are provided, each MUST posses an xml:lang attribute that describes the natural language of the subject. Users MAY subscribe to this node to receive information updates. The Information node has the following attributes:        
+</p>
       <ul>
-        <li>'Date of Configuration Change'.  Encoded as the item ID.</li>
-        <li>'Last Change Made By'.  Bare JID of the user making the last change.</li>
-        <li>'Name'.  The name of the channel</li>
-        <li> 'Members'.  List of JIDs with member rights.  The rights of members are configured in the ACL node.  </li>
-        <li>'Outcast'.  List of JIDs banned from subscribing to any nodes in the MIX channel.  </li>
+        
+        <li>'Name'.  A short string providing a name for the channel</li>
+        
+        <li>'Description'. A longer description of the channel.</li>
+        
+        <li>'Administrator'.  The person or role responsible for the channel, using vCard format following &xep0054;.</li>
+        
+        <li>'Avatar'.  An Avatar associated with the channel.  This MAY be used in rosters that hold information on the channel and MAY be displayed by clients using the channel.  The avatar is stored using the format defined in &xep0084;</li>
+
       </ul>
-      <p>TEMPORARY NOTE AND QUESTION:  This is currently work in progress.  Suggestions for other items to be included in configuration are welcome.</p>
-      <p>The format of the Configuration node follows &xep0004;.  This allows configuration to be updated by MIX defined commands and that the results of update commands can be directly written to the PubSub node.   Updates to the Configuration may use these commands or direct writing to the PubSub node.</p>
-      <example caption="Configuration Node"><![CDATA[
-<items node='urn:xmpp:mix:nodes:config'>
-  <item id='2016-05-30T09:00:00'
-        name='A Dark Cave'>
-    *** TBS ****
+   
+      <p>The format of the Information node follows &xep0004;.  This allows configuration to be updated by MIX defined commands and that the results of update commands can be directly written to the PubSub node.   
+      The following example shows the format of a item in the information node for the example coven@mix.shakespeare.example channel.  
+      </p>
+      <example caption="Information Node"><![CDATA[
+<items node='urn:xmpp:mix:nodes:info'>
+  <item id='2016-05-30T09:00:00' xmlns='urn:xmpp:mix:0'>
+        <name>Witches Coven</name>
+        <description>A location not far from the blasted heath where the three witches meet</description>
+        <administrator>
+           <vCard xmlns='vcard-temp'>
+              <FN>Hecate</FN>
+              <TITLE>Chief Witch</TITLE>
+           </vCard>
+        </administrator>
+        <avatar>
+             <data xmlns='urn:xmpp:avatar:data'>
+          qANQR1DBwU4DX7jmYZnncm...
+            </data>
+        </avatar>
   </item>
 </items>
 ]]></example>
+      
     </section3>
-    <section3 topic="ACL Node" anchor="acl-node">
-      <p>The ACL node is closely related to the configuration node, and contains more information that will generally be more restricted as to who can access and modify.   An anticipated configuration reflected in the defaults has ACL node configured so that it can be modified by channel owners and read only by channel owners and administrators.  The default for the configuration node is update by owners or administrators and visibility to list members.  Split of functionality has been made on the basis of this model. </p>
-      <p>TEMPORARY NOTE AND QUESTION:  The split of configuration/acl is arbitrary.  It would be possible to merge them, or to split into more nodes, giving finer control granularity.  Input is solicited on the split an detailed assignment of items to nodes.</p>
-
-
-      <p>The ACL node holds access control related configuration of the channel as a single item, named by the date-time of the last update to the ACL.  History MUST be set to 1.  Previous ACL history is accessed by MAM.  Users may subscribe to the ACL node if allowed using bare JID.  The ACL node is optional for a MIX channel.  For example, ACL choices could be fixed and not exposed.   A subset of the defined ACL options may be used and additional non-standard ACL options may be added.   If configuration options to control functionality of the nature described here are provided, the options defined in this standard MUST be used. The following ACL options are provided:</p>
+    <section3 topic="Configuration Node" anchor="config-node">
+      <p>
+        The Configuration node holds the configuration of the channel as a single item, named by the date-time of the last update to the configuration.  A single item is stored in the node at a time, with previous configuration history accessed by MAM.  Users MAY subscribe to the configuration node to get notification of configuration change.  The configuration node is optional for a MIX channel.  For example, configuration choices could be fixed and not exposed.   A subset of the defined configuration options may be used and additional non-standard configuration options may be added.   If configuration options to control functionality of the nature described here are provided, the options defined in this standard MUST be used. The following configuration options are provided:
+</p>
+     
       <ul>
         <li>'Date of Configuration Change'.  Encoded as the item ID.</li>
         <li>'Last Change Made By'.  Bare JID of the user making the last change.</li>
         <li>'Owners'.  List of bare JIDs with Owner rights as defined in ACL node.  When a list is created, the JID creating the list is configured as an owner, unless this attribute is explicitly configured to another value.  Owners will generally have full rights to make changes to channel configuration and access control.</li>
-        <li>'Administrators'.  List of bare JIDs with Administrator rights.  An Administrator has rights to make changes to channel access control and configuration as defined in ACL node.  An Administrator also has operational right on a channel, such a kicking users out of the channel. These rights are analogous to moderator rights defined in <cite>Multi-User Chat</cite>.</li>
-
+        <li>'Administrators'.  List of bare JIDs with Administrator rights.  An Administrator has rights to make changes to channel access control and configuration as defined in ACL node.  An Administrator also has operational right on a channel, such a kicking users out of the channel. These rights are analogous to moderator rights defined in &xep0045;.</li>
+        <li> 'Members'.  List of JIDs with member rights.  The rights of members are configured in the configuration node.  </li>
+        <li>'Outcast'.  List of JIDs banned from subscribing to any nodes in the MIX channel.  </li>
         <li>'End of Life'.  The date and time at which the channel will be automatically removed by the server.   If this is not set, the channel is permanent.</li>
         <li>'Nodes Present'.  Specifies which nodes are present: "participants"; "presence"; "subject"; "acl".  Note that "config" is implicit,  and "jidmap" is implied by "participants". </li>
         <li>'Message Node Subscription'.  Controls who can subscribe to messages node: "members-only"; "participants-only"; "anyone".  Users with banned affiliation may not subscribe.  Default "participants-only".</li>
@@ -387,10 +406,9 @@
         <li>'Presence Node Subscription'.  Controls who can subscribe to presence node: "members-only"; "participants-only"; "anyone"; "nobody".  Users with banned affiliation may not subscribe.  Default "participants-only".</li>
         <li>'Subject Node Subscription'.  Controls who can subscribe to subject node: "members-only"; "participants-only"; "anyone"; "nobody".  Users with banned affiliation may not subscribe.  Default "participants-only".</li>
         <li>'Configuration Node Access'.  Controls who can subscribe to and has read access configuration node: "members-only"; "participants-only"; "admins-and-owners"; "owners-only"; "anyone"; "nobody". Default "admins-and-owners".</li>
-        <li>'ACL Node Access'.  Controls who can subscribe to and has read access acl node: "members-only"; "admins-and-owners"; "owners-only"; "anyone"; "nobody". Default "admins-and-owners".</li>
+        <li>'Information Node Access'.  Controls who can subscribe to and has read access acl node: "members-only"; "participants-only"; "admins-and-owners"; "owners-only"; "anyone"; "nobody". Default "participants-only".</li>
         <li>'Configuration Node Update'.  Controls who can modify configuration node: "owners-only"; "admins-and-owners". Default "admins-and-owners".</li>
-        <li>'ACL Node Update'.  Controls who can modify acl node: "owners-only"; "admins-and-owners". Default "owners-only".</li>
-
+        
         <li>'JID Visibility'. Choice of "jid-hidden", "jid-optionally-visible", "jid-mandatory-visible". </li>
         <li>'Open Presence'.  If selected, any client may register presence.  If not selected, only clients with bare JID in the participants list may register presence.</li>
         <li>'Allow Message Retraction'.  If this option is selected users will be able to retract messages sent to the MIX channel.</li>
@@ -399,10 +417,10 @@
         <li>'No Private Messages'.  If this option is selected, private messages may not be used with the channel.</li>
 
       </ul>
-      <p>TEMPORARY NOTE:  This is currently work in progress.  Suggestions for other items to be included in ACL are welcome.</p>
+      <p>AUTHOR'S NOTE AND QUESTION:  Detailed review of this section is solicited, and requirements for any additional configuration control.</p>
       <p>The format of the ACL node follows &xep0004;. </p>
-      <example caption="ACL Node"><![CDATA[
-<items node='urn:xmpp:mix:nodes:acl'>
+      <example caption="Configuration Node"><![CDATA[
+<items node='urn:xmpp:mix:nodes:config'>
   <item id='2016-05-30T09:00:00'>
     *** TBS ****
   </item>
@@ -1034,7 +1052,7 @@
       </p>
       <p>
 
-     AUTHOR'S NOTE:  Allow configuration by direct writes to 'urn:xmpp:mix:nodes:config' and ACL node.    Also specify MIX XEP-0004 commands to achieve this.
+     AUTHOR'S NOTE:  Allow configuration by direct writes to 'urn:xmpp:mix:nodes:config' .    Also specify MIX XEP-0004 commands to achieve this.
 
 
       </p>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -417,6 +417,7 @@
         <li>'No Private Messages'.  If this option is selected, private messages may not be used with the channel.</li>
 
       </ul>
+      <p>AUTHOR'S NOTE:  This version contains a number of AUTHOR NOTES, which are reminder instructions to the author as to editing actions to be taken, and also indicate where changes are anticipated in future versions.</p>
       <p>AUTHOR'S NOTE AND QUESTION:  Detailed review of this section is solicited, and requirements for any additional configuration control.</p>
       <p>The format of the ACL node follows &xep0004;. </p>
       <example caption="Configuration Node"><![CDATA[
@@ -474,14 +475,33 @@
     
   </section2>
   <section2 topic='Discovering the Channels on a Service' anchor='disco-channel-list'>
-    <p>The list of channels supported by a MIX service is obtained by a disco command.</p>
-    <p>AUTHOR'S NOTE:  This version contains a number of AUTHOR NOTES, which are reminder instructions to the author as to editing actions to be taken, and also indicate where changes are anticipated in future versions.</p>
-    <p>
-      AUTHOR'S NOTE:  Need to add  example.   This standard disco approach is going to replace the earlier proposed "urn:xmpp:mix:nodes:channels", unless there are objections.   
-    </p>
+    <p>The list of channels supported by a MIX service is obtained by a disco#items command.   The MIX server MUST only return channel that exist and that the user making the query has rights to subscribe to.  This query MAY be made directly by and XMPP client or by a MIX Proxy.</p>
+    
+    <example caption='MIX Proxy Queries for Channels on MIX Service'><![CDATA[
+<iq from='hag66@shakespeare.lit'
+    id='kl2fax27'
+    to='mix.shakespeare.lit'
+    type='get'>
+  <query xmlns='http://jabber.org/protocol/disco#items'/>
+</iq>
+]]></example>
+    <example caption='MIX Service Returns Disco Items Result'><![CDATA[
+<iq from='mix.shakespeare.lit'
+    id='kl2fax27'
+    to='hag66@shakespeare.lit'
+    type='result'>
+  <query xmlns='http://jabber.org/protocol/disco#items'>
+    <item jid='coven@mix.shakespeare.example' />
+    <item jid='spells@mix.shakespeare.example' />
+    <item jid='wizards@mix.shakespeare.example' />
+  </query>
+</iq>
+]]></example>
+
+  
   </section2>
   <section2 topic='Discovering Channel Information' anchor='disco-channel-info'>
-    <p>In order to find out more information about a given channel, a user can send a disco#info query to the channel.</p>
+    <p>In order to find out more information about a given channel, a user can send a disco#info query to the channel.  This query MUST be made by a MIX Proxy and not the end client.</p>
     <example caption='Entity Queries for Information about a Specific Channel'><![CDATA[
 <iq from='hag66@shakespeare.lit'
     id='ik3vs715'
@@ -508,7 +528,7 @@
 ]]></example>
   </section2>
   <section2 topic='Discovering Nodes at a Channel' anchor='disco-channel-nodes'>
-    <p>Use disco#items to find the nodes associated with a channel.   The MIX server MUST only return nodes that exist and that the user making the query has rights to subscribe to.</p>
+    <p>Use disco#items to find the nodes associated with a channel.   The MIX server MUST only return nodes that exist and that the user making the query has rights to subscribe to. This query MUST be made by a MIX Proxy and not the end client.</p>
     <example caption='Entity Queries for Nodes at a Channel'><![CDATA[
 <iq from='hag66@shakespeare.lit'
     id='kl2fax27'
@@ -517,7 +537,7 @@
   <query xmlns='http://jabber.org/protocol/disco#items'/>
 </iq>
 ]]></example>
-    <example caption='Room Returns Disco Items Result'><![CDATA[
+    <example caption='Channel Returns Disco Items Result'><![CDATA[
 <iq from='coven@mix.shakespeare.lit'
     id='kl2fax27'
     to='hag66@shakespeare.lit'

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -480,7 +480,7 @@
         <li>'JID Visibility'. Choice of "jid-hidden", "jid-optionally-visible", "jid-mandatory-visible". </li>
         <li>'Open Presence'.  If selected, any client may register presence.  If not selected, only clients with bare JID in the participants list may register presence.</li>
         <li>'Allow Message Retraction'.  If this option is selected users will be able to retract messages sent to the MIX channel.</li>
-        <li>'Participation Extension by Invitation'.  This option extends a channel  so that an invitation from a channel participant will add the invited user to the allowed list.
+        <li>'Participation Addition by Invitation from Participant'.  This option extends a channel  so that  a channel participant has rights to invite and enable other users as participants.
         </li>
         <li>'No Private Messages'.  If this option is selected, private messages may not be used with the channel.</li>
 
@@ -1293,50 +1293,117 @@ the participant is not be subscribed to all nodes associated with the channel (i
       </p>
     </section3>
     
-    <section3 topic='Telling another user about a Channel' anchor='usecase-user-tell'>
+    <section3 topic='Telling another User about a Channel' anchor='usecase-user-tell'>
       <p>
         A convenient way to reference another channel is to use &xep0372; which enables the JID of a channel to be shared.  This might be used simply to inform the message recipient about the channel or as mechanism to invite the user to join the channel.   This is useful as an invitation mechanism to a channel that any user can join or where the invitee knows that the user may join (e.g., because the channel is for all users in an organization).   
       </p>
     </section3>
     
-    <section3 topic='Inviting another user to join a Channel' anchor='usecase-user-invite'>
-      <p>When a channel participant invites another user to join a channel, a sequence of steps are followed.
+    <section3 topic='Inviting another User to join a Channel that the user does not have Permission to Join' anchor='usecase-user-invite'>
+      <p> Invitation by reference, as described in the previous section, is a convenient approach to invite a user to join a channel that the user has permission to join.   This section describes the approach used when the inviter has permission to grant rights for the invitee to become a channel participant.   This might be because the inviter is an administrator of the channel or the channel may have a special mode where channel participants may grant rights for other users to join a channel ('Participation Addition by Invitation from Participant' enabled).   This approach is used to avoid cluttering the allowed node with JIDs of users who are invited to join, but do not accept the invitation.
+        
+        
+        When a channel participant(the inviter) invites  another user (the invitee) to join a channel, the following sequence of steps is followed:
 
       </p>
       <ol>
-        <li>The channel participant sends to the channel requesting an invite for the user.</li>
-        <li>The channel sends an invitation to the user requesting the invite.</li>
-        <li>The channel participant sends the invitation to the invitee.</li>
-        <li>The invitee uses the invitation to construct a request to join the channel.</li>
+        <li>The channel inviter sends to the channel requesting an invite for the invitee.</li>
+        <li>The channel sends an invitation to the inviter.</li>
+        <li>The inviter sends the invitation to the invitee.</li>
+        <li>The invitee MAY use the invitation to join the channel.</li>
+        <li>The invitee MAY send a response to the inviter, indicating if the invitation was accepted or declined.</li>
       </ol>
-      <p> AUTHOR'S NOTES AND QUESTION:   Need to consider including declines.   To be expanded considerably and perhaps modified based on the following:  Dave Cridland notes: 
-        > There are three actors - the participant (who is the inviter), the Invitee, and
-        > the Channel.
-        > 
-        > A) The participant obtains an Invitation (containing a verifiable token) from the
-        > Channel. This allows the Channel to reject attempts to invite users who
-        > should not be able to join the channel, but it might provide the token anyway
-        > to avoid probes discovering who is allowed to join the room. This is your step
-        > 1.
-        > 
-        > B) The participant sends this Invitation (including the token) to the Invitee.
-        > (Step 2)
-        > 
-        > C) The Invitee can optionally request from the Channel the validity of the
-        > Invitation. (Not included)
-        > 
-        > D) The Invitee can use the Invitation. (Step 3)
-        > 
-        > The idea behind my step C is that it allows a client to validate that the entity
-        > sending an invitation really is a participant of the channel, and could
-        > legitimately act as a participant. This could be folded into (D), although it
-        > depends on whether we want to present the Invitation without knowing its
-        > validity.
-        > 
-        > It feels as if an Invitee executing on an Invitation ought to be able to tell if the
-        > Invitation was genuine or not.
-        > 
-        . </p>
+      <p> 
+        The first step is for the inviter to request an invitation from the channel.   The invitation contains inviter, invitee and a token.  The channel will evaluate if the inviter has rights to issue the invitation.   This will be because the inviter is a channel administrator or if the inviter is a channel participant and the channel has 'Participation Addition by Invitation from Participant' mode enable.  If the inviter has rights to make the invitation, the channel will return a token.  The token is a string that the channel can subsequently use to validate an invitation.   The format of the token is not specified in this standard.   The encoded token MAY reflect a validity time.
+      </p>
+      
+      <example caption='Inviter Requests and Receives Invitation'><![CDATA[
+<iq from='hag66@shakespeare.lit/pda'
+    id='kl2fax27'
+    to='coven@mix.shakespeare.lit'
+    type='get'>
+  <query xmlns='urn:xmpp:mix:0#request-invitation'/>
+  <invitee>cat@shakespeare.lit</invitee>
+</iq>
+
+
+<iq from='coven@mix.shakespeare.lit'
+    id='kl2fax27'
+    to='hag66@shakespeare.lit/pda'
+    type='result'>
+  <query xmlns='urn:xmpp:mix:0#request-invitation'>
+        <invitation>
+           <inviter>hag66@shakespeare.lit</inviter>
+           <invitee>cat@shakespeare.lit</invitee>
+           <channel>coven@mix.shakespeare.lit</channel>
+           <token>ABCDEF</token>
+        </invitation>
+</iq>
+]]></example>    
+      
+      <p>
+        The inviter can now send the invitee a message containing the invitation, as shown in the following example.
+      </p>
+      
+      <example caption='Inviter sends Invitation to Invitee'><![CDATA[
+<message from='hag66@shakespeare.lit/pda'
+    id='foo'
+    to='cat@shakespeare.lit'>
+    <body>Would you like to join the coven?<body>
+    <invitation xmlns='urn:xmpp:mix:0'> 
+        <inviter>hag66@shakespeare.lit</inviter>
+        <invitee>cat@shakespeare.lit</invitee>
+        <channel>coven@mix.shakespeare.lit</channel>
+        <token>ABCDEF</token>
+   </invitation>
+</iq>
+]]></example>    
+      
+  
+  <p>The invitation can now be used by the invitee to join a channel.   The invitation is simply added to the standard channel join, so that the channel can validate the invitation using the token.   If the allowed node is present and the invitee is not matched against any item, the channel MUST add the invitee to the allowed node as part of the join.</p>
+      
+      
+      <example caption="User Joins a Channel with an Invitation"><![CDATA[
+<iq type='set'
+    from='cat@shakespeare.example'
+    to='coven@mix.shakespeare.example'
+    id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
+  <join xmlns='urn:xmpp:mix:0'>
+    <subscribe node='urn:xmpp:mix:nodes:messages'/>
+    <invitation> 
+        <inviter>hag66@shakespeare.lit</inviter>
+        <invitee>cat@shakespeare.lit</invitee>
+        <channel>coven@mix.shakespeare.lit</channel>
+        <token>ABCDEF</token>
+   </invitation>
+  </join>
+</iq>
+]]></example>
+      
+      <p>The invitee may send an acknowledgement back to the inviter, noting the status of the invitation.  Values are:</p>
+      <ul>
+        <li>'Joined': The invitee has joined the channel.</li>
+        <li>'Declined': The invitee is not taking up the invitation.</li>
+        <li>'Acknowledged': The invitation is acknowledged, without information on action taken or planned.</li>
+      </ul>
+      
+      <example caption='Invitee sends Acknowledgement to Inviter'><![CDATA[
+<message from='cat@shakespeare.lit/miaow'
+    id='bar'
+    to='hag66@shakespeare.lit/pda'>
+    <body>No Thanks - too busy chasing mice....<body>
+    <invitation-ack xmlns='urn:xmpp:mix:0'>
+        <value>Declined</value>
+        <invitation> 
+             <inviter>hag66@shakespeare.lit</inviter>
+             <invitee>cat@shakespeare.lit</invitee>
+              <channel>coven@mix.shakespeare.lit</channel>
+              <token>ABCDEF</token>
+         </invitation>
+     </invitation-ack>
+</iq>
+]]></example>    
+  
     </section3>
 
 

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -728,26 +728,63 @@
     </section3>
 
    <section3 topic="User Preferences and Additional Information" anchor="usecase-visibilty-pref">
-     <p>A channel may store additional user preferences and parameters.  Where the channel requires a value to be explicitly a &xep0004; form will be returned in response to the join request with mandatory and optional fields.  If parameters are optional, the user may request to set them. </p>
+     <p>A channel MAY store user preferences and parameters with each user.    There are two preference options.
+       </p>
      <p>
-       A user may set their JID visibility preference to one of the following values:
+       A user  JID visibility preference have the following values:
      </p>
      <ol>
        <li>'Use Channel Default'.   In this setting, the channel default value will be used.  This value is used if another value is not explicitly set.</li>
        <li>'Never Show JID'.  If this is set, JID will never be shared and user will be removed from the channel if its mode changes to JID-visible-mandatory.</li>
-       <li>'Prefer Not Show JID.   If this is set, JID will only be shared if mode is JID-visible-mandatory.</li>
+       <li>'Prefer Not Show JID'.   If this is set, JID will only be shared if mode is JID-visible-mandatory.</li>
      </ol>
      <p>
-       AUTHOR'S NOTE AND QUESTION: Dave Cridland (+1) has suggested.   I would prefer:
-      
-        a) User options be sent in the initial join/>.
-        b) Unknown options are ignored.
-       c) User options can be requested (as a form). If clients require an option to
-        be supported, they should request the form.
-       
-       
+      The user may specify that no Private Messages are to be sent from the channel, and allow vCard retrieval.
      </p>
-     <p>AUTHOR'S NOTE AND QUESTION:  Add protocol specifications  and examples.   Are there any other specific per user values that should be listed here? </p>
+     <p>
+       The following table sets out the standardized user preference values.   A MIX implementation may use other values.
+     </p>
+     <table caption="Standard User Preference Options">
+       <tr><th>Option</th> <th>Values</th><th>Default</th></tr>
+       
+       <tr><td>'JID Visibility'</td> <td>'Use Channel Default', 'Never Show JID',  'Prefer Not Show JID'</td>  <td>'Use Channel Default'</td></tr>
+       
+       <tr><td>'Private Messages'</td><td>'Allow', 'Block'</td> <td>'Allow'</td></tr>
+       
+       <tr><td>'vCard'</td><td>'Allow', 'Block'</td> <td>'Block'</td></tr>
+     </table>
+     
+     <p>When joining a channel, the client may specify one or more preference options.   In the response, the  server MUST specify all of the user preferences supported by the server, with default values if the user has not requested a different value.  The following example shows joining a channel and setting a preference.</p>
+     
+     <example caption="User Joins a Channel and Specifies a preference"><![CDATA[
+<iq type='set'
+    from='hag66@shakespeare.example'
+    to='coven@mix.shakespeare.example'
+    id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
+  <join xmlns='urn:xmpp:mix:0'>
+    <subscribe node='urn:xmpp:mix:nodes:messages'/>
+    <subscribe node='urn:xmpp:mix:nodes:presence'/>
+    <user-preference key='JID Visibility' value='Never Show JID'/>
+  </join>
+</iq>
+]]></example>
+     <p>The following example shows a successful join, which also reports all the user preferences. </p>
+     <example caption="Channel Successfully Processes Join and returns the preferences set"><![CDATA[
+<iq type='result'
+    from='coven@mix.shakespeare.example'
+    to='hag66@shakespeare.example'
+    id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
+  <join xmlns='urn:xmpp:mix:0' jid='hag66@shakespeare.example'>
+    <subscribe node='urn:xmpp:mix:nodes:messages'/>
+    <subscribe node='urn:xmpp:mix:nodes:presence'/>
+    <user-preference key='JID Visibility' value='Never Show JID'/>
+    <user-preference key='Private Messages' value='Allow'/>
+    <user-preference key='vCard' value='Block'/>
+  </join>
+</iq>
+]]></example>
+     
+     
    </section3>
 
     <section3 topic='Leaving a Channel' anchor='usecase-user-leaving'>
@@ -1095,7 +1132,7 @@
        Private Messages are used to provide communication with another channel participant through the MIX channel, without the initiating  user knowing the real JID of the channel participant.  A channel MAY support use of Private Messages.  Private messages are standard XMPP messages.   A message goes through a number of stages with different addressing.  This is set out in the following table.
       </p>
       
-      <table>
+      <table caption="Setting From and To when sending Private Messages">
         <tr><th>Message</th><th>From</th><th>To</th></tr>
         
         <tr><td>First Message from Client to MIX Channel</td><td>Full JID of initiator's client</td><td>Proxy bare JID of responder</td></tr>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -290,7 +290,7 @@
       <p>Private Messages are not stored in the messages node.</p>
     </section3>
     <section3 topic="Subject Node" anchor="subject-node">
-      <p>The subject node publishes the current subject of channel. Subject history is stored in MAM. A single item is stored in this node at a time which MUST contain a "text" element and MAY contain additional text elements. Where multiple text elements are provided, each MUST posses an xml:lang attribute that describes the natural language of the subject. Users subscribe to this node to receive subject updates. The following example shows the format of a item in the subject node.</p>
+      <p>The subject node publishes the current subject of channel. Subject history is stored in MAM. A single item is stored in this node at a time which MUST contain a "text" element and MAY contain additional text elements. Where multiple text elements are provided, each MUST posses an xml:lang attribute that describes the natural language of the subject.  The following example shows the format of a item in the subject node.</p>
       <example caption="Subject Node">
 <![CDATA[<items node='urn:xmpp:mix:nodes:subject'>
   <item>
@@ -298,10 +298,13 @@
     <text xml:lang="de">Wie benutzt man Kröten</text>
   </item>
 </items>]]></example>
+      <p>
+        When a user subscribes to the Subject Node, this will cause the channel to send Subject messages to the user through the MIX Proxy.  This is done on initial user subscription and on subject change.   Clients MAY directly read the channel subject from the Subject Node using PubSub.
+      </p>
     </section3>
     <section3 topic="Participants Node" anchor="participants-node">
       <p>Each channel participant is represented as an item of the 'urn:xmpp:mix:nodes:participants' channel node. Each item is named by the bare proxy JID of the participant. For example 'coven+123456@mix.shakespeare.example' might name the node item associated with participant 'hag66@shakespeare.example'. The nick associated with the user is mandatory and is stored in the item.  The nick for each channel participant MUST be different to the nick of other participants.
-      This node may be subscribed to for jid-visible channels that permit subscription to this node - this will allow users to see changes to channel membership.
+      This node MAY be subscribed to for jid-visible channels that permit subscription to this node - this will allow users to see changes to channel membership.
       </p>
       <p>If the Participants Node is not used, information on channel participants is not shared.</p>
       <example caption="Value of Participants Node"><![CDATA[
@@ -557,10 +560,16 @@
 </iq>
 ]]></example>
   </section2>
-  <section2 topic='Discovering Participants in a Channel' anchor='disco-channel-participants'>
+  
+  <section2 topic="Determining Information about a Channel" anchor="find-channel-info">
+    <p>The Information Node contains various information about the channel that may be useful to the user.   This can be read by the user.</p>
+    <p>AUTHOR'S NOTE:  Define new protocol. Add example</p>   
+  </section2>
+  <section2 topic='Determining the Participants in a Channel' anchor='find-channel-participants'>
     <p>
+      
       Online clients in the channel are determined from the presence node.   Participants in the channel are determined from the "urn:xmpp:mix:nodes:participants" node which will give proxy JID and nick. The jidmap node is used to map to real JIDs.  </p>
-    <p>AUTHOR'S NOTE:  Add example</p>
+    <p>AUTHOR'S NOTE:  Define new protocol. Add example</p>
   </section2>
   
   
@@ -920,7 +929,7 @@
   <body>Harpier cries: 'tis time, 'tis time.</body>
 </message>
 ]]></example>
-      <p>The message comes from the channel as a standard groupchat message, compatible with MUC.  Messages are sent directly and do not use the MIX Proxy.</p>
+      <p>The message comes from the channel as a standard groupchat message, compatible with MUC.  Messages are sent directly to the channel and do not use the MIX Proxy.  Messages reflected back by the channel are addressed to the user's MIX Proxy, coming from the Full Proxy JID of the message sender.</p>
       <p>AUTHOR NOTE AND QUESTION:  Message id coming back is different in example.  This is because the reflected message uses MAM ID, which seems helpful.  However, it makes it harder for sender to correlate reflections. Need to be explicit as to compliant behaviour.  Input as to whether the ID should change is solicited.  A more complex option would be to include both IDs in some way.</p>
       <example caption="Channel Reflects Message to Participants"><![CDATA[
 <message from='coven+12345@mix.shakespeare.example/678'
@@ -938,6 +947,45 @@
       </p>
       <p>
         AUTHOR'S NOTE: Define new protocol to support this and add example. 
+      </p>
+    </section3>
+    
+    
+    <section3 topic="Setting the Channel Subject" anchor="set-subject">
+      <p>
+       Setting the subject for a channel follows a similar procedure to sending a message.   An XMPP client will send a message setting the subject directly to the MIX channel.
+      </p>
+      <example caption="User Sets Channel Subject"><![CDATA[
+<message from='hag66@shakespeare.example/pda'
+         to='coven@mix.shakespeare.example'
+         id='92vax143g'
+         type='groupchat'>
+  <subject>
+   <item>
+    <text xml:lang="en">How to use Toads</text>
+    <text xml:lang="de">Wie benutzt man Kröten</text>
+  </item>
+  </subject>
+</message>
+]]></example>    
+      <p>
+        This message is received by the MIX channel, which will set the Subject Node for the channel, and then distribute the message to participants that are subscribed to the Subject Node, with the message addressed to the MIX Proxy.
+      </p>
+      <example caption="Channel Reflects New Subject to Participants"><![CDATA[
+<message from='coven+12345@mix.shakespeare.example/678'
+         to='hecate@shakespeare.example'
+         id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
+         type='groupchat'>
+           <subject>
+            <item>
+                <text xml:lang="en">How to use Toads</text>
+               <text xml:lang="de">Wie benutzt man Kröten</text>
+            </item>
+          </subject>
+</message>
+]]></example>   
+      <p>
+        When a new Participant joins a channel and subscribes to the Subject Node, the channel MUST send to the user's MIX Proxy a message with the current subject.   An XMPP Client MAY directly read the Subject node using &xep0060;.
       </p>
     </section3>
     <section3 topic='Inviting another user to join a Channel' anchor='usecase-user-invite'>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -1204,7 +1204,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 
     <section3 topic='Sending a Message' anchor='usecase-user-message'>
-      <p>A user sends a message to a MIX channel as a standard groupchat message, in exactly the same way as for &xep0045;. </p>
+      <p>A client sends a message directly to a MIX channel as a standard groupchat message, in exactly the same way as for &xep0045;. Messages are sent directly to the channel and do not use the MIX Proxy. </p>
       <example caption="User Sends Message to Channel"><![CDATA[
 <message from='hag66@shakespeare.example/pda'
          to='coven@mix.shakespeare.example'
@@ -1213,8 +1213,11 @@ the participant is not be subscribed to all nodes associated with the channel (i
   <body>Harpier cries: 'tis time, 'tis time.</body>
 </message>
 ]]></example>
-      <p>The message comes from the channel as a standard groupchat message, compatible with MUC.  Messages are sent directly to the channel and do not use the MIX Proxy.  Messages reflected back by the channel are addressed to the user's MIX Proxy, coming from the Full Proxy JID of the message sender.</p>
-      <p>AUTHOR NOTE AND QUESTION:  Message id coming back is different in example.  This is because the reflected message uses MAM ID, which seems helpful.  However, it makes it harder for sender to correlate reflections. Need to be explicit as to compliant behaviour.  Input as to whether the ID should change is solicited.  A more complex option would be to include both IDs in some way.</p>
+      
+      <p>The MIX channel then puts a copy of the message into the MAM archive for the channel and sends a copy of  the message to each participant in 
+        standard groupchat format.    These messages sent by the channel are addressed to the bare JID of each participant and this will be handled by the participant's MIX Proxy.  The message from value is the full Proxy JID of the message sender.   The id of the message is the ID from the MAM archive.</p>
+      
+
       <example caption="Channel Reflects Message to Participants"><![CDATA[
 <message from='coven+12345@mix.shakespeare.example/678'
          to='hecate@shakespeare.example'
@@ -1223,6 +1226,23 @@ the participant is not be subscribed to all nodes associated with the channel (i
   <body>Harpier cries: 'tis time, 'tis time.</body>
 </message>
 ]]></example>
+      
+      <p>
+        The messages sent to participants have a different message id to the originally submitted message.  This does not impact most recipients, but it does not allow the message originator to correlate the message with the submitted message.   To address this the MIX channel MUST include an additional element of the message copy going back to the originator's bare JID that includes the original id.  This enables the originator to correlate the received message with the message submitted.
+      </p>
+      
+      
+      <example caption="Channel Reflects Message back to Originator"><![CDATA[
+<message from='coven+12345@mix.shakespeare.example/678'
+         to='hag66@shakespeare.example'
+         id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
+         type='groupchat'>
+  <body>Harpier cries: 'tis time, 'tis time.</body>
+  <submission-id xmlns='urn:xmpp:mix:0'>92vax143g</submission-id>
+</message>
+]]></example> 
+      
+      
     </section3>
 
     <section3 topic="Retracting a Message" anchor="usecase-retract">


### PR DESCRIPTION
xep-0369 update to 0.4

Clarification of MIX Proxy concept; Clarify node definitions; Make all nodes optional; Merge ACL node into configuration node; Add information node including avatar; Resolve 4.1 question by accepting provisional answer; Add discovery examples; setting and sharing Subject; Protocol to request channel information and participants;  vCard Request;  Private Messages 