### PR TITLE
Carbons: add <no-copy/> hint in addition to <private/>

### DIFF
--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -329,7 +329,7 @@
 
 </section1>
 <section1 topic='Avoiding Carbons for a single message' anchor='avoiding'>
-  <p>Some clients might want to avoid Carbons on a single message, while still keeping all of the other semantics of Carbon support. This might be useful for clients sending end-to-end encrypted messages, for example. To exclude a &MESSAGE; from being forwarded to other Carbons-enabled resources, the sending client add a &lt;private/&gt; element qualified by the namespace "urn:xmpp:carbons:2" as a child content element to the &MESSAGE; stanza.</p>
+  <p>Some clients might want to avoid Carbons on a single message, while still keeping all of the other semantics of Carbon support. This might be useful for clients sending end-to-end encrypted messages, for example. To exclude a &MESSAGE; from being forwarded to other Carbons-enabled resources, the sending client must add a &lt;private/&gt; element qualified by the namespace "urn:xmpp:carbons:2" and a &lt;no-copy/&gt; hint according to &xep0334; as child content elements to the &MESSAGE; stanza.</p>
 
   <p><strong>Note:</strong> use of the private mechanism might lead to partial conversations on other devices.  This is the intended effect.</p>
 
@@ -341,6 +341,7 @@
   <body>Neither, fair saint, if either thee dislike.</body>
   <thread>0e3141cd80894871a68e6fe6b1ec56fa</thread>
   <private xmlns='urn:xmpp:carbons:2'/>
+  <no-copy xmlns="urn:xmpp:hints"/>
 </message>]]></example>
 
   <example caption='Romeo&apos;s server delivers original message, without creating Carbon copies'><![CDATA[
@@ -351,6 +352,7 @@
   <body>Neither, fair saint, if either thee dislike.</body>
   <thread>0e3141cd80894871a68e6fe6b1ec56fa</thread>
   <private xmlns='urn:xmpp:carbons:2'/>
+  <no-copy xmlns="urn:xmpp:hints"/>
 </message>]]></example>
   <p>The sending server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resources of the sender. The receiving server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resource of the recipient, and SHOULD remove the &lt;private/&gt; element before delivering to the recipient.</p>
   <p><strong>Note:</strong> if the private &MESSAGE; stanza is addressed to a bare JID, the receiving server still delivers it according to <cite>RFC 6121</cite>. This might result in a copy being delivered to each resource for the recipient, which effectively negates the behavior of the &lt;private/&gt; element for recipients.</p>


### PR DESCRIPTION
This adds both <private> and <no-copy> into the XEP for maximum interoperability.

While Carbons is doing its rounds in Last Call, and people can't decide whether <no-copy> is less strict but more useful than <private>, this one adds a bit of overhead and removes a large burden from implementations only covering one of the two.

Edit: first discussion on standards@:
https://mail.jabber.org/pipermail/standards/2015-September/030288.html