### PR TITLE
XEP-0049: Fix syntax highlighting in examples

### DIFF
--- a/xep-0049.xml
+++ b/xep-0049.xml
@@ -113,7 +113,7 @@
   </query>
 </iq>
 
-<!-- Server: -->
+<!-- SERVER: -->
 <iq type="result"
     from="hamlet@shakespeare.lit/denmark"
     to="hamlet@shakespeare.lit/denmark"

--- a/xep-0049.xml
+++ b/xep-0049.xml
@@ -30,6 +30,12 @@
     <jid>ukscone@burninghorse.com</jid>
   </author>
   <revision>
+    <version>1.2.1</version>
+    <date>2017-01-08</date>
+    <initials>ssw</initials>
+    <remark>Fix syntax highlighting.</remark>
+  </revision>
+  <revision>
     <version>1.2</version>
     <date>2004-03-01</date>
     <initials>psa</initials>
@@ -98,7 +104,7 @@
     <p>The root element of this namespace is query. At least one child element with a proper namespace MUST be included; otherwise the server MUST respond with a "Not Acceptable" error (see &xep0086; for information about error conditions). A client MUST NOT query for more than one namespace in a single IQ get request. However, an IQ set or result MAY contain multiple elements qualified by the same namespace.</p>
 
     <example caption='Client Stores Private Data'><![CDATA[
-CLIENT:
+<!-- CLIENT: -->
 <iq type="set" id="1001">
   <query xmlns="jabber:iq:private">
     <exodus xmlns="exodus:prefs">
@@ -107,22 +113,22 @@ CLIENT:
   </query>
 </iq>
 
-SERVER:
+<!-- Server: -->
 <iq type="result"
     from="hamlet@shakespeare.lit/denmark"
     to="hamlet@shakespeare.lit/denmark"
     id="1001"/>
-    ]]></example>			
+]]></example>			
 
     <example caption='Client Retrieves Private Data'><![CDATA[
-CLIENT:
+<!-- CLIENT: -->
 <iq type="get" id="1002">
   <query xmlns="jabber:iq:private">
     <exodus xmlns="exodus:prefs"/>
   </query>
 </iq>
 
-SERVER:
+<!-- SERVER: -->
 <iq type="result"
     from="hamlet@shakespeare.lit/denmark"
     to="hamlet@shakespeare.lit/denmark"
@@ -133,11 +139,11 @@ SERVER:
     </exodus>
   </query>
 </iq>
-    ]]></example>
+]]></example>
 
     <p>If a user attempts to get or set jabber:iq:private data that belongs to another user, the server MUST return a "Forbidden" or "Service Unavailable" error to the sender (the latter condition is in common use by existing implementations, although the former is preferable).</p>
     <example caption='User Attempts to Get or Set Data for Another User'><![CDATA[
-CLIENT:
+<!-- CLIENT: -->
 <iq type="set" to="hamlet@shakespeare.lit" id="1003">
   <query xmlns="jabber:iq:private">
     <exodus xmlns="exodus:prefs">
@@ -146,7 +152,7 @@ CLIENT:
   </query>
 </iq>
 
-SERVER:
+<!-- SERVER: -->
 <iq type="error"
     from="hamlet@shakespeare.lit"
     to="macbeth@shakespeare.lit"
@@ -161,15 +167,15 @@ SERVER:
         xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
     <p>If a user attempts to perform an IQ get without providing a child element, the server SHOULD return a "Bad Format" error (however, some existing implementations return a "Not Acceptable" error in such circumstances):</p>
     <example caption='User Attempts to Get Data Without Specifying Child Element/Namespace'><![CDATA[
-CLIENT:
+<!-- CLIENT: -->
 <iq type="set" id="1004">
   <query xmlns="jabber:iq:private"/>
 </iq>
 
-SERVER:
+<!-- SERVER: -->
 <iq type="error" id="1004">
   <query xmlns="jabber:iq:private"/>
   <error code="406" type="modify">
@@ -177,10 +183,10 @@ SERVER:
         xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
     <p>Certain namespaces are reserved in Jabber (namespaces beginning with 'jabber:' or 'http://jabber.org/', as well as 'vcard-temp'). If a user attempts to get or set jabber:iq:private data in a reserved namespace, historically some server implementations have chosen to return an error (commonly "Not Acceptable") to the sender. Such behavior is OPTIONAL, but may be encountered by clients when interacting with some existing server implementations.</p>
     <example caption='User Attempts to Get or Set Data in a Reserved Namespace'><![CDATA[
-CLIENT:
+<!-- CLIENT: -->
 <iq type="set" id="1005">
   <query xmlns="jabber:iq:private">
     <vCard xmlns="vcard-temp">
@@ -189,7 +195,7 @@ CLIENT:
   </query>
 </iq>
 
-SERVER (optional error):
+<!-- SERVER (optional error): -->
 <iq type="error" id="1005">
   <query xmlns="jabber:iq:private">
     <vCard xmlns="vcard-temp">
@@ -201,7 +207,7 @@ SERVER (optional error):
         xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
   </section2>
 </section1>
 <section1 topic='Error Conditions'>
@@ -247,6 +253,6 @@ SERVER (optional error):
   </xs:element>
 
 </xs:schema>
-    ]]></code>
+]]></code>
 </section1>
 </xep>


### PR DESCRIPTION
Fix broken syntax highlighting by making all examples valid XML.