### PR TITLE
Check for dead links when building XEP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ $(OUTDIR)/%.html: %.xml $(XMLDEPS) dependencies
 	# TODO: After existing issues are worked out this and the ratcheting CI build
 	#       should be removed and become an error, not just a warning.
 	xmllint --nonet --noout --noent --loaddtd --valid "$<" || true
+	python checkdeadlinks.py -x "$<"
 	xsltproc --path $(CURDIR) xep.xsl "$<" > "$@" && echo "Finished building $@"
 
 $(OUTDIR)/%.js: %.js

--- a/checkdeadlinks.py
+++ b/checkdeadlinks.py
@@ -71,6 +71,15 @@ def is_dead(url):
         return False
 
 def get_deadlinks(xep, is_verbose=False):
+    # Support filenames (xep-0001.html) as well as numbers (1 or 0001).
+    try:
+        if xep.startswith('xep-'):
+            xep = xep[4:]
+        if '.' in xep:
+            xep = xep[0:xep.index('.')]
+    finally:
+        xep = int(xep)
+
     global xepnum
     xepnum = '%04d' % xep
 
@@ -91,7 +100,7 @@ def get_deadlinks(xep, is_verbose=False):
 def main():
     parser = ArgumentParser(description=__doc__)
     parser.add_argument('-v', '--verbose', action='store_true', help='Enables more verbosity')
-    parser.add_argument('-x', '--xep', type=int, help='Defines the number of the XEP to check')
+    parser.add_argument('-x', '--xep', help='Defines the number of the XEP to check')
     args = parser.parse_args()
 
     deadlinks = get_deadlinks(args.xep, args.verbose)


### PR DESCRIPTION
Error if building an XEP contains dead links. Affects CI and normal users building XEPs.

EDIT: CI is failing because the step is working. Existing dead links should be fixed before this is merged.
