### PR TITLE
XEP-0050, XEP-0055: Schema, DTD, and whitespace

### DIFF
--- a/xep-0050.xml
+++ b/xep-0050.xml
@@ -15,7 +15,7 @@
   <sig>Standards</sig>
   <dependencies>
     <spec>XMPP Core</spec>
-    <spec dep='SHOULD'>XEP-0004</spec>
+    <spec>XEP-0004</spec>
     <spec>XEP-0030</spec>
   </dependencies>
   <supersedes/>
@@ -548,10 +548,10 @@
 </iq>
     ]]></example>
     <example caption="Execute command result (with language/locale)"><![CDATA[
-<iq type='result' 
-    from='responder@domain' 
-    to='requester@domain' 
-    id='exec1' 
+<iq type='result'
+    from='responder@domain'
+    to='requester@domain'
+    id='exec1'
     xml:lang='en-us'>
   <command xmlns='http://jabber.org/protocol/commands'
            sessionid='list:20020923T213616Z-700'
@@ -936,7 +936,7 @@ xmpp:montague.net?command;node=stats
       <xs:attribute ref='xml:lang' use='optional'/>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name='actions'>
     <xs:complexType>
       <xs:sequence>
@@ -955,12 +955,12 @@ xmpp:montague.net?command;node=stats
       </xs:attribute>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name='note'>
     <xs:complexType>
       <xs:simpleContent>
         <xs:extension base='xs:string'>
-          <xs:attribute name='type' use='required'>
+          <xs:attribute name='type' use='optional'>
             <xs:simpleType>
               <xs:restriction base='xs:NCName'>
                 <xs:enumeration value='error'/>

--- a/xep-0050.xml
+++ b/xep-0050.xml
@@ -26,6 +26,12 @@
   </schemaloc>
   &linuxwolf;
   <revision>
+    <version>1.2.2</version>
+    <date>2016-12-03</date>
+    <initials>XEP Editor (ssw, fs)</initials>
+    <remark>Mark 'note' element's 'type' attribute as optional in the schema. Introduce 'Acknowledgements' section.</remark>
+  </revision>
+  <revision>
     <version>1.2.1</version>
     <date>2015-10-15</date>
     <initials>XEP Editor (mam)</initials>
@@ -990,4 +996,10 @@ xmpp:montague.net?command;node=stats
 </xs:schema>
   ]]></code>
 </section1>
+
+<section1 topic='Acknowledgements' anchor='acks'>
+  <p>Many thanks to Florian Schmaus, Christian Schudt and Anno van Vliet
+  for their input and feedback on this specification.</p>
+</section1>
+
 </xep>

--- a/xep-0055.xml
+++ b/xep-0055.xml
@@ -15,7 +15,7 @@
   <sig>Standards</sig>
   <dependencies>
     <spec>XMPP Core</spec>
-    <spec dep="SHOULD">XEP-0004</spec>
+    <spec>XEP-0004</spec>
   </dependencies>
   <supersedes/>
   <supersededby/>


### PR DESCRIPTION
Fix issues with XEP-0050's schema (https://trello.com/c/6PHfEitZ/139-xep-0050-inconsistency) and clean up some whitespace and DTD issues as well, one of which also occured in 0055.