### PR TITLE
XEP-0313: server MAY add the id to incoming messages

### DIFF
--- a/xep-0313.xml
+++ b/xep-0313.xml
@@ -28,6 +28,14 @@
   &mwild;
   &ksmith;
   <revision>
+    <version>0.5.2</version>
+    <date>2016-10-30</date>
+    <initials>dg</initials>
+    <remark>
+      <p>Added method for server to communicate the archive id</p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.5.1</version>
     <date>2016-03-07</date>
     <initials>XEP Editor (ssw)</initials>
@@ -168,6 +176,17 @@
 	</section2>
 	<section2 topic='Querying Entities' anchor='entities'>
 		<p>While this document talks about 'clients' and 'servers', as these are the common cases, the querying entity (referred to as a 'client') need not be an XMPP client as defined by RFC6120, but could potentially be any type of entity, and the queried entity (referred to as a 'server') need not be an XMPP server as defined by RFC6120, although access controls might prohibit any given entity from being able to access an archive.</p>
+	</section2>
+	<section2 topic='Communicating the archive ID' anchor='archives_id'>
+		<p>When an incoming message is archived, the server MAY add an &lt;stanza-id/&gt; element as defined in &xep0359; to the message, which informs the client of where and under what ID the message is stored. When doing this the server MUST follow the business rules defined in XEP-0359. The 'by'-attribute MUST be set to the address of the archive. For regular users that’s the bare JID of the account and for MUC that’s the bare JID of the room.</p>
+		<p>Servers MUST NOT include the &lt;stanza-id/&gt; element in messages addressed to JIDs that do not have permissions to access the archive, such as a users’s outgoing messages to their contacts. However servers SHOULD include the element as a child of the forwarded message when using &xep0280;</p>
+		<example caption='Client receives a message that has been archived'><![CDATA[
+<message to='juliet@capulet.lit/balcony'
+	 from='romeo@montague.lit/orchard'
+         type='chat'>
+  <body>Call me but love, and I'll be new baptized; Henceforth I never will be Romeo.</body>
+  <stanza-id xmlns='urn:xmpp:sid:0' by='juliet@capulet.lit' id='28482-98726-73623' />
+</message>]]></example>
 	</section2>
 </section1>
 


### PR DESCRIPTION
Note that this PR depends on PR #270 being merged before.

This PR brings the old `<archive-id/>` back but as a `<stanza-id/>` defined in XEP-0359. This PR only influence the live incoming messages and doesn't change the syntax of regular interaction with MAM. It also doesn't include a namespace bump and is purely optional (MAY keyword). All security aspects are handled by the stanza-id XEP.

I know that the original archive-id was dropped because it doesn't have a way to communicate the id for outgoing messages but I figure it is better to have the ID half the time than never.
Ejabberd already adds the id (but with a wrong by attribute IIRC) and a patch in prosody would be extremely simple and will help clients a lot. This feature doesn't stand in the way of future refactors of the entire MAM spec which @mwild1 has been planning and is also entirely optional. I hope we can merge this to kinda bridge the gap until we have something better. 
