### PR TITLE
XEP-0363, 0369: typo fixes

### DIFF
--- a/xep-0363.xml
+++ b/xep-0363.xml
@@ -29,6 +29,12 @@
     <jid>daniel@gultsch.de</jid>
   </author>
   <revision>
+    <version>0.2.5</version>
+    <date>2017-01-08</date>
+    <initials>XEP Editor: ssw</initials>
+    <remark><p>Merge typo fixes suggested by an unnamed user.</p></remark>
+  </revision>
+  <revision>
     <version>0.2.4</version>
     <date>2016-10-28</date>
     <initials>dg (XEP Editor: ssw)</initials>
@@ -91,13 +97,13 @@
 <section1 topic='Requirements' anchor='reqs'>
   <ul>
     <li>Be as easy to implement as possible. This is grounded on the idea that most programming languages already have HTTP libraries available.</li>
-    <li>Be agnostic toward the distribution of the actual URL. Users can choose to send the URL in the body of a message stanza, utilize &xep0066; or even use it as their avatar in &xep0084;</li>
+    <li>Be agnostic toward the distribution of the actual URL. Users can choose to send the URL in the body of a message stanza, utilize &xep0066;, or even use it as their avatar in &xep0084;.</li>
     <li>Do not provide any kind of access control or security beyond Transport Layer Security in form of HTTPS and long random paths that are impossible to guess. That means everyone who knows the URL SHOULD be able to access it.</li>
   </ul>
 </section1>
 <section1 topic='Discovering Support' anchor='disco'>
   <p>An entity advertises support for this protocol by including the "urn:xmpp:http:upload" in its service discovery information features as specified in &xep0030; or section 6.3 of &xep0115;. To avoid unnecessary round trips an entity SHOULD also include the maximum file size as specified in &xep0128; if such a limitation exists. The field name MUST be "max-file-size" and the value MUST be in bytes.</p>
-  <p>A users server SHOULD include any known entities that provide such services into its service discovery items.</p>
+  <p>A user's server SHOULD include any known entities that provide such services into its service discovery items.</p>
   <example caption='Client sends service discovery request to server'><![CDATA[
 <iq from='romeo@montague.tld/garden'
     id='step_01'
@@ -246,6 +252,6 @@
   </section2>
 </section1>
 <section1 topic='XML Schema' anchor='schema'>
- <p>tbd</p>
+  <p>tbd</p>
 </section1>
 </xep>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -63,7 +63,7 @@
     <date>2016-12-05</date>
     <initials>sek</initials>
     <remark><p>
-      Clarify Direct PubSub access to each node type
+      Clarify Direct PubSub access to each node type.
     </p></remark>
   </revision>
   <revision>


### PR DESCRIPTION
Fix typos in XEP-0363 and XEP-0369.

This commit originally had a schema for 0363 when the author submitted it, but it appears to have been copy/pasted from another spec and was not actually relavant for 0363 so I have removed it.