### PR TITLE
Use LaTeX makeglossary tool during PDF generation

### DIFF
--- a/xep-0383.xml
+++ b/xep-0383.xml
@@ -50,31 +50,31 @@
     is (optionally) locally authenticated.
   </p>
 </section1>
-<section1 topic='Glossary' anchor='glossary'>
+<glossary>
   <dl>
     <di>
       <dt>Burner JID</dt>
       <dd>
         A temporary JID that is not valid for the purpose of authentication but
-        which may be authorized by an existing pre-authenticated session.
+        which may be authorized by an existing pre-authenticated session
       </dd>
     </di>
     <di>
       <dt>Ephemeral identity</dt>
       <dd>
         The identity of a user on the server comprising a burner JID and any
-        other associated data.
+        other associated data
       </dd>
     </di>
     <di>
       <dt>Authentication identity</dt>
       <dd>
         The users normal identity and JID which they use to authenticate with
-        the server and create new XMPP sessions.
+        the server and create new XMPP sessions
       </dd>
     </di>
   </dl>
-</section1>
+</glossary>
 <section1 topic='Use Cases' anchor='usecases'>
   <ul>
     <li>

--- a/xep.dtd
+++ b/xep.dtd
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 -->
 
-<!ELEMENT xep ( header, section1* ) >
+<!ELEMENT xep ( header, (glossary?, section1)* ) >
 <!ATTLIST xep
           xmlns CDATA '' >
 <!ELEMENT header ( title, abstract, legal, number, status, lastcall*, interim*, type, sig, approver*, dependencies, supersedes, supersededby, shortname, schemaloc*, registry?, discuss?, expires?, author+, revision+, councilnote? ) >
@@ -111,6 +111,7 @@ THE SOFTWARE.
 <!ATTLIST li
           class CDATA ''
           style CDATA '' >
+<!ELEMENT glossary (dl) >
 <!ELEMENT dl (di+) >
 <!ELEMENT di ( dt, dd ) >
 <!ELEMENT dt (#PCDATA)* >

--- a/xep.xsl
+++ b/xep.xsl
@@ -2,30 +2,30 @@
 
 <!--
 
-Copyright (c) 1999 - 2015 XMPP Standards Foundation
+Copyright (c) 1999–2017 XMPP Standards Foundation
 
-Permission is hereby granted, free of charge, to any 
-person obtaining a copy of this software and 
-associated documentation files (the "Software"), to 
-deal in the Software without restriction, including 
-without limitation the rights to use, copy, modify, 
-merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom 
-the Software is furnished to do so, subject to the 
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and
+associated documentation files (the "Software"), to
+deal in the Software without restriction, including
+without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom
+the Software is furnished to do so, subject to the
 following conditions:
 
-The above copyright notice and this permission notice 
-shall be included in all copies or substantial portions 
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
 of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF 
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT 
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
-ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN 
-ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 OR OTHER DEALINGS IN THE SOFTWARE.
 
 -->
@@ -218,7 +218,7 @@ OR OTHER DEALINGS IN THE SOFTWARE.
         <!-- END FRONT MATTER -->
         <!-- BEGIN XEP CONTENTS -->
         <hr />
-        <xsl:apply-templates select='/xep/section1'/>
+        <xsl:apply-templates select='/xep/section1 | /xep/glossary'/>
         <!-- END XEP CONTENTS -->
         <!-- BEGIN APPENDICES -->
         <hr />
@@ -429,7 +429,7 @@ OR OTHER DEALINGS IN THE SOFTWARE.
   <xsl:template name='processTOC'>
     <h2>Table of Contents</h2>
     <div class='indent'>
-    <p><xsl:apply-templates select='//section1' mode='toc'/></p>
+    <p><xsl:apply-templates select='//section1 | //glossary' mode='toc'/></p>
     <p><a href='#appendices'>Appendices</a>
       <br />&#160;&#160;&#160;&#160;<a href="#appendix-docinfo">A: Document Information</a>
       <br />&#160;&#160;&#160;&#160;<a href="#appendix-authorinfo">B: Author Information</a>
@@ -442,7 +442,7 @@ OR OTHER DEALINGS IN THE SOFTWARE.
     </p>
     </div>
   </xsl:template>
-  
+
   <xsl:template match='councilnote'>
     <hr />
     <div>
@@ -566,7 +566,7 @@ OR OTHER DEALINGS IN THE SOFTWARE.
       <xsl:value-of select='@anchor'/>
     </xsl:variable>
     <xsl:variable name='num'>
-      <xsl:number level='multiple' count='section1'/><xsl:text>.</xsl:text>
+      <xsl:number level='multiple' count='section1|glossary'/><xsl:text>.</xsl:text>
     </xsl:variable>
     <xsl:variable name='sect2.count' select='count(section2)'/>
     <br />
@@ -593,6 +593,21 @@ OR OTHER DEALINGS IN THE SOFTWARE.
     </xsl:if>
   </xsl:template>
 
+  <xsl:template match='glossary' mode='toc'>
+    <xsl:variable name='oid'>
+      <xsl:call-template name='object.id'/>
+    </xsl:variable>
+    <xsl:variable name='num'>
+      <xsl:number level='multiple' count='section1|glossary'/><xsl:text>.</xsl:text>
+    </xsl:variable>
+    <br />
+      <xsl:value-of select='$num'/> <xsl:text>  </xsl:text>
+      <a>
+        <xsl:attribute name='href'>#glossary</xsl:attribute>
+        Glossary
+      </a>
+  </xsl:template>
+
   <xsl:template match='section1'>
     <xsl:variable name='oid'>
       <xsl:call-template name='object.id'/>
@@ -601,7 +616,7 @@ OR OTHER DEALINGS IN THE SOFTWARE.
       <xsl:value-of select='@anchor'/>
     </xsl:variable>
     <h2>
-      <xsl:number level='single' count='section1'/>.
+      <xsl:number level='single' count='section1|glossary'/>.
       <xsl:text> </xsl:text>
       <a>
         <xsl:attribute name='name'>
@@ -615,6 +630,21 @@ OR OTHER DEALINGS IN THE SOFTWARE.
           </xsl:choose>
         </xsl:attribute>
         <xsl:value-of select='@topic' />
+      </a>
+    </h2>
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match='glossary'>
+    <xsl:variable name='oid'>
+      <xsl:call-template name='object.id'/>
+    </xsl:variable>
+    <h2>
+      <xsl:number level='single' count='section1|glossary'/>.
+      <xsl:text> </xsl:text>
+      <a>
+        <xsl:attribute name='name'>glossary</xsl:attribute>
+        Glossary
       </a>
     </h2>
     <xsl:apply-templates/>

--- a/xep2texml.xsl
+++ b/xep2texml.xsl
@@ -24,8 +24,8 @@
   * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
   * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
   * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  
-	Thanks to the XSLT Standard Library http://xsltsl.sourceforge.net/.
+
+  Thanks to the XSLT Standard Library http://xsltsl.sourceforge.net/.
 -->
 
 <!--<xsl:include href="xsltsl/string.xsl"/>-->
@@ -33,7 +33,7 @@
 
 <!-- Create a variable named $maxXEPVersiom containing the MAX version -->
 <xsl:variable name="maxXEPVersion">
-	<xsl:value-of select='/xep/header/revision[position()=1]/version'/>
+  <xsl:value-of select='/xep/header/revision[position()=1]/version'/>
 </xsl:variable>
 
 <!-- Create a variable named $maxXEPDate containing the MAX date -->
@@ -70,14 +70,14 @@
 \KOMAoptions{paper=a4}
 
 \usepackage[
-	pdftitle={XEP-<xsl:value-of select="/xep/header/number"/>: <xsl:value-of select="/xep/header/title"/>},
-	pdfauthor={XMPP Standards Foundation},
-	pdfcreator={XEP2PDF},
-	pdfproducer={XEP2PDF},
-	breaklinks = true, 
-	unicode, 
-	pagebackref, 
-	xetex]{hyperref}
+  pdftitle={XEP-<xsl:value-of select="/xep/header/number"/>: <xsl:value-of select="/xep/header/title"/>},
+  pdfauthor={XMPP Standards Foundation},
+  pdfcreator={XEP2PDF},
+  pdfproducer={XEP2PDF},
+  breaklinks = true,
+  unicode,
+  pagebackref,
+  xetex]{hyperref}
 
 % break URLs at more places
 \renewcommand{\UrlBreaks}{\do\/\do\a\do\b\do\c\do\d\do\e\do\f\do\g\do\h\do\i\do\j\do\k\do\l\do\m\do\n\do\o\do\p\do\q\do\r\do\s\do\t\do\u\do\v\do\w\do\x\do\y\do\z\do\A\do\B\do\C\do\D\do\E\do\F\do\G\do\H\do\I\do\J\do\K\do\L\do\M\do\N\do\O\do\P\do\Q\do\R\do\S\do\T\do\U\do\V\do\W\do\X\do\Y\do\Z\do\0\do\1}
@@ -93,6 +93,7 @@
 \usepackage{titletoc}
 \usepackage{float}
 \usepackage{adjustbox}
+<xsl:if test="glossary">\usepackage[toc,nonumberlist]{glossaries}</xsl:if>
 
 \usepackage{hyphenat}
 
@@ -131,9 +132,10 @@
 \begin{center}\LARGE
 }
 
+<xsl:if test="glossary">\makeglossaries</xsl:if>
 \sloppy
     </TeXML>
-    
+
     <cmd name="title" nl2="1">
       <parm>XEP-<cmd name="XEPNumber" />: <xsl:value-of select="/xep/header/title"/></parm>
     </cmd>
@@ -153,19 +155,18 @@
     <env name="document">
       <TeXML escape="0">
         <cmd name="lstset">
-			<parm>language=XML,
-				breaklines=true,
-				emptylines=5,
-				frame=single,
-				rulecolor=\color{black},
-				basicstyle=\ttfamily\small\color{darkgray},
-				keywordstyle=\color{cyan},
-				stringstyle=\color{blue},
-				tagstyle=\color{purple},
-				markfirstintag=true
-			</parm>
+          <parm>language=XML,
+            breaklines=true,
+            emptylines=5,
+            frame=single,
+            rulecolor=\color{black},
+            basicstyle=\ttfamily\small\color{darkgray},
+            keywordstyle=\color{cyan},
+            stringstyle=\color{blue},
+            tagstyle=\color{purple},
+            markfirstintag=true
+          </parm>
         </cmd>
-        
       </TeXML>
       <cmd name="KOMAoptions"><parm>DIV=24</parm></cmd>
       <cmd name="pagestyle"><parm>empty</parm></cmd>
@@ -177,7 +178,7 @@
       <cmd name="textbf"><parm>Status</parm></cmd> &amp; <cmd name="textbf"><parm>Type</parm></cmd> &amp; <cmd name="textbf"><parm>Short Name</parm></cmd> \\
         <xsl:value-of select="/xep/header/status"/> &amp; <xsl:value-of select="/xep/header/type"/> &amp; <TeXML escape="1"><xsl:value-of select="/xep/header/shortname"/></TeXML>
       </TeXML>
-      </env>  
+      </env>
       </env>
       <env name="abstract">
         <xsl:value-of select="/xep/header/abstract"/>
@@ -196,6 +197,8 @@
       <cmd name="pagestyle" nl2="1"><parm>fancy</parm></cmd>
       <cmd name="setcounter" nl2="1"><parm>page</parm><parm>1</parm></cmd>
       <xsl:apply-templates/>
+      <xsl:if test="glossary"><cmd name="glsaddall"/></xsl:if>
+      <xsl:if test="glossary"><cmd name="printglossaries"/></xsl:if>
     </env>
   </TeXML>
 </xsl:template>
@@ -340,27 +343,27 @@
 <xsl:template match="li">
   <TeXML escape="1" emptylines="1">
   <cmd name="item" /> <xsl:apply-templates/><xsl:text>
-  
+
   </xsl:text>
   </TeXML>
 </xsl:template>
 
 <!-- ul -->
-<xsl:template match="ul">  
+<xsl:template match="ul">
   <env name="itemize">
     <xsl:apply-templates/>
   </env>
-</xsl:template>  
+</xsl:template>
 
 <!-- ol -->
-<xsl:template match="ol">  
+<xsl:template match="ol">
   <env name="enumerate">
     <xsl:apply-templates/>
   </env>
 </xsl:template>
 
 <!-- dl -->
-<xsl:template match="dl">  
+<xsl:template match="dl">
   <env name="description">
     <xsl:apply-templates/>
   </env>
@@ -370,38 +373,38 @@
 <xsl:template match="di">
   <TeXML escape="1" emptylines="1">
   <cmd name="item"><opt><xsl:value-of select="./dt" /></opt></cmd>
-	<xsl:text>
+  <xsl:text>
   </xsl:text>
-	<xsl:value-of select="./dd" /> 
+  <xsl:value-of select="./dd" />
   </TeXML>
 </xsl:template>
-  
-<!-- example -->                               
-<xsl:template match="example">                   
-    <env name="lstlisting">                         
+
+<!-- example -->
+<xsl:template match="example">
+    <env name="lstlisting">
       <opt>caption=<group><TeXML escape="1"><xsl:value-of select="@caption"/></TeXML></group></opt>
       <TeXML escape="0" emptylines="1">
-      <xsl:apply-templates />     
+      <xsl:apply-templates />
       </TeXML>
-    </env>                                                  
-</xsl:template>      
+    </env>
+</xsl:template>
 
 <xsl:template match="br">
   <!--<cmd name="newline" gr="0"/>-->
-  
+
 </xsl:template>
 
-<!-- code -->                               
+<!-- code -->
 <xsl:template match="code">
   <xsl:if test='@class = "inline"'>
     <cmd name='path'><parm><TeXML escape="0"><xsl:value-of select="."/></TeXML></parm></cmd>
   </xsl:if>
   <xsl:if test='not(@class)'>
-    <env name="lstlisting">              
+    <env name="lstlisting">
     <TeXML escape="0" emptylines="1" ligatures="1">
       <xsl:value-of select="."/>
     </TeXML>
-    </env>                          
+    </env>
   </xsl:if>
 </xsl:template>
 
@@ -446,6 +449,25 @@
   <xsl:apply-templates />
 </xsl:template>
 
+<!-- glossary -->
+<xsl:template match="glossary">
+  <xsl:apply-templates select="dl" mode="glossary"/>
+</xsl:template>
 
+<xsl:template match="dl" mode="glossary">
+  <xsl:apply-templates select="di" mode="glossary"/>
+</xsl:template>
+
+<xsl:template match="di" mode="glossary">
+  <TeXML escape="1" emptylines="1">
+    <cmd name="newglossaryentry">
+      <parm><xsl:value-of select="./dt" /></parm>
+      <parm>
+          name=<xsl:value-of select="./dt" />,
+          description=<group><xsl:value-of select="./dd" /></group>
+      </parm>
+    </cmd>
+  </TeXML>
+</xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Experimenting with using actual LaTeX glossaries for PDF generation. I'm not 100% sure that there's a point to this, but it was good for figuring out how the build process worked. It might be nice for eventually being able to generate a global glossary PDF from all XEPs…

This adds a optional &lt;glossary&gt; node which looks exactly like a &lt;section1&gt; node in the HTML, but is converted to a LaTeX glossary for the PDF. The only thing that is valid in the glossary is a &lt;dl&gt;.