### PR TITLE
XEP-0153 and XEP-0008 are superseded by XEP-0084

### DIFF
--- a/xep-0008.xml
+++ b/xep-0008.xml
@@ -19,7 +19,7 @@
     <spec>XMPP IM</spec>
   </dependencies>
   <supersedes/>
-  <supersededby/>
+  <supersededby><spec>XEP-0084</spec></supersededby>
   <shortname>None</shortname>
   &temas;
   &xvirge;

--- a/xep-0153.xml
+++ b/xep-0153.xml
@@ -7,10 +7,15 @@
 <xep>
 <header>
   <title>vCard-Based Avatars</title>
-  <abstract>This document provides historical documentation of a vCard-based protocol for exchanging user avatars.</abstract>
+  <abstract>
+    This document provides historical documentation of a vCard-based protocol
+    for exchanging user avatars.
+    Note well: Implementation of this specification is not recommended except
+    for backwards compatibility as it has been superseded by XEP-0084.
+  </abstract>
   &LEGALNOTICE;
   <number>0153</number>
-  <status>Active</status>
+  <status>Obsolete</status>
   <type>Historical</type>
   <sig>Standards</sig>
   <approver>Council</approver>
@@ -20,12 +25,18 @@
     <spec>XEP-0054</spec>
   </dependencies>
   <supersedes/>
-  <supersededby/>
+  <supersededby><spec>XEP-0084</spec></supersededby>
   <shortname>vcard-avatar</shortname>
   <schemaloc>
     <url>http://www.xmpp.org/schemas/vcard-avatar.xsd</url>
   </schemaloc>
   &stpeter;
+  <revision>
+    <version>1.1</version>
+    <date>2017-01-08</date>
+    <initials>ssw</initials>
+    <remark>Obsolete in favor of XEP-0084.</remark>
+  </revision>
   <revision>
     <version>1.0</version>
     <date>2006-08-16</date>


### PR DESCRIPTION
Changes the status of XEP-0153 to "Obsolete" so that it will stop showing up in the list and people will stop implementing it (XEP-0084 was already marked as superseding it).

Also fixes the 'supersededby' element in both 0153 and 0008.

Trello: https://trello.com/c/Ka3zzdG1
Mailing list: https://mail.jabber.org/pipermail/standards/2017-January/031832.html