### PR TITLE
XEP-0037: Fix double “Version” in revision history

### DIFF
--- a/xep-0037.xml
+++ b/xep-0037.xml
@@ -26,49 +26,49 @@
     <jid>bac9@jabber.org</jid>
   </author>
   <revision>
-    <version>Version 0.8</version>
+    <version>0.8</version>
     <date>2002-09-18</date>
     <initials>Bac9</initials>
     <remark>Streamlined and enhanced handshake procedure, and cleaned up document.</remark>
   </revision>
   <revision>
-    <version>Version 0.7</version>
+    <version>0.7</version>
     <date>2002-08-20</date>
     <initials>Bac9</initials>
     <remark>Added public connections and reduced number of tags.</remark>
   </revision>
   <revision>
-    <version>Version 0.6</version>
+    <version>0.6</version>
     <date>2002-08-11</date>
     <initials>Bac9</initials>
     <remark>Added data tracking, inviting peer, auto-disconnect for slow peers, elaboration on protocol and suggested example of file transfer.</remark>
   </revision>
   <revision>
-    <version>Version 0.5</version>
+    <version>0.5</version>
     <date>2002-07-29</date>
     <initials>Bac9</initials>
     <remark>Elaborated on some functionality and cleaned up XML protocol.</remark>
   </revision>
   <revision>
-    <version>Version 0.4</version>
+    <version>0.4</version>
     <date>2002-07-11</date>
     <initials>lw</initials>
     <remark>Converted to XML format.</remark>
   </revision>
   <revision>
-    <version>Version 0.3</version>
+    <version>0.3</version>
     <date>2002-06-25</date>
     <initials>Bac9</initials>
     <remark>Added support for HTTP, SSL and throughput logging. Changed relay behaviour.</remark>
   </revision>
   <revision>
-    <version>Version 0.2</version>
+    <version>0.2</version>
     <date>2002-06-21</date>
     <initials>Bac9</initials>
     <remark>Revised, standardized and extended XML protocol structure.</remark>
   </revision>
   <revision>
-    <version>Version 0.1</version>
+    <version>0.1</version>
     <date></date>
     <initials>rn</initials>
     <remark>Initial version.</remark>

--- a/xep-0037.xml
+++ b/xep-0037.xml
@@ -26,6 +26,12 @@
     <jid>bac9@jabber.org</jid>
   </author>
   <revision>
+    <version>0.8.1</version>
+    <date>2016-10-04</date>
+    <initials>egp</initials>
+    <remark><p>Made the revision’s version element include only the actual version.</p></remark>
+  </revision>
+  <revision>
     <version>0.8</version>
     <date>2002-09-18</date>
     <initials>Bac9</initials>


### PR DESCRIPTION
~~This commit explicitly doesn’t create a new version, since this XEP is
already rejected.~~