### PR TITLE
XEP-0045: Remove trailing whitespace in examples

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -1030,7 +1030,7 @@
     type='get'>
   <query xmlns='http://jabber.org/protocol/disco#items'/>
 </iq>
-    ]]></example>
+]]></example>
     <p>The server then returns the services that are associated with it.</p>
     <example caption='Server Returns Disco Items Result'><![CDATA[
 <iq from='shakespeare.lit'
@@ -1042,7 +1042,7 @@
           name='Chatroom Service'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
   </section2>
   <section2 topic='Discovering the Features Supported by a MUC Service' anchor='disco-service-features'>
     <p>An entity may wish to discover if a service implements the Multi-User Chat protocol; in order to do so, it sends a service discovery information ("disco#info") query to the MUC service's JID.</p>
@@ -1053,7 +1053,7 @@
     type='get'>
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST return its identity and the features it supports.</p>
     <example caption='Service Returns Disco Info Result'><![CDATA[
 <iq from='chat.shakespeare.lit'
@@ -1068,7 +1068,7 @@
     <feature var='http://jabber.org/protocol/muc'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Discovering Rooms' anchor='disco-rooms'>
@@ -1080,7 +1080,7 @@
     type='get'>
   <query xmlns='http://jabber.org/protocol/disco#items'/>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service SHOULD return a full list of the public rooms it hosts (i.e., not return any rooms that are hidden).</p>
     <example caption='Service Returns Disco Items Result'><![CDATA[
 <iq from='chat.shakespeare.lit'
@@ -1098,7 +1098,7 @@
           name='Macbeth&apos;s Castle'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>If the full list of rooms is large (see <cite>XEP-0030</cite> for details), the service MAY return only a partial list of rooms. If it does so, it SHOULD include a &lt;set/&gt; element qualified by the 'http://jabber.org/protocol/rsm' namespace (as defined in &xep0059;) to indicate that the list is not the full result set.</p>
     <example caption='Service Returns Limited List of Disco Items Result'><![CDATA[
 <iq from='chat.shakespeare.lit'
@@ -1123,7 +1123,7 @@
     </set>
   </query>
 </iq>
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Querying for Room Information' anchor='disco-roominfo'>
@@ -1135,7 +1135,7 @@
     type='get'>
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>
-    ]]></example>
+]]></example>
     <p>The room MUST return its identity and SHOULD return the features it supports:</p>
     <example caption='Room Returns Disco Info Result'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -1156,7 +1156,7 @@
     <feature var='muc_nonanonymous'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>Note: The room SHOULD return the materially-relevant features it supports, such as password protection and room moderation (these are listed fully in the feature registry maintained by the XMPP Registrar; see also the <link url='#registrar'>XMPP Registrar</link> section of this document).</p>
     <p>A chatroom MAY return more detailed information in its disco#info response using &xep0128;, identified by inclusion of a hidden FORM_TYPE field whose value is "http://jabber.org/protocol/muc#roominfo". Such information might include a more verbose description of the room, the current room subject, and the current number of occupants in the room:</p>
     <example caption='Room Returns Extended Disco Info Result'><![CDATA[
@@ -1227,7 +1227,7 @@
     </x>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>Some extended room information is dynamically generated (e.g., the URL for discussion logs, which may be based on service-wide configuration), whereas other information is based on the more-stable room configuration, which is why any field defined for the <link url='#registrar-formtype-owner'>muc#roomconfig FORM_TYPE</link> can be included in the extended service discovery fields (as shown above for the "muc#roomconfig_changesubject" field).</p>
     <p>Note: The foregoing extended service discovery fields for the 'http://jabber.org/protocol/muc#roominfo' FORM_TYPE are examples only and might be supplemented in the future via the mechanisms described in the <link url="#registrar-formtype">Field Standardization</link> section of this document.</p>
   </section2>
@@ -1241,7 +1241,7 @@
     type='get'>
   <query xmlns='http://jabber.org/protocol/disco#items'/>
 </iq>
-    ]]></example>
+]]></example>
     <p>An implementation MAY return a list of existing occupants if that information is publicly available, or return no list at all if this information is kept private. Implementations and deployments are advised to turn off such information sharing by default.</p>
     <example caption='Room Returns Disco Items Result (Items are Public)'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -1253,7 +1253,7 @@
     <item jid='coven@chat.shakespeare.lit/secondwitch'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>Note: These &lt;item/&gt; elements are qualified by the disco#items namespace, not the muc namespace; this means that they cannot possess 'affiliation' or 'role' attributes, for example.</p>
     <p>If the list of occupants is private, the room MUST return an empty &QUERY; element, in accordance with <cite>XEP-0030</cite>.</p>
     <example caption='Room Returns Empty Disco Items Result (Items are Private)'><![CDATA[
@@ -1263,7 +1263,7 @@
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#items'/>
 </iq>
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Querying a Room Occupant' anchor='disco-occupant'>
@@ -1279,7 +1279,7 @@
     type='get'>
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>
-    ]]></example>
+]]></example>
     <p>The client SHOULD return its identity and the features it supports.</p>
     <example caption='Contact Returns Disco Info Result'><![CDATA[
 <iq from='wiccarocks@shakespeare.lit/laptop'
@@ -1295,7 +1295,7 @@
     ...
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>An entity may also query a contact regarding which rooms the contact is in. This is done by querying the contact's full JID (&lt;user@host/resource&gt;) while specifying the well-known Service Discovery node 'http://jabber.org/protocol/muc#rooms'.</p>
     <example caption='Entity Queries Contact for Current Rooms'><![CDATA[
 <iq from='hag66@shakespeare.lit/pda'
@@ -1305,7 +1305,7 @@
   <query xmlns='http://jabber.org/protocol/disco#items'
          node='http://jabber.org/protocol/muc#rooms'/>
 </iq>
-    ]]></example>
+]]></example>
     <example caption='Contact Returns Room Query Result'><![CDATA[
 <iq from='wiccarocks@shakespeare.lit/laptop'
     id='gp7w61v3'
@@ -1317,14 +1317,14 @@
     <item jid='characters@conference.shakespeare.lit'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>Optionally, the contact MAY include its roomnick as the value of the 'name' attribute:</p>
     <code><![CDATA[
     ...
     <item jid='coven@chat.shakespeare.lit'
           name='secondwitch'/>
     ...
-    ]]></code>
+]]></code>
     <p>If this information is private, the user MUST return an empty &QUERY; element, in accordance with <cite>XEP-0030</cite>.</p>
   </section2>
 
@@ -1357,7 +1357,7 @@
     from='hag66@shakespeare.lit/pda'
     id='ng91xs69'
     to='coven@chat.shakespeare.lit/thirdwitch'/>
-      ]]></example>
+]]></example>
       <p>In this example, a user with a full JID of "hag66@shakespeare.lit/pda" has requested to enter the room "coven" on the "chat.shakespeare.lit" chat service with a room nickname of "thirdwitch".</p>
       <p>If the user does not specify a room nickname (note the bare JID on the 'from' address in the following example), the service MUST return a &badjid; error:</p>
       <example caption='No Nickname Specified'><![CDATA[
@@ -1370,7 +1370,7 @@
     <jid-malformed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </presence>
-      ]]></example>
+]]></example>
       <p>Note: The presence stanza used to join a room MUST NOT possess a 'type' attribute, i.e., it must be available presence. For further discussion, see the <link url='#bizrules-presence'>Presence</link> business rules.</p>
     </section3>
 
@@ -1383,7 +1383,7 @@
     to='coven@chat.shakespeare.lit/thirdwitch'>
   <x xmlns='http://jabber.org/protocol/muc'/>
 </presence>
-      ]]></example>
+]]></example>
       <p>Before attempting to enter the room, a MUC-compliant client SHOULD first discover its reserved room nickname (if any) by following the protocol defined in the <link url='#reservednick'>Discovering Reserved Room Nickname</link> section of this document.</p>
     </section3>
 
@@ -1407,7 +1407,7 @@
     <item affiliation='admin' role='moderator'/>
   </x>
 </presence>
-      ]]></example>
+]]></example>
       <p>In this example, the user from the previous example has entered the room, by which time two other people had already entered the room: a user with a room nickname of "firstwitch" (who is a room owner) and a user with a room nickname of "secondwitch" (who is a room admin).</p>
       <p>Unless the room is configured to not broadcast presence from new occupants below a certain affiliation level (as controlled by the "muc#roomconfig_presencebroadcast" room configuration option), the service MUST also send presence from the new participant's occupant JID to the full JIDs of all the occupants (including the new occupant).</p>
       <example caption="Service Sends New Occupant's Presence to All Occupants"><![CDATA[
@@ -1438,7 +1438,7 @@
     <status code='110'/>
   </x>
 </presence>
-      ]]></example>
+]]></example>
       <p>In this example, initial room presence is being sent from the new occupant (thirdwitch) to all occupants, including the new occupant.</p>
       <p>As shown in the last stanza, the "self-presence" sent by the room to the new user MUST include a status code of 110 so that the user knows this presence refers to itself as an occupant. This self-presence MUST NOT be sent to the new occupant until the room has sent the presence of all other occupants to the new occupant; this enables the new occupant to know when it has finished receiving the room roster.</p>
       <p>The service MAY rewrite the new occupant's roomnick (e.g., if roomnicks are locked down or based on some other policy).</p>
@@ -1455,7 +1455,7 @@
     <not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </presence>
-      ]]></example>
+]]></example>
       <p>If the user has connected using a MUC client (as indicated on joining the room by inclusion of the MUC extension), then the service MUST allow the client to enter the room, modify the nick in accordance with the lockdown policy, and include a status code of "210" in the presence broadcast that it sends to the new occupant.</p>
       <example caption="Service Sends New Occupant's Presence to New Occupant"><![CDATA[
 <presence
@@ -1468,7 +1468,7 @@
     <status code='210'/>
   </x>
 </presence>
-      ]]></example>
+]]></example>
       <p>Note: The order of the presence stanzas sent to the new occupant is important. The service MUST first send the complete list of the existing occupants to the new occupant and only then send the new occupant's own presence to the new occupant. This helps the client know when it has received the complete "room roster". For tracking purposes, the room might also reflect the original 'id' value if provided in the presence stanza sent by the user.</p>
       <p>After sending the presence broadcast (and only after doing so), the service MAY then send discussion history, the room subject, live messages, presence updates, and other in-room traffic.</p>
     </section3>
@@ -1488,7 +1488,7 @@
 </presence>
 
 [ ... ]
-      ]]></example>
+]]></example>
       <p>If the user is entering a room that is non-anonymous (i.e., which informs all occupants of each occupant's full JID as shown above), the service MUST warn the user by including a status code of "100" in the initial presence that the room sends to the new occupant:</p>
       <example caption="Service Sends New Occupant's Presence to New Occupant"><![CDATA[
 <presence
@@ -1502,7 +1502,7 @@
     <status code='210'/>
   </x>
 </presence>
-      ]]></example>
+]]></example>
       <p>The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality).</p>
     </section3>
 
@@ -1524,7 +1524,7 @@
     <not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </presence>
-      ]]></example>
+]]></example>
       <p>Passwords SHOULD be supplied with the presence stanza sent when entering the room, contained within an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc' namespace and containing a &lt;password/&gt; child. Passwords are to be sent as cleartext; no other authentication methods are supported at this time, and any such authentication or authorization methods shall be defined in a separate specification (see the <link url='#security'>Security Considerations</link> section of this document).</p>
       <example caption='User Provides Password On Entering a Room'><![CDATA[
 <presence
@@ -1535,7 +1535,7 @@
     <password>cauldronburn</password>
   </x>
 </presence>
-      ]]></example>
+]]></example>
     </section3>
 
     <section3 topic='Members-Only Rooms' anchor='enter-members'>
@@ -1551,7 +1551,7 @@
     <registration-required xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </presence>
-      ]]></example>
+]]></example>
     </section3>
 
     <section3 topic='Banned Users' anchor='enter-banned'>
@@ -1567,7 +1567,7 @@
     <forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </presence>
-      ]]></example>
+]]></example>
     </section3>
 
     <section3 topic='Nickname Conflict' anchor='enter-conflict'>
@@ -1583,7 +1583,7 @@
     <conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </presence>
-      ]]></example>
+]]></example>
       <p>However, if the bare JID &LOCALBARE; of the present occupant matches the bare JID of the user seeking to enter the room, then the service SHOULD allow entry to the user, so that the user has two (or more) in-room "sessions" with the same roomnick, one for each resource. If a service allows more than one occupant with the same bare JID and the same room nickname, it MUST route in-room messages to all of the user's resources and allow all of the user's resources to send messages to the room; it is up to the implementation whether to route private messages to all resources or only one resource (based on presence priority or some other algorithm); however, it is RECOMMENDED to route to all resources.</p>
       <p>How nickname conflicts are determined is up to the implementation (e.g., whether the service applies a case folding routine, a stringprep profile such as Resourceprep or Nodeprep, etc.).</p>
     </section3>
@@ -1601,7 +1601,7 @@
     <service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </presence>
-      ]]></example>
+]]></example>
       <p>Alternatively, the room could kick an "idle user" in order to free up space (where the definition of "idle user" is up to the implementation).</p>
       <p>If the room has reached its maximum number of occupants and a room admin or owner attempts to join, the room MUST allow the admin or owner to join, up to some reasonable number of additional occupants; this helps to prevent denial of service attacks caused by stuffing the room with non-admin users.</p>
     </section3>
@@ -1619,7 +1619,7 @@
     <item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </presence>
-      ]]></example>
+]]></example>
     </section3>
 
     <section3 topic='Nonexistent Room' anchor='enter-nonexistent'>
@@ -1641,7 +1641,7 @@
     <status code='210'/>
   </x>
 </presence>
-      ]]></example>
+]]></example>
     </section3>
 
     <section3 topic='Discussion History' anchor='enter-history'>
@@ -1679,7 +1679,7 @@
      from='coven@chat.shakespeare.lit'
      stamp='2002-10-13T23:58:49Z'/>
 </message>
-      ]]></example>
+]]></example>
       <p>Discussion history messages MUST be stamped with &xep0203; information qualified by the 'urn:xmpp:delay' namespace to indicate that they are sent with delayed delivery and to specify the times at which they were originally sent. The 'from' attribute MUST be set to the JID of the room itself.</p>
       <p>(Note: The 'urn:xmpp:delay' namespace defined in <cite>XEP-0203</cite> supersedes the older 'jabber:x:delay' namespace defined in &xep0091;; some implementations include both formats for backward compatibility.)</p>
       <p>The service MUST send all discussion history messages before delivering the room subject and any "live" messages sent after the user enters the room. Note well that this means the room subject (and changes to the room subject prior to the current subject) are not part of the discussion history.</p>
@@ -1698,7 +1698,7 @@
     <address type='ofrom' jid='crone1@shakespeare.lit/desktop'/>
   </addresses>
 </message>
-      ]]></example>
+]]></example>
     </section3>
 
     <section3 topic='Managing Discussion History' anchor='enter-managehistory'>
@@ -1742,7 +1742,7 @@
     <history maxchars='65000'/>
   </x>
 </presence>
-      ]]></example>
+]]></example>
       <example caption='User Requests Limit on Number of Messages in History'><![CDATA[
 <presence
     from='hag66@shakespeare.lit/pda'
@@ -1752,7 +1752,7 @@
     <history maxstanzas='20'/>
   </x>
 </presence>
-      ]]></example>
+]]></example>
       <example caption='User Requests History in Last 3 Minutes'><![CDATA[
 <presence
     from='hag66@shakespeare.lit/pda'
@@ -1762,7 +1762,7 @@
     <history seconds='180'/>
   </x>
 </presence>
-      ]]></example>
+]]></example>
       <example caption='User Requests All History Since the Beginning of the Unix Era'><![CDATA[
 <presence
     from='hag66@shakespeare.lit/pda'
@@ -1772,7 +1772,7 @@
     <history since='1970-01-01T00:00:00Z'/>
   </x>
 </presence>
-      ]]></example>
+]]></example>
       <p>Obviously the service SHOULD NOT return all messages sent in the room since the beginning of the Unix era, and SHOULD appropriately limit the amount of history sent to the user based on service or room defaults.</p>
       <example caption='User Requests No History'><![CDATA[
 <presence
@@ -1783,7 +1783,7 @@
     <history maxchars='0'/>
   </x>
 </presence>
-      ]]></example>
+]]></example>
     </section3>
 
     <section3 topic='Room Subject' anchor='enter-subject'>
@@ -1796,7 +1796,7 @@
     type='groupchat'>
   <subject>Fire Burn and Cauldron Bubble!</subject>
 </message>
-      ]]></example>
+]]></example>
       <p>If there is no subject set, the room MUST return an empty &SUBJECT; element.</p>
       <example caption='No Subject'><![CDATA[
 <message
@@ -1806,7 +1806,7 @@
     type='groupchat'>
   <subject></subject>
 </message>
-      ]]></example>
+]]></example>
       <p>Note: In accordance with the core definition of XML stanzas, any message can contain a &SUBJECT; element; only a message that contains a &SUBJECT; but no &BODY; element shall be considered a subject change for MUC purposes.</p>
     </section3>
 
@@ -1872,7 +1872,7 @@
     type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
 </message>
-    ]]></example>
+]]></example>
     <p>If the sender has voice in the room (this is the default except in moderated rooms) and the message does not violate any service-level or room-level policies (e.g., policies regarding message content or size), the service MUST change the 'from' attribute to the sender's occupant JID and reflect the message out to the full JID of each occupant.</p>
     <example caption='Service Reflects Message to All Occupants'><![CDATA[
 <message
@@ -1896,7 +1896,7 @@
     type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
 </message>
-    ]]></example>
+]]></example>
     <p>Note well that for tracking purposes this service assigns a new 'id' to each message it generates (here using a UUID as defined in &rfc4122;).</p>
     <p>If the sender is a visitor (i.e., does not have voice in a moderated room), the service MUST return a &forbidden; error to the sender and MUST NOT reflect the message to all occupants. If the sender is not an occupant of the room, the service SHOULD return a &notacceptable; error to the sender and SHOULD NOT reflect the message to all occupants; the only exception to this rule is that an implementation MAY allow users with certain privileges (e.g., a room owner, room admin, or service-level admin) to send messages to the room even if those users are not occupants.</p>
   </section2>
@@ -1911,7 +1911,7 @@
     type='chat'>
   <body>I'll give thee a wind.</body>
 </message>
-    ]]></example>
+]]></example>
     <p>The service is responsible for changing the 'from' address to the sender's occupant JID and delivering the message to the intended recipient's full JID.</p>
     <example caption='Recipient Receives the Private Message'><![CDATA[
 <message
@@ -1921,7 +1921,7 @@
     type='chat'>
   <body>I'll give thee a wind.</body>
 </message>
-    ]]></example>
+]]></example>
     <p>If the sender attempts to send a private message of type "groupchat" to a particular occupant, the service MUST refuse to deliver the message (since the recipient's client would expect in-room messages to be of type "groupchat") and return a &badrequest; error to the sender:</p>
     <example caption='Occupant Attempts to Send a Message of Type "Groupchat" to a Particular Occupant'><![CDATA[
 <message
@@ -1942,7 +1942,7 @@
     <bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </message>
-    ]]></example>
+]]></example>
     <p>If the sender attempts to send a private message to an occupant JID that does not exist, the service MUST return an &notfound; error to the sender.</p>
     <p>If the sender is not an occupant of the room in which the intended recipient is visiting, the service MUST return a &notacceptable; error to the sender.</p>
   </section2>
@@ -1954,7 +1954,7 @@
     from='hag66@shakespeare.lit/pda'
     id='ifd1c35'
     to='coven@chat.shakespeare.lit/oldhag'/>
-    ]]></example>
+]]></example>
     <p>The service then sends two presence stanzas to the full JID of each occupant (including the occupant who is changing his or her room nickname), one of type "unavailable" for the old nickname and one indicating availability for the new nickname.</p>
    <p>The unavailable presence MUST contain the following as extended presence information in an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace:</p>
     <ul>
@@ -2035,7 +2035,7 @@
     <status code='110'/>
   </x>
 </presence>
-    ]]></example>
+]]></example>
     <p>If the service modifies the user's nickname in accordance with local service policies, it MUST include a MUC status code of 210 in the presence stanza sent to the user. An example follows (here the service changes the nickname to all lowercase).</p>
     <example caption='Occupant Changes Nickname, Modified by Service'><![CDATA[
 <presence
@@ -2055,7 +2055,7 @@
     <status code='210'/>
   </x>
 </presence>
-    ]]></example>
+]]></example>
     <p>If the user attempts to change his or her room nickname to a room nickname that is already in use by another user (or that is reserved by another user affiliated with the room, e.g., a member or owner), the service MUST deny the nickname change request and inform the user of the conflict; this is done by returning a presence stanza of type "error" specifying a &conflict; error condition:</p>
     <example caption='Service Denies Nickname Change Because of Nick Conflict'><![CDATA[
 <presence
@@ -2068,7 +2068,7 @@
     <conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </presence>
-    ]]></example>
+]]></example>
     <p>However, if the bare JID &LOCALBARE; of the present occupant matches the bare JID of the user seeking to change his or her nickname, then the service MAY allow the nickname change. See the <link url='#enter-conflict'>Nickname Conflict</link> section of this document for details.</p>
     <p>If the user attempts to change their room nickname but nicknames are "locked down", the service MUST either deny the nickname change request and return a presence stanza of type "error" with a &notacceptable; error condition:</p>
     <example caption='Service Denies Nickname Change Because Roomnicks Are Locked Down'><![CDATA[
@@ -2082,7 +2082,7 @@
     <not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </presence>
-    ]]></example>
+]]></example>
     <p>The user SHOULD then discover its reserved nickname as specified in the <link url='#reservednick'>Discovering Reserved Room Nickname</link> section of this document.</p>
   </section2>
 
@@ -2096,7 +2096,7 @@
   <show>xa</show>
   <status>gone where the goblins go</status>
 </presence>
-    ]]></example>
+]]></example>
     <p>If the room is configured to broadcast presence from entities with the occupant's role, the service then sends a presence stanza from the occupant changing his or her presence to the full JID of each occupant, including extended presence information about the occupant's role and full JID to those with privileges to view such information:</p>
     <example caption='Service Passes Along Changed Presence to All Occupants'><![CDATA[
 <presence
@@ -2113,7 +2113,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Inviting Another User to a Room' anchor='invite'>
@@ -2140,7 +2140,7 @@
     </invite>
   </x>
 </message>
-      ]]></example>
+]]></example>
       <p>The &ROOMJID; itself MUST then add a 'from' address to the &lt;invite/&gt; element whose value is the bare JID, full JID, or occupant JID of the inviter and send the invitation to the invitee specified in the 'to' address; the room SHOULD add the password if the room is password-protected):</p>
       <example caption='Room Sends Invitation to Invitee on Behalf of Invitor'><![CDATA[
 <message
@@ -2156,7 +2156,7 @@
     <password>cauldronburn</password>
   </x>
 </message>
-      ]]></example>
+]]></example>
       <p>If the room is members-only, the service MAY also add the invitee to the member list. (Note: Invitation privileges in members-only rooms SHOULD be restricted to room admins; if a member without privileges to edit the member list attempts to invite another user, the service SHOULD return a &forbidden; error to the occupant; for details, see the <link url='#modifymember'>Modifying the Member List</link> section of this document.)</p>
       <p>If the inviter supplies a non-existent JID, the room SHOULD return an &notfound; error to the inviter.</p>
       <p>The invitee MAY choose to formally decline (as opposed to ignore) the invitation; and this is something that the sender might want to be informed about. In order to decline the invitation, the invitee MUST send a message of the following form to the &ROOMJID; itself:</p>
@@ -2173,7 +2173,7 @@
     </decline>
   </x>
 </message>
-      ]]></example>
+]]></example>
       <example caption='Room Informs Invitor that Invitation Was Declined'><![CDATA[
 <message
     from='coven@chat.shakespeare.lit'
@@ -2187,7 +2187,7 @@
     </decline>
   </x>
 </message>
-      ]]></example>
+]]></example>
       <p>It may be wondered why the invitee does not send the decline message directly to the inviter. The main reason is that certain implementations might choose to base invitations on occupant JIDs rather than bare JIDs (so that, for example, an occupant could invite someone from one room to another without knowing that person's bare JID). Thus the service needs to handle both the invites and declines.</p>
     </section3>
 
@@ -2214,7 +2214,7 @@
   <thread>e0ffe42b28561960c6b12b944a092794b9683a38</thread>
   <body>Thrice and once the hedge-pig whined.</body>
 </message>
-    ]]></example>
+]]></example>
     <p>Now the first person decides to include a third person in the discussion, so she does the following:</p>
     <ol start='1'>
       <li>Creates a new multi-user chatroom</li>
@@ -2238,7 +2238,7 @@
     <status code='110'/>
   </x>
 </presence>
-    ]]></example>
+]]></example>
     <example caption='Continuing the Discussion II: Owner Sends History to Room'><![CDATA[
 <message
     from='crone1@shakespeare.lit/desktop'
@@ -2263,7 +2263,7 @@
      from='crone1@shakespeare.lit/desktop'
      stamp='2004-09-29T01:55:21Z'/>
 </message>
-    ]]></example>
+]]></example>
     <p>Note: Use of the <cite>Delayed Delivery</cite> protocol enables the room creator to specify the datetime of each message from the one-to-one chat history (via the 'stamp' attribute), as well as the JID of the original sender of each message (via the 'from' attribute); note well that the 'from' here is not the room itself, since the originator of the message is the delaying party. The room creator might send the complete one-to-one chat history before inviting additional users to the room, and also send as history any messages appearing in the one-to-one chat interface after joining the room and before the second person joins the room; if the one-to-one history is especially large, the sending client might want to send the history over a few seconds rather than all at once (to avoid triggering rate limits). The service SHOULD NOT add its own delay elements (as described in the <link url='#enter-history'>Discussion History</link> section of this document) to prior chat history messages received from the room owner.</p>
     <example caption='Continuing the Discussion III: Owner Sends Invitations, Including Continue Flag'><![CDATA[
 <message
@@ -2281,7 +2281,7 @@
     </invite>
   </x>
 </message>
-    ]]></example>
+]]></example>
     <p>Note: Since the inviter's client knows the full JID of the person with whom the inviter was having a one-to-one chat, it SHOULD include the full JID (rather than the bare JID) in its invitation to that user.</p>
     <p>The invitations are delivered to the invitees:</p>
     <example caption='Invitations Delivered'><![CDATA[
@@ -2308,7 +2308,7 @@
     </invite>
   </x>
 </message>
-    ]]></example>
+]]></example>
     <p>When the client being used by &lt;wiccarocks@shakespeare.lit/laptop&gt; receives the invitation, it can either auto-join the room or prompt the user whether to join (subject to user preferences) and then seamlessly convert the existing one-to-one chat window into a multi-user conferencing window:</p>
     <example caption='Invitee Accepts Invitation, Joins Room, and Receives Presence and History'><![CDATA[
 <presence
@@ -2356,7 +2356,7 @@
      from='coven@chat.shakespeare.lit'
      stamp='2004-09-29T01:55:21Z'/>
 </message>
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Registering with a Room' anchor='register'>
@@ -2369,7 +2369,7 @@
     type='get'>
   <query xmlns='jabber:iq:register'/>
 </iq>
-    ]]></example>
+]]></example>
     <p>If the room does not exist, the service MUST return an &notfound; error.</p>
     <example caption='Room Does Not Exist'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -2380,7 +2380,7 @@
     <item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
     <p>If the user requesting registration requirements is not allowed to register with the room (e.g., because that privilege has been restricted), the room MUST return a &notallowed; error to the user.</p>
     <example caption='User Is Not Allowed to Register'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -2391,7 +2391,7 @@
     <not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
     <p>If the user is already registered, as described in <cite>XEP-0077</cite> the room MUST reply with an IQ stanza of type "result", which MUST contain an empty &lt;registered/&gt; element and SHOULD contain at least a &lt;username/&gt; element that specifies the user's registered nickname in the room.</p>
     <example caption='User Is Already Registered'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -2403,7 +2403,7 @@
     <username>thirdwitch</username>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>Otherwise, the room MUST then return a Data Form to the user (as described in &xep0004;). The information required to register might vary by implementation or deployment and is not fully specified in this document (e.g., the fields registered by this document for the 'http://jabber.org/protocol/muc#register' FORM_TYPE might be supplemented in the future via the mechanisms described in the <link url="#registrar-formtype">Field Standardization</link> section of this document). The following can be taken as a fairly typical example:</p>
     <example caption='Service Returns Registration Form'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -2458,7 +2458,7 @@
     </x>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The user SHOULD then submit the form:</p>
     <example caption='User Submits Registration Form'><![CDATA[
 <iq from='hag66@shakespeare.lit/pda'
@@ -2491,7 +2491,7 @@
     </x>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>If the desired room nickname is already reserved for that room, the room MUST return a &conflict; error to the user:</p>
     <example caption='Room Returns Conflict Error to User'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -2502,7 +2502,7 @@
     <conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
     <p>If the room or service does not support registration, it MUST return a &unavailable; error to the user:</p>
     <example caption='Room Returns Service Unavailable Error to User'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -2513,7 +2513,7 @@
     <service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
     <p>If the user did not include a valid data form, the room MUST return a &badrequest; error to the user:</p>
     <example caption='Room Returns Service Bad Request Error to User'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -2524,14 +2524,14 @@
     <bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
     <p>Otherwise, the room MUST inform the user that the registration request was successfully received:</p>
     <example caption='Room Informs User that Registration Request Has Been Processed'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='nv71va54'
     to='hag66@shakespeare.lit/pda'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>After the user submits the form, the service MAY request that the submission be approved by a room admin/owner (see the <link url='#regapprove'>Approving Registration Requests</link> section of this document), MAY immediately add the user to the member list by changing the user's affiliation from "none" to "member", or MAY perform some service-specific checking (e.g., email verification).</p>
     <p>If the service changes the user's affiliation and the user is in the room, it MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "member".</p>
     <example caption="Service Sends Notice of Membership to All Occupants"><![CDATA[
@@ -2546,7 +2546,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
     <p>If the user's nickname is modified by the service as a result of registration and the user is in the room, the service SHOULD include status code "210" in the updated presence notification that it sends to all users.</p>
     <p>If a user has registered with a room, the room MAY choose to restrict the user to use of the registered nickname only in that room. If it does so, it SHOULD modify the user's nickname to be the registered nickname (instead of returning a &notacceptable; error) if the user attempts to join the room with a roomnick other than the user's registered roomnick (this enables a room to "lock down" roomnicks for consistent identification of occupants).</p>
   </section2>
@@ -2565,7 +2565,7 @@
   <query xmlns='http://jabber.org/protocol/disco#info'
          node='x-roomuser-item'/>
 </iq>
-    ]]></example>
+]]></example>
     <p>It is OPTIONAL for a multi-user chat service to support the foregoing service discovery node. If the room or service does not support the foregoing service discovery node, it MUST return a &feature; error to the user. If it does and the user has a registered nickname, it MUST return the nickname to the user as the value of the 'name' attribute of a Service Discovery &lt;identity/&gt; element (for which the category/type SHOULD be "conference/text"):</p>
     <example caption="Room Returns Nickname"><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -2580,7 +2580,7 @@
         type='text'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>If the user does not have a registered nickname, the room MUST return a service discovery &QUERY; element that is empty (in accordance with <cite>XEP-0030</cite>).</p>
     <p>Even if a user has registered one room nickname, the service SHOULD allow the user to specify a different nickname on entering the room (e.g., in order to join from different client resources), although the service MAY choose to "lock down" nicknames and therefore deny entry to the user, including a &notacceptable; error. The service MUST NOT return an error to the user if his or her client sends the foregoing request after having already joined the room, but instead SHOULD reply as previously described.</p>
     <p>If another user attempts to join the room with a nickname reserved by the first user, the service MUST deny entry to the second user and return a &conflict; error as previously described.</p>
@@ -2603,7 +2603,7 @@
     </field>
   </x>
 </message>
-    ]]></example>
+]]></example>
     <p>The service then proceeds as described in the <link url='#voiceapprove'>Approving Voice Requests</link> section of this document.</p>
   </section2>
 
@@ -2614,7 +2614,7 @@
     from='hag66@shakespeare.lit/pda'
     to='coven@chat.shakespeare.lit/thirdwitch'
     type='unavailable'/>
-    ]]></example>
+]]></example>
     <p>The service MUST then send a presence stanzas of type "unavailable" from the departing user's occupant JID to the departing occupant's full JIDs, including a status code of "110" to indicate that this notification is "self-presence":</p>
     <example caption='Service Sends Self-Presence Related to Departure of Occupant'><![CDATA[
 <presence
@@ -2628,7 +2628,7 @@
     <status code='110'/>
   </x>
 </presence>
-    ]]></example>
+]]></example>
     <p>Note: The presence stanza used to exit a room MUST possess a 'type' attribute whose value is "unavailable". For further discussion, see the <link url='#bizrules-presence'>Presence</link> business rules.</p>
     <p>The service MUST then send presence stanzas of type "unavailable" from the departing user's occupant JID to the full JIDs of the remaining occupants:</p>
     <example caption='Service Sends Presence Related to Departure of Occupant'><![CDATA[
@@ -2663,7 +2663,7 @@
           role='none'/>
   </x>
 </presence>
-    ]]></example>
+]]></example>
     <p>Presence stanzas of type "unavailable" reflected by the room MUST contain extended presence information about roles and affiliations; in particular, the 'role' attribute MUST be set to a value of "none" to denote that the individual is no longer an occupant.</p>
     <p>The occupant MAY include normal &lt;status/&gt; information in the unavailable presence stanzas; this enables the occupant to provide a custom exit message if desired:</p>
     <example caption='Custom Exit Message'><![CDATA[
@@ -2673,7 +2673,7 @@
     type='unavailable'>
   <status>gone where the goblins go</status>
 </presence>
-    ]]></example>
+]]></example>
     <p>Normal presence stanza generation rules apply as defined in &xmppim;, so that if the user sends a general unavailable presence stanza, the user's server will broadcast that stanza to the client's &OCCUPANTJID;; as a result, there is no need for the leaving client to send directed unavailable presence to its occupant JID. It is possible that a user might not be able to gracefully exit the room by sending unavailable presence. If the user goes offline without sending unavailable presence, the user's server is responsible for sending unavailable presence on behalf of the user (in accordance with <cite>RFC 6121</cite>).</p>
     <p>Note: See <link url='#impl-service-ghosts'>Ghost Users</link> for suggestions regarding room occupants that appear to be present in the room but that are actually offline.</p>
     <p>Note: If the room is not persistent and this occupant is the last to exit, the service is responsible for destroying the room.</p>
@@ -2705,7 +2705,7 @@
     type='groupchat'>
   <subject>Fire Burn and Cauldron Bubble!</subject>
 </message>
-    ]]></example>
+]]></example>
     <p>The MUC service MUST reflect the message to all other occupants with a 'from' address equal to the room JID or to the occupant JID that corresponds to the sender of the subject change:</p>
     <example caption='Service Informs All Occupants of Subject Change'><![CDATA[
 <message
@@ -2717,12 +2717,12 @@
 </message>
 
 [ ... ]
-    ]]></example>
+]]></example>
     <p>As explained under <link url='#enter-history'></link>, when a new occupant joins the room the room SHOULD include the last subject change after the discussion history.</p>
     <p>A MUC client that receives such a message MAY choose to display an in-room message, such as the following:</p>
     <example caption='Client Displays Room Subject Change Message'><![CDATA[
 * secondwitch has changed the subject to: Fire Burn and Cauldron Bubble!
-    ]]></example>
+]]></example>
     <p>If someone without appropriate privileges attempts to change the room subject, the service MUST return a message of type "error" specifying a &forbidden; error condition:</p>
     <example caption='Service Returns Error Related to Unauthorized Subject Change'><![CDATA[
 <message
@@ -2735,7 +2735,7 @@
     <forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </message>
-    ]]></example>
+]]></example>
     <p>In order to remove the existing subject but not provide a new subject (i.e., set the subject to be empty), the client shall send an empty &lt;subject/&gt; element (i.e., either "&lt;subject/&gt;" or "&lt;subject&gt;&lt;/subject&gt;").</p>
     <example caption='Moderator Sets Empty Subject'><![CDATA[
 <message
@@ -2745,7 +2745,7 @@
     type='groupchat'>
   <subject></subject>
 </message>
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Kicking an Occupant' anchor='kick'>
@@ -2761,7 +2761,7 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST remove the kicked occupant by sending a presence stanza of type "unavailable" to each kicked occupant, including status code 307 in the extended presence information, optionally along with the reason (if provided) and the roomnick or bare JID of the user who initiated the kick.</p>
     <example caption='Service Removes Kicked Occupant'><![CDATA[
 <presence
@@ -2777,7 +2777,7 @@
     <status code='307'/>
   </x>
 </presence>
-    ]]></example>
+]]></example>
     <p>The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality). The optional inclusion of the reason and actor enable the kicked user to understand why he or she was kicked, and by whom if the kicked occupant would like to discuss the matter. <note>Some commentors have complained that this opens room owners and administrators up to potential abuse; unfortunately, with great power comes great responsibility.</note></p>
     <p>After removing the kicked occupant(s), the service MUST then inform the moderator of success:</p>
     <example caption='Service Informs Moderator of Success'><![CDATA[
@@ -2785,7 +2785,7 @@
     id='kick1'
     to='fluellen@shakespeare.lit/pda'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>After informing the moderator, the service MUST then inform all of the remaining occupants that the kicked occupant is no longer in the room by sending presence stanzas of type "unavailable" from the individual's roomnick (&OCCUPANTJID;) to all the remaining occupants (just as it does when occupants exit the room of their own volition), including the status code and optionally the reason and actor.</p>
     <example caption='Service Informs Remaining Occupants'><![CDATA[
 <presence
@@ -2799,7 +2799,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
     <p>A user cannot be kicked by a moderator with a lower affiliation. Therefore, if a moderator who is a member attempts to kick an admin or a moderator who is a member or admin attempts to kick an owner, the service MUST deny the request and return a &notallowed; error to the sender:</p>
     <example caption='Service Returns Error on Attempt to Kick User With Higher Affiliation'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -2810,7 +2810,7 @@
     <not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
     <p>If a moderator attempts to kick himself, the service MAY deny the request and return a &conflict; error to the sender. (Although the act of kicking oneself may seem odd, it is common in IRC as a way of apologizing for one's actions in the room.)</p>
   </section2>
 
@@ -2826,7 +2826,7 @@
           role='participant'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The &lt;reason/&gt; element is OPTIONAL:</p>
     <example caption='Moderator Grants Voice to a Visitor (With a Reason)'><![CDATA[
 <iq from='crone1@shakespeare.lit/desktop'
@@ -2840,14 +2840,14 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST then inform the moderator of success:</p>
     <example caption='Service Informs Moderator of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='voice1'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>The service MUST then send updated presence from this individual's &OCCUPANTJID; to all occupants, indicating the addition of voice privileges by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "participant".</p>
     <example caption="Service Sends Notice of Voice to All Occupants"><![CDATA[
 <presence
@@ -2863,7 +2863,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Revoking Voice from a Participant' anchor='revokevoice'>
@@ -2878,7 +2878,7 @@
           role='visitor'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The &lt;reason/&gt; element is OPTIONAL:</p>
     <example caption='Moderator Revokes Voice from a Visitor (With a Reason)'><![CDATA[
 <iq from='crone1@shakespeare.lit/desktop'
@@ -2892,14 +2892,14 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST then inform the moderator of success:</p>
     <example caption='Service Informs Moderator of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='voice2'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>The service MUST then send updated presence from this individual to all occupants, indicating the removal of voice privileges by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "visitor".</p>
     <example caption="Service Notes Loss of Voice"><![CDATA[
 <presence
@@ -2913,7 +2913,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
     <p>A moderator MUST NOT be able to revoke voice from a user whose affiliation is at or above the moderator's level. In addition, a service MUST NOT allow the voice privileges of an admin or owner to be removed by anyone. If a moderator attempts to revoke voice privileges from such a user, the service MUST deny the request and return a &notallowed; error to the sender along with the offending item(s):</p>
     <example caption='Service Returns Error on Attempt to Revoke Voice from an Admin, Owner, or User with a Higher Affiliation'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -2924,7 +2924,7 @@
     <not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Modifying the Voice List' anchor='modifyvoice'>
@@ -2938,7 +2938,7 @@
     <item role='participant'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST then return the voice list to the moderator; each item MUST include the 'nick' and 'role' attributes and SHOULD include the 'affiliation' and 'jid' attributes:</p>
     <example caption='Service Sends Voice List to Moderator'><![CDATA[
 <iq from='goodfolk@chat.shakespeare.lit'
@@ -2960,7 +2960,7 @@
           role='participant'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The moderator can then modify the voice list if desired. In order to do so, the moderator MUST send the changed items (i.e., only the "delta") back to the service; each item MUST include the 'nick' attribute and 'role' attribute (normally set to a value of "participant" or "visitor") but SHOULD NOT include the 'jid' attribute and MUST NOT include the 'affiliation' attribute (which is used to manage affiliations such as owner rather than the participant role):</p>
     <example caption='Moderator Sends Modified Voice List to Service'><![CDATA[
 <iq from='bard@shakespeare.lit/globe'
@@ -2980,14 +2980,14 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST then inform the moderator of success:</p>
     <example caption='Service Informs Moderator of Success'><![CDATA[
 <iq from='goodfolk@chat.shakespeare.lit'
     id='voice1'
     to='bard@shakespeare.lit/globe'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in voice privileges by sending the appropriate extended presence stanzas as described in the foregoing use cases.</p>
     <p>As noted, voice privileges cannot be revoked from a room owner or room admin, nor from any user with a higher affiliation than the moderator making the request. If a room admin attempts to revoke voice privileges from such a user by modifying the voice list, the service MUST deny the request and return a &notallowed; error to the sender:</p>
     <example caption='Service Returns Error on Attempt to Revoke Voice from an Admin, Owner, or User with a Higher Affiliation'><![CDATA[
@@ -2999,7 +2999,7 @@
     <not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Approving Voice Requests' anchor='voiceapprove'>
@@ -3041,7 +3041,7 @@
     </field>
   </x>
 </message>
-    ]]></example>
+]]></example>
     <p>In order to approve the request, a moderator shall submit the form:</p>
     <example caption='Voice Request Approval Submission'><![CDATA[
 <message from='crone1@shakespeare.lit/pda'
@@ -3065,7 +3065,7 @@
     </field>
   </x>
 </message>
-    ]]></example>
+]]></example>
     <p>If a moderator approves the voice request, the service shall grant voice to the occupant and send a presence update as described in the <link url='#grantvoice'>Granting Voice to a Visitor</link> section of this document.</p>
   </section2>
 
@@ -3094,7 +3094,7 @@
           jid='earlofcambridge@shakespeare.lit'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The &lt;reason/&gt; element is OPTIONAL.</p>
     <example caption='Admin Bans User (With a Reason)'><![CDATA[
 <iq from='kinghenryv@shakespeare.lit/throne'
@@ -3108,14 +3108,14 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST add that bare JID to the ban list, MUST remove the outcast's nickname from the list of registered nicknames, and MUST inform the admin or owner of success:</p>
     <example caption='Service Informs Admin or Owner of Success'><![CDATA[
 <iq from='southampton@chat.shakespeare.lit'
     id='ban1'
     to='kinghenryv@shakespeare.lit/throne'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>The service MUST also remove any banned users who are in the room by sending a presence stanza of type "unavailable" to each banned occupant, including status code 301 in the extended presence information, optionally along with the reason (if provided) and the roomnick or bare JID of the user who initiated the ban.</p>
     <example caption='Service Removes Banned User'><![CDATA[
 <presence
@@ -3130,7 +3130,7 @@
     <status code='301'/>
   </x>
 </presence>
-    ]]></example>
+]]></example>
     <p>The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality). The optional inclusion of the reason and actor enable the banned user to understand why he or she was banned, and by whom if the banned user would like to discuss the matter.</p>
     <p>The service MUST then inform all of the remaining occupants that the banned user is no longer in the room by sending presence stanzas of type "unavailable" from the banned user to all remaining occupants (just as it does when occupants exit the room of their own volition), including the status code and optionally the reason and actor:</p>
     <example caption='Service Informs Remaining Occupants'><![CDATA[
@@ -3147,7 +3147,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
     <p>As with <link url='#kick'>Kicking an Occupant</link>, a user cannot be banned by an admin with a lower affiliation. Therefore, if an admin attempts to ban an owner, the service MUST deny the request and return a &notallowed; error to the sender:</p>
     <example caption='Service Returns Error on Attempt to Ban User With Higher Affiliation'><![CDATA[
 <iq from='kinghenryv@shakespeare.lit/throne'
@@ -3158,7 +3158,7 @@
     <not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
     <p>If an admin or owner attempts to ban himself, the service MUST deny the request and return a &conflict; error to the sender. (Note: This is different from the recommended service behavior on kicking oneself.)</p>
   </section2>
 
@@ -3173,7 +3173,7 @@
     <item affiliation='outcast'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST then return the list of banned users to the admin; each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' and 'role' attributes:</p>
     <example caption='Service Sends Ban List to Admin'><![CDATA[
 <iq from='southampton@chat.shakespeare.lit'
@@ -3187,7 +3187,7 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The admin can then modify the ban list if desired. In order to do so, the admin MUST send the changed items (i.e., only the "delta") back to the service; each item MUST include the 'affiliation' attribute (normally set to a value of "outcast" to ban or "none" to remove ban) and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than affiliations such as outcast); in addition, the reason and actor elements are OPTIONAL:</p>
     <example caption='Admin Sends Modified Ban List to Service'><![CDATA[
 <iq from='kinghenryv@shakespeare.lit/throne'
@@ -3205,14 +3205,14 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>After updating the ban list, the service MUST inform the admin of success:</p>
     <example caption='Service Informs Admin of Success'><![CDATA[
 <iq from='southampton@chat.shakespeare.lit'
     id='ban3'
     to='kinghenryv@shakespeare.lit/throne'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>The service MUST then remove the affected occupants (if they are in the room) and send updated presence (including the appropriate status code) from them to all the remaining occupants as described in the "Banning a User" use case. (The service MUST also remove each banned user's reserved nickname from the list of reserved roomnicks, if appropriate.)</p>
     <p>When an entity is banned from a room, an implementation SHOULD match JIDs in the following order (these matching rules are the same as those defined for privacy lists in &xep0016;):</p>
     <ol start='1'>
@@ -3237,7 +3237,7 @@
           nick='thirdwitch'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The &lt;reason/&gt; element is OPTIONAL.</p>
     <example caption='Admin Grants Membership (With a Reason)'><![CDATA[
 <iq from='crone1@shakespeare.lit/desktop'
@@ -3252,14 +3252,14 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST add the user to the member list and then inform the admin of success:</p>
     <example caption='Service Informs Admin of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='member1'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of membership by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "member".</p>
     <example caption="Service Sends Notice of Membership to All Occupants"><![CDATA[
 <presence
@@ -3274,7 +3274,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Revoking Membership' anchor='revokemember'>
@@ -3289,7 +3289,7 @@
           jid='hag66@shakespeare.lit'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The &lt;reason/&gt; element is OPTIONAL.</p>
     <example caption='Admin Revokes Membership (With a Reason)'><![CDATA[
 <iq from='crone1@shakespeare.lit/desktop'
@@ -3303,14 +3303,14 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST remove the user from the member list and then inform the moderator of success:</p>
     <example caption='Service Informs Moderator of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='member2'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>The service MUST then send updated presence from this individual to all occupants, indicating the loss of membership by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "none".</p>
     <example caption="Service Notes Loss of Membership"><![CDATA[
 <presence
@@ -3324,7 +3324,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
     <p>If the room is members-only, the service MUST remove the user from the room, including a status code of 321 to indicate that the user was removed because of an affiliation change, and inform all remaining occupants:</p>
     <example caption='Service Removes Non-Member'><![CDATA[
 <presence
@@ -3350,7 +3350,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Modifying the Member List' anchor='modifymember'>
@@ -3366,7 +3366,7 @@
     <item affiliation='member'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>Note: A service SHOULD also return the member list to any occupant in a members-only room; i.e., it SHOULD NOT generate a &forbidden; error when a member in the room requests the member list. This functionality can assist clients in showing all the existing members even if some of them are not in the room, e.g. to help a member determine if another user should be invited. A service SHOULD also allow any member to retrieve the member list even if not yet an occupant.</p>
     <p>The service MUST then return the full member list to the admin qualified by the 'http://jabber.org/protocol/muc#admin' namespace; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for each member that is currently an occupant.</p>
     <example caption='Service Sends Member List to Admin'><![CDATA[
@@ -3381,7 +3381,7 @@
           role='participant'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The admin can then modify the member list if desired. In order to do so, the admin MUST send the changed items (i.e., only the "delta") to the service; each item MUST include the 'affiliation' attribute (normally set to a value of "member" or "none") and 'jid' attribute but SHOULD NOT include the 'nick' attribute (unless modifying the user's reserved nickname) and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than affiliations such as member):</p>
     <example caption='Admin Sends Modified Member List to Service'><![CDATA[
 <iq from='crone1@shakespeare.lit/desktop'
@@ -3395,14 +3395,14 @@
           jid='hecate@shakespeare.lit'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST modify the member list and then inform the moderator of success:</p>
     <example caption='Service Informs Moderator of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='member4'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>The service MUST change the affiliation of any affected user. If the user has been removed from the member list, the service MUST change the user's affiliation from "member" to "none". If the user has been added to the member list, the service MUST change the user's affiliation to "member".</p>
     <p>If a removed member is currently in a members-only room, the service SHOULD kick the occupant by changing the removed member's role to "none" and send appropriate presence to the removed member as previously described. The service MUST subsequently refuse entry to the user.</p>
     <p>For all room types, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "none".</p>
@@ -3418,7 +3418,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
     <p>In addition, the service SHOULD send an invitation to any user who has been added to the member list of a members-only room if the user is not currently affiliated with the room (note that the following example includes a password but not a reason -- both child elements are OPTIONAL):</p>
     <example caption='Room Sends Invitation to New Member'><![CDATA[
 <message
@@ -3430,7 +3430,7 @@
     <password>cauldronburn</password>
   </x>
 </message>
-    ]]></example>
+]]></example>
     <p>Although only admins and owners SHOULD be allowed to modify the member list, an implementation MAY provide a configuration option that opens invitation privileges to any member of a members-only room. In such a situation, any invitation sent SHOULD automatically trigger the addition of the invitee to the member list. However, if invitation privileges are restricted to admins and a mere member attempts to a send an invitation, the service MUST deny the invitation request and return a &forbidden; error to the sender:</p>
     <example caption='Service Returns Error on Attempt by Mere Member to Invite Others to a Members-Only Room'><![CDATA[
 <message
@@ -3449,7 +3449,7 @@
     <forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </message>
-    ]]></example>
+]]></example>
     <p>Invitations sent through an open room MUST NOT trigger the addition of the invitee to the member list.</p>
     <p>If a user is added to the member list of an open room and the user is in the room, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "member".</p>
     <example caption="Service Sends Notice of Membership to All Occupants"><![CDATA[
@@ -3464,7 +3464,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Granting Moderator Status' anchor='grantmod'>
@@ -3479,7 +3479,7 @@
           role='moderator'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The &lt;reason/&gt; element is OPTIONAL.</p>
     <example caption='Admin Grants Moderator Status (With a Reason)'><![CDATA[
 <iq from='crone1@shakespeare.lit/desktop'
@@ -3493,14 +3493,14 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST add the user to the moderator list and then inform the admin of success:</p>
     <example caption='Service Informs Admin of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='mod1'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>The service MUST then send updated presence from this individual to all occupants, indicating the addition of moderator status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "moderator".</p>
     <example caption="Service Sends Notice of Moderator Status to All Occupants"><![CDATA[
 <presence
@@ -3514,7 +3514,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Revoking Moderator Status' anchor='revokemod'>
@@ -3529,7 +3529,7 @@
           role='participant'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The &lt;reason/&gt; element is OPTIONAL.</p>
     <example caption='Admin Revokes Moderator Status (With a Reason)'><![CDATA[
 <iq from='crone1@shakespeare.lit/desktop'
@@ -3543,14 +3543,14 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST remove the user from the moderator list and then inform the admin of success:</p>
     <example caption='Service Informs Admin of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='mod2'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>The service MUST then send updated presence from this individual to all occupants, indicating the removal of moderator status by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "participant".</p>
     <example caption="Service Notes Loss of Moderator Status"><![CDATA[
 <presence
@@ -3564,7 +3564,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
     <p>As noted, an admin MUST NOT be allowed to revoke moderator status from a user whose affiliation is "owner" or "admin". If an admin attempts to revoke moderator status from such a user, the service MUST deny the request and return a &notallowed; error to the sender:</p>
     <example caption='Service Returns Error on Attempt to Revoke Moderator Status from an Admin or Owner'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -3575,7 +3575,7 @@
     <not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Modifying the Moderator List' anchor='modifymod'>
@@ -3589,7 +3589,7 @@
     <item role='moderator'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST then return the moderator list to the admin; each item MUST include the 'nick' and 'role' attributes, and MAY include the 'jid' and 'affiliation' attributes:</p>
     <example caption='Service Sends Moderator List to Admin'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -3603,7 +3603,7 @@
           role='moderator'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The admin can then modify the moderator list if desired. In order to do so, the admin MUST send the changed items (i.e., only the "delta") back to the service; each item MUST include the 'nick' attribute and 'role' attribute (set to a value of "moderator" to grant moderator status or "participant" to revoke moderator status), but SHOULD NOT include the 'jid' attribute and MUST NOT include the 'affiliation' attribute (which is used to manage affiliations such as admin rather than the moderator role):</p>
     <example caption='Admin Sends Modified Moderator List to Service'><![CDATA[
 <iq from='crone1@shakespeare.lit/desktop'
@@ -3617,14 +3617,14 @@
           role='moderator'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST modify the moderator list and then inform the admin of success:</p>
     <example caption='Service Informs Admin of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='mod4'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in moderator status by sending the appropriate extended presence stanzas as described in the foregoing use cases.</p>
     <p>As noted, moderator status cannot be revoked from a room owner or room admin. If a room admin attempts to revoke moderator status from such a user by modifying the moderator list, the service MUST deny the request and return a &notallowed; error to the sender:</p>
     <example caption='Service Returns Error on Attempt to Revoke Moderator Status from an Admin or Owner'><![CDATA[
@@ -3636,7 +3636,7 @@
     <not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Approving Registration Requests' anchor='regapprove'>
@@ -3693,7 +3693,7 @@
     </field>
   </x>
 </message>
-    ]]></example>
+]]></example>
     <p>If the admin approves the registration request, the service shall register the user with the room.</p>
     <p>More advanced registration approval mechanisms (e.g., retrieving a list of registration requests using &xep0050; as is done in &xep0060;) are out of scope for this document.</p>
   </section2>
@@ -3717,7 +3717,7 @@
     <not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </presence>
-      ]]></example>
+]]></example>
       <p>If access is not restricted, the service MUST allow the user to create a room as described below.</p>
       <p>From the perspective of room creation, there are in essence two kinds of rooms:</p>
       <ul>
@@ -3741,7 +3741,7 @@
     to='coven@chat.shakespeare.lit/firstwitch'>
   <x xmlns='http://jabber.org/protocol/muc'/>
 </presence>
-      ]]></example>
+]]></example>
       <p>If the room does not yet exist, the service SHOULD create the room (subject to local policies regarding room creation), assign the bare JID of the requesting user as the owner, add the owner to the room, and acknowledge successful creation of the room by sending a presence stanza of the following form:</p>
       <example caption="Service Acknowledges Room Creation"><![CDATA[
 <presence
@@ -3754,7 +3754,7 @@
     <status code='201'/>
   </x>
 </presence>
-      ]]></example>
+]]></example>
       <p>After receiving notification that the room has been created, the room owner needs to decide whether to accept the default room configuration (i.e., create an "instant room") or configure the room to use something other than the default room configuration (i.e., create a "reserved room"). The protocol flows for completing those two use cases are shown in the following sections.</p>
       <p>Note: If the presence stanza sent to a nonexistent room does not include an &X; element qualified by the 'http://jabber.org/protocol/muc' namespace as shown above, the service SHOULD create a default room without delay (i.e., it MUST assume that the client supports groupchat 1.0 rather than MUC and therefore it MUST NOT lock the room while waiting for the room creator to either accept an instant room or configure a reserved room).</p>
     </section3>
@@ -3770,7 +3770,7 @@
     <x xmlns='jabber:x:data' type='submit'/>
   </query>
 </iq>
-      ]]></example>
+]]></example>
       <p>The service MUST then unlock the room and allow other entities to join it.</p>
     </section3>
 
@@ -3783,7 +3783,7 @@
     type='get'>
   <query xmlns='http://jabber.org/protocol/muc#owner'/>
 </iq>
-      ]]></example>
+]]></example>
       <p>If the room does not already exist, the service MUST return an initial room configuration form to the user. (Note: The following example shows a representative sample of configuration options. A full list of x:data fields registered for use in room creation and configuration is maintained by the XMPP Registrar; see the <link url="#registrar">XMPP Registrar Considerations</link> section of this document.)</p>
       <example caption='Service Sends Configuration Form'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -3976,7 +3976,7 @@
     </x>
   </query>
 </iq>
-      ]]></example>
+]]></example>
       <p>Note: The _whois configuration option specifies whether the room is non-anonymous (a value of "anyone"), semi-anonymous (a value of "moderators"), or fully anonmyous (a value of "none", not shown here).</p>
       <p>If there are no configuration options available, the service MUST return an empty query element to the room owner:</p>
       <example caption='Service Informs Owner that No Configuration is Possible'><![CDATA[
@@ -3986,7 +3986,7 @@
     type='result'>
   <query xmlns='http://jabber.org/protocol/muc#owner'/>
 </iq>
-      ]]></example>
+]]></example>
       <p>The room owner SHOULD then fill out the form and submit it to the service.</p>
       <example caption='Owner Submits Configuration Form'><![CDATA[
 <iq from='crone1@shakespeare.lit/desktop'
@@ -4050,14 +4050,14 @@
     </x>
   </query>
 </iq>
-      ]]></example>
+]]></example>
       <p>If room creation is successful, the service MUST inform the new room owner of success:</p>
       <example caption='Service Informs New Room Owner of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='create2'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-      ]]></example>
+]]></example>
       <p>If the room creation fails because the specified room configuration options violate one or more service policies (e.g., because the password for a password-protected room is blank), the service MUST return a &notacceptable; error.</p>
       <example caption='Service Informs Owner that Requested Configuration Options Are Unacceptable'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -4068,7 +4068,7 @@
     <not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-      ]]></example>
+]]></example>
       <p>Alternatively, the room owner MAY cancel the configuration process:</p>
       <example caption='Owner Cancels Initial Configuration'><![CDATA[
 <iq from='crone1@shakespeare.lit/desktop'
@@ -4079,7 +4079,7 @@
     <x xmlns='jabber:x:data' type='cancel'/>
   </query>
 </iq>
-      ]]></example>
+]]></example>
       <p>If the room owner cancels the initial configuration, the service MUST destroy the room, making sure to send unavailable presence to the room owner (see the "Destroying a Room" use case for protocol details).</p>
       <p>If the room owner becomes unavailable for any reason before submitting the form (e.g., a lost connection), the service will receive a presence stanza of type "unavailable" from the owner to the owner's &OCCUPANTJID;. The service MUST then destroy the room, sending a presence stanza of type "unavailable" from the room to the owner including a &lt;destroy/&gt; element and reason (if provided) as defined in the <link url='#destroyroom'>Destroying a Room</link> section of this document.</p>
     </section3>
@@ -4095,7 +4095,7 @@
     type='get'>
   <query xmlns='http://jabber.org/protocol/muc#owner'/>
 </iq>
-    ]]></example>
+]]></example>
     <p>If the &lt;user@host&gt; of the 'from' address does not match the bare JID of a room owner, the service MUST return a &forbidden; error to the sender:</p>
     <example caption='Service Denies Configuration Access to Non-Owner'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -4107,7 +4107,7 @@
     <forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
     <p>Otherwise, the service MUST send a configuration form to the room owner with the current options set as defaults:</p>
     <example caption='Service Sends Configuration Form to Owner'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -4295,7 +4295,7 @@
     </x>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>If there are no configuration options available, the service MUST return an empty query element to the room owner as shown in the previous use case.</p>
     <p>The room owner then submits the form with updated configuration information. (Example not shown.)</p>
     <p>Alternatively, the room owner MAY cancel the configuration process:</p>
@@ -4308,7 +4308,7 @@
     <x xmlns='jabber:x:data' type='cancel'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>If the room owner cancels the subsequent configuration, the service MUST leave the configuration of the room as it was before the room owner initiated the subsequent configuration process.</p>
     <p>If as a result of a change in the room configuration a room admin loses admin status while in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "member" or "none" and the 'role' attribute set to a value of "participant" or "visitor" as appropriate for the affiliation level and the room type:</p>
     <example caption="Service Notes Loss of Admin Affiliation"><![CDATA[
@@ -4323,7 +4323,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
     <p>If as a result of a change in the room configuration a user gains admin status while in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "admin" and the 'role' attribute set to a value of "moderator":</p>
     <example caption="Service Notes Gain of Admin Affiliation to All Users"><![CDATA[
 <presence
@@ -4337,7 +4337,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
     <p>If as a result of a change in the room configuration a room owner loses owner status while that owner is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "admin" and the 'role' attribute set to an appropriate value given the affiliation and room type ("moderator" is recommended).</p>
     <example caption="Service Notes Loss of Owner Affiliation"><![CDATA[
 <presence
@@ -4351,7 +4351,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
     <p>A service MUST NOT allow an owner to revoke his or her own owner status if there are no other owners; if an owner attempts to do this, the service MUST return a &conflict; error to the owner. However, a service SHOULD allow an owner to revoke his or her own owner status if there are other owners.</p>
     <p>If as a result of a change in the room configuration a user gains owner status while in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "owner" and the 'role' attribute set to an appropriate value given the affiliation and room type ("moderator" is recommended).</p>
     <example caption="Service Notes Gain of Owner Affiliation to All Users"><![CDATA[
@@ -4366,7 +4366,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
     <p>If as a result of a change in the room configuration the room type is changed to members-only but there are non-members in the room, the service MUST remove any non-members from the room and include a status code of 322 in the presence unavailable stanzas sent to those users as well as any remaining occupants.</p>
     <section3 topic='Notification of Configuration Changes' anchor='roomconfig-notify'>
       <p>A room MUST send notification to all occupants when the room configuration changes in a way that has an impact on the privacy or security profile of the room. This notification shall consist of a &MESSAGE; stanza containing an &X; element qualified by the 'http://jabber.org/protocol/muc#user' namespace, which shall contain only a &lt;status/&gt; element with an appropriate value for the 'code' attribute. Here is an example:</p>
@@ -4379,7 +4379,7 @@
     <status code='170'/>
   </x>
 </message>
-      ]]></example>
+]]></example>
       <p>The codes to be generated as a result of a privacy-related change in room configuration are as follows:</p>
       <ul>
         <li>If room logging is now enabled, status code 170.</li>
@@ -4404,7 +4404,7 @@
           jid='hecate@shakespeare.lit'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The &lt;reason/&gt; element is OPTIONAL.</p>
     <example caption='Owner Grants Owner Status (With a Reason)'><![CDATA[
 <iq from='crone1@shakespeare.lit/desktop'
@@ -4418,14 +4418,14 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST add the user to the owner list and then inform the owner of success:</p>
     <example caption='Service Informs Owner of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='owner1'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of owner status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "owner" and the 'role' attribute set to an appropriate value given the affiliation and room type ("moderator" is recommended).</p>
     <example caption="Service Sends Notice of Owner Status to All Occupants"><![CDATA[
 <presence
@@ -4439,7 +4439,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
     <p>If the user is not in the room, the service MAY send a message from the room itself to the room occupants, indicating the granting of owner status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "owner".</p>
     <example caption="Service Sends Notice of Owner Status to All Occupants"><![CDATA[
 <message
@@ -4454,7 +4454,7 @@
 </message>
 
 [ ... ]
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Revoking Owner Status' anchor='revokeowner'>
@@ -4469,7 +4469,7 @@
           jid='hecate@shakespeare.lit'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The &lt;reason/&gt; element is OPTIONAL.</p>
     <example caption='Owner Revokes Owner Status (With a Reason)'><![CDATA[
 <iq from='crone1@shakespeare.lit/desktop'
@@ -4483,7 +4483,7 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>A service MUST NOT allow an owner to revoke his or her own owner status if there are no other owners; if an owner attempts to do this, the service MUST return a &conflict; error to the owner. However, a service SHOULD allow an owner to revoke his or her own owner status if there are other owners.</p>
     <p>If an implementation does not allow one owner to revoke another user's owner status, the implementation MUST return a &notauthorized; error to the owner who made the request.</p>
     <p>Note: Allowing an owner to remove another user's owner status can compromise the control model for room management; therefore this feature is OPTIONAL, and implementations are encouraged to support owner removal through an interface that is open only to individuals with service-wide admin status.</p>
@@ -4493,7 +4493,7 @@
     id='owner2'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the loss of owner status by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value other than "owner" and the 'role' attribute set to an appropriate value:</p>
     <example caption="Service Notes Loss of Owner Affiliation"><![CDATA[
 <presence
@@ -4507,7 +4507,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Modifying the Owner List' anchor='modifyowner'>
@@ -4521,7 +4521,7 @@
     <item affiliation='owner'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>If the &lt;user@host&gt; of the 'from' address does not match the bare JID of a room owner, the service MUST return a &forbidden; error to the sender.</p>
     <p>Otherwise, the service MUST then return the owner list to the owner; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for any owner that is currently an occupant:</p>
     <example caption='Service Sends Owner List to Owner'><![CDATA[
@@ -4534,7 +4534,7 @@
           jid='crone1@shakespeare.lit'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The owner can then modify the owner list if desired. In order to do so, the owner MUST send the changed items (i.e., only the "delta") back to the service; <note>This is different from the behavior of room configuration, wherein the "muc#roomconfig_roomowners" field specifies the full list of room owners, not the delta.</note> each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than affiliations such as owner):</p>
     <example caption='Owner Sends Modified Owner List to Service'><![CDATA[
 <iq from='bard@shakespeare.lit/globe'
@@ -4546,7 +4546,7 @@
           jid='hecate@shakespeare.lit'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>Only owners shall be allowed to modify the owner list. If a non-owner attempts to view or modify the owner list, the service MUST deny the request and return a &forbidden; error to the sender:</p>
     <example caption='Service Returns Error on Attempt by Non-Owner to Modify Owner List'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -4557,7 +4557,7 @@
     <forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
     <p>A service MUST NOT allow an owner to revoke his or her own owner status if there are no other owners; if an owner attempts to do this, the service MUST return a &conflict; error to the owner. However, a service SHOULD allow an owner to revoke his or her own owner status if there are other owners.</p>
     <p>In all other cases, the service MUST modify owner list and then inform the owner of success:</p>
     <example caption='Service Informs Owner of Success'><![CDATA[
@@ -4565,7 +4565,7 @@
     id='owner4'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>The service MUST also send presence notifications related to any affiliation changes that result from modifying the owner list as previously described.</p>
   </section2>
 
@@ -4581,7 +4581,7 @@
           jid='wiccarocks@shakespeare.lit'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The &lt;reason/&gt; element is OPTIONAL.</p>
     <example caption='Owner Grants Admin Privileges (With a Reason)'><![CDATA[
 <iq from='crone1@shakespeare.lit/desktop'
@@ -4595,14 +4595,14 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST add the user to the admin list and then inform the owner of success:</p>
     <example caption='Service Informs Owner of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='admin1'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of admin status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "admin" and the 'role' attribute set to an appropriate value given the affiliation and room type (typically "moderator").</p>
     <example caption="Service Sends Notice of Admin Status to All Occupants"><![CDATA[
 <presence
@@ -4616,7 +4616,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
     <p>If the user is not in the room, the service MAY send a message from the room itself to the room occupants, indicating the granting of admin status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "admin".</p>
     <example caption="Service Sends Notice of Admin Status to All Occupants"><![CDATA[
 <message
@@ -4631,7 +4631,7 @@
 </message>
 
 [ ... ]
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Revoking Admin Status' anchor='revokeadmin'>
@@ -4646,7 +4646,7 @@
           jid='wiccarocks@shakespeare.lit'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The &lt;reason/&gt; element is OPTIONAL.</p>
     <example caption='Owner Revokes Admin Status (With a Reason)'><![CDATA[
 <iq from='crone1@shakespeare.lit/desktop'
@@ -4660,14 +4660,14 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service MUST remove the user from the admin list and then inform the owner of success:</p>
     <example caption='Service Informs Owner of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='admin2'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the loss of admin status by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value other than "admin" or "owner" and the 'role' attribute set to an appropriate value given the affiliation level and the room type (typically "participant").</p>
     <example caption="Service Notes Loss of Admin Affiliation"><![CDATA[
 <presence
@@ -4681,7 +4681,7 @@
 </presence>
 
 [ ... ]
-    ]]></example>
+]]></example>
     <p>If the user is not in the room, the service MAY send a message from the room itself to the room occupants, indicating the loss of admin status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value other than "admin".</p>
     <example caption="Service Notes Loss of Admin Affiliation"><![CDATA[
 <message
@@ -4696,7 +4696,7 @@
 </message>
 
 [ ... ]
-    ]]></example>
+]]></example>
   </section2>
 
   <section2 topic='Modifying the Admin List' anchor='modifyadmin'>
@@ -4710,7 +4710,7 @@
     <item affiliation='admin'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>If the &lt;user@host&gt; of the 'from' address does not match the bare JID of a room owner, the service MUST return a &forbidden; error to the sender.</p>
     <p>Otherwise, the service MUST then return the admin list to the owner; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for any admin that is currently an occupant:</p>
     <example caption='Service Sends Admin List to Owner'><![CDATA[
@@ -4726,7 +4726,7 @@
           jid='hag66@shakespeare.lit'/>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The owner can then modify the admin list if desired. In order to do so, the owner MUST send the changed items (i.e., only the "delta") back to the service; <note>This is different from the behavior of room configuration, wherein the "muc#roomconfig_roomadmins" field specifies the full list of room admins, not the delta.</note> each item MUST include the 'affiliation' attribute (normally set to a value of "admin" or "none") and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than affiliations such as owner).</p>
     <example caption='Owner Sends Modified Admin List to Service'><![CDATA[
 <iq from='bard@shakespeare.lit/globe'
@@ -4742,7 +4742,7 @@
     </item>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>Only owners shall be allowed to modify the admin list. If a non-owner attempts to view or modify the admin list, the service MUST deny the request and return a &forbidden; error to the sender.</p>
     <example caption='Service Returns Error on Attempt by Non-Owner to Modify Admin List'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -4753,14 +4753,14 @@
     <forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
     <p>Otherwise, the service MUST modify the admin list and then inform the owner of success:</p>
     <example caption='Service Informs Owner of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='admin4'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>The service MUST also send presence notifications related to any affiliation changes that result from modifying the admin list as previously described.</p>
   </section2>
 
@@ -4784,7 +4784,7 @@
     </destroy>
   </query>
 </iq>
-    ]]></example>
+]]></example>
     <p>The service is responsible for removing all the occupants. It SHOULD NOT broadcast presence stanzas of type "unavailable" from all occupants, instead sending only one presence stanza of type "unavailable" to each occupant so that the user knows he or she has been removed from the room. If extended presence information specifying the JID of an alternate location and the reason for the room destruction was provided by the room owner, the presence stanza MUST include that information.</p>
     <example caption='Service Removes Each Occupant'><![CDATA[
 <presence
@@ -4822,13 +4822,13 @@
     </destroy>
   </x>
 </presence>
-    ]]></example>
+]]></example>
     <example caption='Service Informs Owner of Successful Destruction'><![CDATA[
 <iq from='heath@chat.shakespeare.lit'
     id='begone'
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
-    ]]></example>
+]]></example>
     <p>If the &lt;user@host&gt; of the 'from' address received on a destroy request does not match the bare JID of a room owner, the service MUST return a &forbidden; error to the sender:</p>
     <example caption='Service Denies Destroy Request Submitted by Non-Owner'><![CDATA[
 <iq from='heath@chat.shakespeare.lit'
@@ -4844,7 +4844,7 @@
     <forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-    ]]></example>
+]]></example>
   </section2>
 
 </section1>
@@ -5009,7 +5009,7 @@
   <desc>Unsecured room in Multi-User Chat (MUC)</desc>
   <doc>XEP-0045</doc>
 </var>
-    ]]></code>
+]]></code>
   </section2>
 
   <section2 topic='Well-Known Service Discovery Nodes' anchor='registrar-nodes'>
@@ -5059,7 +5059,7 @@
       type='text-single'
       label='A Web Page'/>
 </form_type>
-      ]]></code>
+]]></code>
     </section3>
 
     <section3 topic='muc#request FORM_TYPE' anchor='registrar-formtype-request'>
@@ -5085,7 +5085,7 @@
          type='boolean'
          label='Whether to grant voice'/>
 </form_type>
-      ]]></code>
+]]></code>
     </section3>
 
     <section3 topic='muc#roomconfig FORM_TYPE' anchor='registrar-formtype-owner'>
@@ -5182,7 +5182,7 @@
       type='list-single'
       label='Affiliations that May Discover Real JIDs of Occupants'/>
 </form_type>
-      ]]></code>
+]]></code>
     </section3>
 
     <section3 topic='muc#roominfo FORM_TYPE' anchor='registrar-formtype-roominfo'>
@@ -5236,7 +5236,7 @@
       type='boolean'
       label='The room subject can be modified by participants'/>
 </form_type>
-      ]]></code>
+]]></code>
     </section3>
 
   </section2>
@@ -5263,7 +5263,7 @@
     the descriptive child element (reserved for future use)
   </child>
 </statuscode>
-      ]]></code>
+]]></code>
       <p>The registrant may register more than one status code at a time, each contained in a separate &lt;statuscode/&gt; element.</p>
     </section3>
 
@@ -5418,7 +5418,7 @@
     because the MUC service is being shut down
   </purpose>
 </statuscode>
-      ]]></code>
+]]></code>
     </section3>
 
   </section2>
@@ -5429,24 +5429,24 @@
       <p>The "join" querytype is registered as a MUC-related action, with an optional key of "password".</p>
       <example caption='Join Action: IRI/URI'><![CDATA[
 xmpp:coven@chat.shakespeare.lit?join
-      ]]></example>
+]]></example>
       <p>The application MUST either present an interface enabling the user to provide a room nickname or populate the room nickname based on configured preferences or nickname discovery.</p>
       <example caption='Join Action: Resulting Stanza'><![CDATA[
 <presence to='coven@chat.shakespeare.lit/thirdwitch'>
   <x xmlns='http://jabber.org/protocol/muc'/>
 </presence>
-      ]]></example>
+]]></example>
       <p>The join action MAY include a password for the room. Naturally, access to a URI that includes a room password MUST be appropriately controlled.</p>
       <example caption='Join Action with Password: IRI/URI'><![CDATA[
 xmpp:coven@chat.shakespeare.lit?join;password=cauldronburn
-      ]]></example>
+]]></example>
       <example caption='Join Action with Password: Resulting Stanza'><![CDATA[
 <presence to='coven@chat.shakespeare.lit/thirdwitch'>
   <x xmlns='http://jabber.org/protocol/muc'>
     <password>cauldronburn</password>
   </x>
 </presence>
-      ]]></example>
+]]></example>
       <p>The following submission registers the "join" querytype.</p>
       <code><![CDATA[
 <querytype>
@@ -5461,14 +5461,14 @@ xmpp:coven@chat.shakespeare.lit?join;password=cauldronburn
     </key>
   </keys>
 </querytype>
-      ]]></code>
+]]></code>
     </section3>
 
     <section3 topic='invite' anchor='registrar-querytypes-invite'>
       <p>The "invite" querytype is registered as a MUC-related action, with an optional key of "jid".</p>
       <example caption='Invite Action: IRI/URI'><![CDATA[
 xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit
-      ]]></example>
+]]></example>
       <p>If the joining user is not yet in the room, the application MUST send two stanzas: the first to join the room and the second to invite the other individual. If the joining user is in the room already, the application shall send only the invitation stanza.</p>
       <example caption='Invite Action: Resulting Stanza(s)'><![CDATA[
 <presence to='coven@chat.shakespeare.lit/thirdwitch'>
@@ -5480,11 +5480,11 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit
     <invite to='hecate@shakespeare.lit'/>
   </x>
 </message>
-      ]]></example>
+]]></example>
       <p>The URI can include multiple invitees:</p>
       <example caption='Invite Action With Multiple Invitees: IRI/URI'><![CDATA[
 xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;jid=bard@shakespeare.lit
-      ]]></example>
+]]></example>
       <example caption='Invite Action With Multiple Invitees: Resulting Stanza'><![CDATA[
 <message to='coven@chat.shakespeare.lit'>
   <x xmlns='http://jabber.org/protocol/muc#user'>
@@ -5492,11 +5492,11 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;jid=bard@shake
     <invite to='bard@shakespeare.lit'/>
   </x>
 </message>
-      ]]></example>
+]]></example>
       <p>The URI can also include a password:</p>
       <example caption='Invite Action With Password: IRI/URI'><![CDATA[
 xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauldronburn
-      ]]></example>
+]]></example>
       <example caption='Invite Action With Password: Resulting Stanza(s)'><![CDATA[
 <presence to='coven@chat.shakespeare.lit/thirdwitch'>
   <x xmlns='http://jabber.org/protocol/muc'/>
@@ -5508,7 +5508,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
     <password>cauldronburn</password>
   </x>
 </message>
-      ]]></example>
+]]></example>
       <p>The following submission registers the "invite" querytype.</p>
       <code><![CDATA[
 <querytype>
@@ -5527,7 +5527,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
     </key>
   </keys>
 </querytype>
-      ]]></code>
+]]></code>
     </section3>
 
   </section2>
@@ -5607,7 +5607,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
   <query xmlns='http://jabber.org/protocol/disco#info'
          node='http://jabber.org/protocol/muc#traffic'/>
 </iq>
-      ]]></example>
+]]></example>
       <example caption='Service Returns Allowable Namespaces'><![CDATA[
 <iq from='heath@chat.shakespeare.lit'
     to='wiccarocks@shakespeare.lit/laptop'
@@ -5619,7 +5619,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
     <feature var='http://jabber.org/protocol/rosterx'/>
   </query>
 </iq>
-      ]]></example>
+]]></example>
       <p>If a service does not discard any namespaces, it MUST return a &unavailable; error:</p>
       <example caption='Service Returns Service Unavailable'><![CDATA[
 <iq from='heath@chat.shakespeare.lit'
@@ -5630,7 +5630,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
     <service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
 </iq>
-      ]]></example>
+]]></example>
     </section3>
 
     <section3 topic='Ghost Users' anchor='impl-service-ghosts'>
@@ -5666,7 +5666,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
     </item>
   </query>
 </iq>
-          ]]></code></td>
+]]></code></td>
         </tr>
         <tr>
           <td>/invite &lt;jid&gt; [comment]</td>
@@ -5679,7 +5679,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
     </invite>
   </x>
 </message>
-          ]]></code></td>
+]]></code></td>
         </tr>
         <tr>
           <td>/join &lt;roomname&gt; [pass]</td>
@@ -5690,7 +5690,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
     <password>pass</password>
   </x>
 </presence>
-          ]]></code></td>
+]]></code></td>
         </tr>
         <tr>
           <td>/kick &lt;roomnick&gt; [comment]</td>
@@ -5705,7 +5705,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
     </item>
   </query>
 </iq>
-          ]]></code></td>
+]]></code></td>
         </tr>
         <tr>
           <td>/msg &lt;roomnick&gt; &lt;foo&gt;</td>
@@ -5714,14 +5714,14 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
 <message to='room@service/nick' type='chat'>
   <body>foo</body>
 </message>
-          ]]></code></td>
+]]></code></td>
         </tr>
         <tr>
           <td>/nick &lt;newnick&gt;</td>
           <td>changes nick in this room to "newnick"</td>
           <td><code><![CDATA[
 <presence to='room@service/newnick'/>
-          ]]></code></td>
+]]></code></td>
         </tr>
         <tr>
           <td>/part [comment]</td>
@@ -5731,7 +5731,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
           type='unavailable'>
   <status>comment</status>
 </presence>
-          ]]></code></td>
+]]></code></td>
         </tr>
         <tr>
           <td>/topic &lt;foo&gt;</td>
@@ -5740,7 +5740,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
 <message to='room@service' type='groupchat'>
   <subject>foo</subject>
 </message>
-          ]]></code></td>
+]]></code></td>
         </tr>
       </table>
       <p>Note: Because MUC roomnicks follow the Resourceprep profile of stringprep, they are allowed to contain a space character, whereas IRC nicknames do not. Although a given client MAY support quotation characters for this purpose (resulting in commands such as '/ban "king lear" insanity is no defense'), most common quotation characters (such as " and ') are also allowed by Resourceprep, thus leading to added complexity and potential problems with quotation of roomnicks that contain both spaces and quotation characters. Therefore it is NOT RECOMMENDED for XMPP clients to support IRC-style shortcut commands with roomnicks that contain space characters.</p>
@@ -5802,7 +5802,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
   </xs:simpleType>
 
 </xs:schema>
-    ]]></code>
+]]></code>
   </section2>
 
   <section2 topic='http://jabber.org/protocol/muc#user' anchor='schemas-user'>
@@ -5940,7 +5940,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
   </xs:simpleType>
 
 </xs:schema>
-    ]]></code>
+]]></code>
   </section2>
 
   <section2 topic='http://jabber.org/protocol/muc#admin' anchor='schemas-admin'>
@@ -6020,7 +6020,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
   </xs:simpleType>
 
 </xs:schema>
-    ]]></code>
+]]></code>
   </section2>
 
   <section2 topic='http://jabber.org/protocol/muc#owner' anchor='schemas-owner'>
@@ -6070,7 +6070,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
   </xs:simpleType>
 
 </xs:schema>
-    ]]></code>
+]]></code>
   </section2>
 
 </section1>


### PR DESCRIPTION
This is a purely cosmetic change, so no version bump.