### PR TITLE
add abilty to discover entites that add stanza-ids and follow the rules

### DIFF
--- a/xep-0359.xml
+++ b/xep-0359.xml
@@ -24,6 +24,14 @@
   <shortname>stanza-id</shortname>
   &flow;
   <revision>
+    <version>0.4</version>
+    <date>2016-10-30</date>
+    <initials>dg</initials>
+    <remark>
+      <p>Add ability to discover support</p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.3.0</version>
     <date>2016-10-29</date>
     <initials>fs</initials>
@@ -124,6 +132,29 @@
 	<li>Every &stanza-id; and &origin-id; extension element MUST always posses an 'id' attribute and MUST NOT have any child elements or text content.</li>
 	<li>The value of the 'by' attribute MUST be the XMPP address of the entity assigning the unique and stable stanza ID. Note that XMPP addresses are normalized as defined in &rfc6122;</li>
   </ol>
+</section1>
+<section1 topic='Discovering Support' anchor='disco'>
+  <p>An entity that follows the business rules, especially the rule on overriding the ID in elements where the by atttribute matches the entities own XMPP address, SHOULD announce the 'urn:xmpp:sid:0' namespace in its disco features allowing other entities to verify that those business rules are properly enforced.</p>
+  <example caption='Client sends service discovery request to server'><![CDATA[
+<iq from='romeo@montague.tld/garden'
+    id='somethingrandom'
+    to='montague.tld'
+    type='get'>
+  <query xmlns='http://jabber.org/protocol/disco#info' />
+</iq>
+]]></example>
+  <example caption='Servers includes the stanza ID namespace in its features'><![CDATA[
+<iq from='montague.tld'
+    to='romeo@montague.tld/garden'
+    id='somethingrandom'
+    type='result'>
+  <query xmlns='http://jabber.org/protocol/disco#info'>
+    …
+    <feature var='urn:xmpp:sid:0'/>
+    …
+  </query>
+</iq>
+]]></example>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
   <p>The value of the 'id' attribute should not provide any further information besides the opaque ID itself. Entities observing the value MUST NOT be able to infer any information from it, e.g. the size of the message archive. The value of 'id' MUST be considered a non-secret value.</p>

--- a/xep-0359.xml
+++ b/xep-0359.xml
@@ -164,7 +164,11 @@
 </section1>
 <section1 topic='XMPP Registrar Considerations' anchor='registrar'>
   <section2 topic='Protocol Namespaces' anchor='ns'>
-    <p>The &REGISTRAR; includes "urn:xmpp:sid:0" in its registry of protocol namespaces (see &NAMESPACES;).</p>
+    <p>This specification defines the following XML namespaces:</p>
+    <ul>
+      <li>urn:xmpp:sid:0</li>
+    </ul>
+    <p>The &REGISTRAR; shall include the foregoing namespaces in its registry of protocol namespaces (see &NAMESPACES;) and in its disco features registry (&DISCOFEATURES;) as defined in &xep0030;.</p>
   </section2>
 </section1>
 <section1 topic='XML Schema' anchor='schema'>


### PR DESCRIPTION
stanza ids are not very useful in itself if you a receiving entity can not verify that the originating entity (the one in the by attribute) did in fact add that stanza id itself. A disco features solves this problem.
