### PR TITLE
Add PDF generation back to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ target/
 Session.vim
 .netrwhist
 *~
+
+*.pdf

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ help:
 	@echo '                 clean  -  recursively unlink the build tree'
 	@echo '               preview  -  builds html whenever an XEP changes (requires inotify-tools)'
 	@echo '              xep-xxxx  -  build xep-xxxx.html'
+	@echo '          xep-xxxx.pdf  -  build xep-xxxx.pdf (requires xelatex and texml)'
 	@echo '         xep-xxxx.html  -  build xep-xxxx.html'
 	@echo ' '
 	@echo 'Output directory: "$(OUTDIR)/"'
@@ -29,11 +30,17 @@ all: html
 .PHONY: html
 html: $(patsubst %.xml, $(OUTDIR)/%.html, $(wildcard *.xml))
 
+.PHONY: pdf
+pdf: $(patsubst %.xml, $(OUTDIR)/%.pdf, $(wildcard *.xml))
+
 .PHONY: xep-%
 xep-%: $(OUTDIR)/xep-%.html ;
 
 .PHONY: xep-%.html
 xep-%.html: $(OUTDIR)/xep-%.html ;
+
+.PHONY: xep-%.pdf
+xep-%.pdf: $(OUTDIR)/xep-%.pdf ;
 
 .PHONY: dependencies
 dependencies: $(OUTDIR)/prettify.css $(OUTDIR)/prettify.js $(OUTDIR)/xmpp.css ;
@@ -44,8 +51,23 @@ $(OUTDIR)/%.html: %.xml $(XMLDEPS) dependencies
 	xmllint --nonet --noout --noent --loaddtd --valid "$<" || true
 	# Check for non-data URIs
 	! xmllint --nonet --noout --noent --loaddtd --xpath "//img/@src[not(starts-with(., 'data:'))]" $< 2>/dev/null && true
+
 	# Actually build the HTML
 	xsltproc --path $(CURDIR) xep.xsl "$<" > "$@" && echo "Finished building $@"
+
+$(OUTDIR)/%.pdf: %.xml $(XMLDEPS) dependencies
+	# TODO: After existing issues are worked out this and the ratcheting CI build
+	#       should be removed and become an error, not just a warning.
+	xmllint --nonet --noout --noent --loaddtd --valid "$<" || true
+	# Check for non-data URIs
+	! xmllint --nonet --noout --noent --loaddtd --xpath "//img/@src[not(starts-with(., 'data:'))]" $< 2>/dev/null && true
+
+	xsltproc --path $(CURDIR) xep2texml.xsl "$<" > "$(@:.pdf=.tex.xml)"
+	texml -e utf8 "$(@:.pdf=.tex.xml)" "$(@:.pdf=.tex)"
+	sed -i -e 's|\([\s"]\)\([^"]http://[^ "]*\)|\1\\path{\2}|g' \
+		-e 's|\\hyperref\[#\([^}]*\)\]|\\hyperref\[\1\]|g' \
+		-e 's|\\pageref{#\([^}]*\)}|\\pageref{\1}|g' "$(@:.pdf=.tex)"
+	cd $(OUTDIR); xelatex -interaction=batchmode -no-shell-escape "$(notdir $(basename $@)).tex" && echo "Finished building $@"
 
 $(OUTDIR)/%.js: %.js
 	cp "$<" "$@"


### PR DESCRIPTION
Adds a make target for `xep-xxxx.pdf` and gitignores pdf files in the main directory.

Something similar to this was removed a while back, but I'm not sure why. Would anyone complain if I added it back?