### PR TITLE
Add ratcheting DTD checking to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
-script: make all
-
 addons:
   apt:
     packages:
       - xsltproc
+      - libxml2-utils
+before_install:
+  - wget -O git-ratchet https://github.com/iangrunert/git-ratchet/releases/download/v0.3.1/linux_amd64_git-ratchet
+  - chmod +x git-ratchet
+  - git fetch https://github.com/xsf/xeps.git refs/notes/*:refs/notes/*
+script:
+  - make all
+  - echo "lint,$(xmllint --nonet --noout --noent --loaddtd --valid *.xml 2>&1 | wc -l)" | ./git-ratchet check -v

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ xep-%.html: $(OUTDIR)/xep-%.html ;
 dependencies: $(OUTDIR)/prettify.css $(OUTDIR)/prettify.js $(OUTDIR)/xmpp.css ;
 
 $(OUTDIR)/%.html: %.xml $(XMLDEPS) dependencies
+	# TODO: After existing issues are worked out this and the ratcheting CI build
+	#       should be removed and become an error, not just a warning.
+	xmllint --nonet --noout --noent --loaddtd --valid "$<" || true
 	xsltproc --path $(CURDIR) xep.xsl "$<" > "$@" && echo "Finished building $@"
 
 $(OUTDIR)/%.js: %.js


### PR DESCRIPTION
This runs `xmllint` against all XEPs, but only fails the build if *new* issues were introduced (to prevent all builds failing until the ~4000 something existing issues are fixed).

Currently fixes to existing issues require that the number of open problems be manually updated, this can be done by installing [git-ratchet](https://github.com/iangrunert/git-ratchet) and then doing something like this:

```sh
echo "lint,$(xmllint --nonet --noout --noent --loaddtd --valid *.xml 2>&1 | wc -l)" | git-ratchet check -v -w
git push https://github.com/xsf/registrar.git refs/notes/*:refs/notes/*
```

(or replace the URL with `upstream` or `origin` or whatever points to the xsf version of this repo for you)

CI could also update this when you merge to master, but I don't have access to create a deploy key to let it push changes back to this repo.