### PR TITLE
XEP-0375: Add e2e encryption to compliance suites and remove MIX

### DIFF
--- a/xep-0375.xml
+++ b/xep-0375.xml
@@ -6,9 +6,9 @@
 <?xml-stylesheet type='text/xsl' href='xep.xsl'?>
 <xep>
   <header>
-    <title>XMPP Compliance Suites 2016</title>
+    <title>XMPP Compliance Suites 2017</title>
     <abstract>
-      This document defines XMPP protocol compliance levels for 2016.
+      This document defines XMPP protocol compliance levels for 2017.
     </abstract>
     &LEGALNOTICE;
     <number>0375</number>
@@ -39,15 +39,16 @@
       <spec>XEP-0270</spec>
     </supersedes>
     <supersededby/>
-    <shortname>CS2016</shortname>
+    <shortname>CS2017</shortname>
     &stpeter;
     &sam;
     <revision>
       <version>0.4</version>
-      <date>2016-12-29</date>
+      <date>2016-12-31</date>
       <initials>ssw</initials>
       <remark>
         <ul>
+          <li>Update compliance suite year to 2017.</li>
           <li>Add OMEMO encryption to IM suite.</li>
           <li>Remove MIX until it's ready.</li>
         </ul>
@@ -94,7 +95,7 @@
   <section1 topic='Introduction' anchor='intro'>
     <p>
       The &XSF; defines protocol suites for the purpose of compliance testing
-      and software certification. This document specifies the 2016 compliance
+      and software certification. This document specifies the 2017 compliance
       levels for XMPP clients and servers; it is hoped that this document will
       advance the state of the art, and provide guidence and eventual
       certification to XMPP client and server authors. Unless explicitly noted,
@@ -103,7 +104,7 @@
   </section1>
   <section1 topic='Compliance Levels' anchor='levels'>
     <section2 topic='Core Compliance Suite' anchor='core'>
-      <table caption='XMPP Core Compliance Levels for 2016'>
+      <table caption='XMPP Core Compliance Levels'>
         <tr>
           <th>Feature</th>
           <th>Core Server</th>
@@ -167,7 +168,7 @@
         To be considered XMPP web compliant, all line items from the core
         compliance suite above must be met, as well as all items in this suite.
       </p>
-      <table caption='XMPP Web Compliance Levels for 2016'>
+      <table caption='XMPP Web Compliance Levels'>
         <tr>
           <th>Feature</th>
           <th>Core Server</th>
@@ -191,7 +192,7 @@
         To be considered XMPP IM compliant, all line items from the core
         compliance suite above must be met, as well as all items in this suite.
       </p>
-      <table caption='XMPP IM Compliance Levels for 2016'>
+      <table caption='XMPP IM Compliance Levels'>
         <tr>
           <th>Feature</th>
           <th>Core Server</th>
@@ -287,7 +288,7 @@
         To be considered XMPP mobile compliant, all line items from the core
         compliance suite above must be met, as well as all items in this suite.
       </p>
-      <table caption='XMPP Mobile Compliance Levels for 2016'>
+      <table caption='XMPP Mobile Compliance Levels'>
         <tr>
           <th>Feature</th>
           <th>Core Server</th>

--- a/xep-0375.xml
+++ b/xep-0375.xml
@@ -43,6 +43,17 @@
     &stpeter;
     &sam;
     <revision>
+      <version>0.4</version>
+      <date>2016-12-29</date>
+      <initials>ssw</initials>
+      <remark>
+        <ul>
+          <li>Add OMEMO encryption to IM suite.</li>
+          <li>Remove MIX until it's ready.</li>
+        </ul>
+      </remark>
+    </revision>
+    <revision>
       <version>0.3</version>
       <date>2016-07-20</date>
       <initials>ssw</initials>
@@ -55,12 +66,10 @@
       <date>2016-07-11</date>
       <initials>ssw</initials>
       <remark>
-        <p>
-          <ul>
-            <li>Add rationale.</li>
-            <li>Refactor suites to focus less on XEPs and more on features.</li>
-          </ul>
-        </p>
+        <ul>
+          <li>Add rationale.</li>
+          <li>Refactor suites to focus less on XEPs and more on features.</li>
+        </ul>
       </remark>
     </revision>
     <revision>
@@ -229,7 +238,7 @@
           <td align='center'>&#10003;&#x2021;</td>
           <td align='center'>&#10003;&#x2020;</td>
           <td align='center'>&#10003;&#x2021;</td>
-          <td>&xep0045;; &xep0369;</td>
+          <td>&xep0045;</td>
         </tr>
         <tr>
           <td><strong>Bookmarks</strong></td>
@@ -262,6 +271,14 @@
           <td align='center'>&#10003;</td>
           <td align='center'>&#10003;</td>
           <td>&xep0313;</td>
+        </tr>
+        <tr>
+          <td><strong>End-to-End Encryption</strong></td>
+          <td align='center'>&#10003;</td>
+          <td align='center'>&#10003;</td>
+          <td align='center'>&#10003;</td>
+          <td align='center'>&#10003;</td>
+          <td>&xep0384;</td>
         </tr>
       </table>
     </section2>


### PR DESCRIPTION
Adds End-to-End encryption to the compliance suites for instant messaging with OMEMO as the only provider (in my mind not all use cases for XMPP need e2e encryption, so I didn't add it to the core suites).

Also removes MIX; I'm still torn about this, but it seems like most of the community wanted it removed for now.

This also bumps the year to 2017.