### PR TITLE
XEP-0302: Move to status Obsolete

### DIFF
--- a/xep-0302.xml
+++ b/xep-0302.xml
@@ -10,7 +10,7 @@
   <abstract>This document defines XMPP protocol compliance levels for 2012.</abstract>
   &LEGALNOTICE;
   <number>0302</number>
-  <status>Deferred</status>
+  <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <dependencies>


### PR DESCRIPTION
Council decided last week to obsolete XEP-0270 (2010 compliance suites) in favour of XEP-0375 (2016 compliance suites), it makes a lot of sense to also obsolete the 2012 version.