### PR TITLE
XEP-0053: Add deprecated status

### DIFF
--- a/xep-0053.xml
+++ b/xep-0053.xml
@@ -20,6 +20,12 @@
   <shortname>N/A</shortname>
   &stpeter;
   <revision>
+    <version>1.6</version>
+    <date>2016-11-04</date>
+    <initials>ssw</initials>
+    <remark><p>Introduce 'Deprecated' registration status.</p></remark>
+  </revision>
+  <revision>
     <version>1.5</version>
     <date>2016-05-31</date>
     <initials>fs</initials>
@@ -94,7 +100,7 @@
 </section1>
 <section1 topic='Registry Creation and Maintenance' anchor='registries'>
   <p>Every XMPP Extension Protocol specification (XEP) must contain a section devoted to "XMPP Registrar Considerations", detailing the namespaces and parameters to be registered with the XMPP Registrar, as well as any new registries to be created as a result of the XEP.</p>
-  <p>Registry entries have either a status of 'Proposed' or 'Standard'. Entries of an experimental XEP are added by the XMPP Registar to the registry in the 'Proposed' Status. The registry additions or creations specified in a XEP shall not transition to 'Standard' status until the document advances to a status of Draft (Standards-Track XEPs) or Active (Informational and Historical XEPs). Registration of namespaces shall be handled as described in the <link url='#namespaces'>Namespace Issuance</link> section of this document. Registration of particular parameters used within a specification shall be initiated by the XMPP Extensions Editor if specified in the XEP, and may also be initiated by implementors of the XEP after it has advanced to Active, Draft, or Final. Creation of new registries shall be initiated by the XMPP Registrar; if a document specifies the creation of a new registry, the author is strongly encouraged to consult with the XMPP Registrar before seeking a Last Call on the XEP.</p>
+  <p>Registry entries have a status of 'Proposed', 'Standard', or 'Deprecated'. Entries of an experimental XEP are added by the XMPP Registar to the registry in the 'Proposed' Status. The registry additions or creations specified in a XEP shall not transition to 'Standard' status until the document advances to a status of Draft (Standards-Track XEPs) or Active (Informational and Historical XEPs). When an XEP transitions to a status of 'Deprecated' or 'Obsolete' the editor will transition its registry entries to a status of 'Deprecated'. Registration of namespaces shall be handled as described in the <link url='#namespaces'>Namespace Issuance</link> section of this document. Registration of particular parameters used within a specification shall be initiated by the XMPP Extensions Editor if specified in the XEP, and may also be initiated by implementors of the XEP after it has advanced to Active, Draft, or Final. Creation of new registries shall be initiated by the XMPP Registrar; if a document specifies the creation of a new registry, the author is strongly encouraged to consult with the XMPP Registrar before seeking a Last Call on the XEP.</p>
   <p>Requests for parameter assignments must be sent to the XMPP Registrar in accordance with the process specified in the document (usually a XEP) that defines the relevant registry, normally by sending an appropriately formatted email message to the URI &lt;mailto:registrar&#64;xmpp.org&gt;. If, in the Registrar's judgment, discussion of a request is required, the Registrar shall initiate such discussion within the &SSIG;. The Registrar shall add registry items at its discretion based on discussion within the Standards SIG if necessary, but shall not unduly restrict registration of parameter values. If a document author or implementor thinks that a request was unfairly denied by the Registrar, an appeal of the decision may be directed to the XMPP Council.</p>
   <p>The XMPP Registrar shall maintain registries of assigned namespaces and parameters at &lt;<link url="http://www.xmpp.org/registrar/">http://www.xmpp.org/registrar/</link>&gt; and shall update those registries in a timely fashion. Changes to the registries shall be announced on the &lt;standards&#64;xmpp.org&gt; mailing list.</p>
 </section1>


### PR DESCRIPTION
I'm not sure if this is desirable or not, but I noticed a lot of registry entries have "(DEPRECATED)" at the end of their name or description. This adds deprecated as an official status which could work in the same way xsf/registrar#12 adds the proposed status, giving us a consitsent way to mark registry entry status'.