### PR TITLE
XEP-0144: Make date field a valid date

### DIFF
--- a/xep-0144.xml
+++ b/xep-0144.xml
@@ -29,7 +29,7 @@
   &stpeter;
   <revision>
     <version>1.1rc1</version>
-    <date>in progress, last updated 2012-06-19</date>
+    <date>2012-06-19</date>
     <initials>psa</initials>
     <remark>Clarified use of message vs. IQ and full JID vs. bare JID; removed IQ handling rules, which are specified in RFC 6120.</remark>
   </revision>


### PR DESCRIPTION
I'm not sure this is strictly required, but it's nice to keep things consistent.