### PR TITLE
XEP-0124: Fix typo and DTD

### DIFF
--- a/xep-0124.xml
+++ b/xep-0124.xml
@@ -12,7 +12,8 @@
     <number>0124</number>
     <status>Draft</status>
     <type>Standards Track</type>
-    <jig>Standards</jig>
+    <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies>
       <spec>RFC 1945</spec>
       <spec>RFC 2616</spec>
@@ -498,7 +499,7 @@ Content-Length: 69
 <body ack='1249243564'
       xmlns='http://jabber.org/protocol/httpbind'/>]]></example>
       <p>If the connection manager will be including 'ack' attributes on responses during a session, then it MUST include an 'ack' attribute in its session creation response, and set the 'ack' attribute of responses throughout the session. The only exception is that, after its session creation response, the connection manager SHOULD NOT include an 'ack' attribute in any response if the value would be the 'rid' of the request being responded to.</p>
-      <p>If the connection manager is permitted to hold more than one request at a time, then the reception of a lower-than-expected 'ack' value from the connection manager (or the unexpected abscence of an 'ack' attribute) can give the client an early warning that a network failure might have occurred (e.g., if the client believes the connection manager should have received another request by the time it responded).</p>
+      <p>If the connection manager is permitted to hold more than one request at a time, then the reception of a lower-than-expected 'ack' value from the connection manager (or the unexpected absence of an 'ack' attribute) can give the client an early warning that a network failure might have occurred (e.g., if the client believes the connection manager should have received another request by the time it responded).</p>
     </section2>
     <section2 topic='Response Acknowledgements' anchor='ack-response'>
       <p>The client MAY similarly inform the connection manager about the responses it has received by setting the 'ack' attribute of any request to the value of the highest 'rid' of a request for which it has already received a response in the case where it has also received all responses associated with lower 'rid' values. If the client will be including 'ack' attributes on requests during a session, then it MUST include an 'ack' attribute (set to '1') in its session creation request, and set the 'ack' attribute of requests throughout the session. The only exception is that, after its session creation request, the client SHOULD NOT include an 'ack' attribute in any request if it has received responses to all its previous requests.</p>


### PR DESCRIPTION
Editorial change, but it's to a draft document. As usual, I cannot remember what that means despite the fact that I do this every time.