### PR TITLE
Fix tls reference in http upload xep

### DIFF
--- a/xep-0363.xml
+++ b/xep-0363.xml
@@ -145,7 +145,7 @@
     <content-type>image/jpeg</content-type>
   </request>
 </iq>]]></example>
-  <p>The upload service responds with both a PUT and a GET URL wrapped by a &lt;slot&gt; element. The service SHOULD keep the file name and especially the file ending intact. Using the same hostname for PUT and GET is OPTIONAL. The host SHOULD provide Transport Layer Security (&rfc5256;).</p>
+  <p>The upload service responds with both a PUT and a GET URL wrapped by a &lt;slot&gt; element. The service SHOULD keep the file name and especially the file ending intact. Using the same hostname for PUT and GET is OPTIONAL. The host SHOULD provide Transport Layer Security (&rfc5246;).</p>
   <example caption='The upload service responds with a slot'><![CDATA[
 <iq from='upload.montague.tld'
     id='step_03'


### PR DESCRIPTION
The reference to the TLS rfc is wrong this commit fixes that.