### PR TITLE
Implement initial last call comments for XEP-0368, editorial changes, SNI is now MUST

### DIFF
--- a/xep-0368.xml
+++ b/xep-0368.xml
@@ -5,12 +5,13 @@
 <!ENTITY rfc7301 "<span class='ref'><link url='https://tools.ietf.org/html/rfc7301'>RFC 7301</link></span> <note>RFC 7301: Transport Layer Security (TLS) Application-Layer Protocol Negotiation Extension &lt;<link url='https://tools.ietf.org/html/rfc7301'>https://tools.ietf.org/html/rfc7301</link>&gt;.</note>" >
 <!ENTITY rfc7590 "<span class='ref'><link url='https://tools.ietf.org/html/rfc7590'>RFC 7590</link></span> <note>RFC 7590: Use of Transport Layer Security (TLS) in the
            Extensible Messaging and Presence Protocol (XMPP) &lt;<link url='https://tools.ietf.org/html/rfc7590'>https://tools.ietf.org/html/rfc7590</link>&gt;.</note>" >
+<!ENTITY rfc2595 "<span class='ref'><link url='https://tools.ietf.org/html/rfc2595'>RFC 2595</link></span> <note>RFC 2595: Using TLS with IMAP, POP3 and ACAP - Section 7 &lt;<link url='https://tools.ietf.org/html/rfc2595'>https://tools.ietf.org/html/rfc2595</link>&gt;.</note>" >
 ]>
 <?xml-stylesheet type='text/xsl' href='xep.xsl'?>
 <xep>
 <header>
   <title>SRV records for XMPP over TLS</title>
-  <abstract>This specification defines a procedure to look up xmpps-client/xmpps-server SRV records (for TLS connections) in addition to xmpp-client/xmpp-server and mix weights/priorities.</abstract>
+  <abstract>This specification defines a procedure to look up xmpps-client/xmpps-server SRV records (for direct TLS connections) in addition to xmpp-client/xmpp-server and mix weights/priorities.</abstract>
   &LEGALNOTICE;
   <number>0368</number>
   <status>Proposed</status>
@@ -32,6 +33,12 @@
     <jid>travis@burtrum.org</jid>
   </author>
   <revision>
+    <version>0.1.1</version>
+    <date>2017-02-06</date>
+    <initials>tjb</initials>
+    <remark><p>Implement last call comments, editorial changes, SNI is now MUST.</p></remark>
+  </revision>
+  <revision>
     <version>0.1</version>
     <date>2015-12-15</date>
     <initials>XEP Editor (asw)</initials>
@@ -51,7 +58,17 @@
   </revision>
 </header>
 <section1 topic='Introduction' anchor='intro'>
-  <p>&xmppcore; specifies the use of xmpp-client/xmpp-server SRV records as the method of discovering how to connect to an XMPP server. This XEP extends that to include new xmpps-client/xmpps-server SRV records pointing to TLS ports and combine priorities and weights as if they were a single SRV record. Applied to both xmpps-client and xmpps-server SRV records, this provides the opportunity to connect to XMPP servers with at least equal and perhaps increased security and privacy over using STARTTLS. It also provides an easy way for clients to bypass restrictive firewalls that only allow HTTPS, and for servers to host multiple protocols/services on a single port.</p>
+  <p>&xmppcore; specifies the use of xmpp-client/xmpp-server SRV records as the method of discovering how to connect to an XMPP server. This XEP extends that to include new xmpps-client/xmpps-server SRV records pointing to direct TLS ports and combine priorities and weights as if they were a single SRV record. Applied to both xmpps-client and xmpps-server SRV records, this provides the opportunity to connect to XMPP servers with at least equal and perhaps increased security and privacy over using STARTTLS. It also provides an easy way for clients to bypass restrictive firewalls that only allow HTTPS, and for servers to host multiple protocols/services on a single port.</p>
+</section1>
+<section1 topic='Glossary' anchor='glossary'>
+  <dl>
+    <di>
+      <dt>Direct TLS</dt>
+      <dd>
+        Where TLS is attempted immediately on connect to a TCP socket, like how HTTPS works, not like how STARTTLS works with any protocol.
+      </dd>
+    </di>
+  </dl>
 </section1>
 <section1 topic='Requirements' anchor='reqs'>
     <p>The following format for DNS SRV resource records is specified in &rfc2782;:</p>
@@ -61,28 +78,52 @@
     <p><cite>XMPP Core</cite> defines SRV records only where 'service' is 'xmpp-client' and 'xmpp-server'. This document specifies to additionally look up records where 'service' is 'xmpps-client' and 'xmpps-server'. This document specifies that the following additional rules apply:</p>
     <ol>
       <li>Treat both 'xmpp-' and 'xmpps-' records as the same record with regard to connection order as specified by <cite>RFC 2782</cite>, in that all priorities and weights are mixed. (so the server operator can decide if they would rather clients connect to tcp with STARTTLS or just with TLS directly)</li>
-      <li>Where 'service' starts with 'xmpps-' the client or server MUST connect with TLS enabled.</li>
-      <li>Where 'service' starts with 'xmpp-' the client or server MUST NOT connect with TLS enabled, connection method is unchanged from <cite>XMPP Core</cite>.</li>
+      <li>Where 'service' starts with 'xmpps-' the client or server MUST connect with direct TLS enabled.</li>
+      <li>Where 'service' starts with 'xmpp-' the client or server MUST NOT connect with direct TLS enabled, connection method is unchanged from <cite>XMPP Core</cite>.</li>
       <li>TLS certificates MUST be validated the same way as for STARTTLS. (i.e., as specified in <cite>XMPP Core</cite>).</li>
-      <li>STARTTLS MUST NOT be used over TLS connections.</li>
-      <li>Client or server SHOULD set SNI TLS extension to the JID's domain part.</li>
+      <li>STARTTLS MUST NOT be used over direct TLS connections.</li>
+      <li>Client or server MUST set SNI TLS extension to the JID's domain part.</li>
       <li>Client or server SHOULD set the ALPN (&rfc7301;) TLS extension.</li>
-      <li>When ALPN is used protocol MUST be 'xmpp-client' where 'xmpps-client' is the SRV 'service'.</li>
-      <li>When ALPN is used protocol MUST be 'xmpp-server' where 'xmpps-server' is the SRV 'service'.</li>
+      <li>When ALPN is used, the ALPN protocol MUST be 'xmpp-client', where the SRV service is 'xmpps-client'.</li>
+      <li>When ALPN is used, the ALPN protocol MUST be 'xmpp-server', where the SRV service is 'xmpps-server'.</li>
     </ol>
 </section1>
 <section1 topic='Use Cases' anchor='usecases'>
-  <p>For server operators, this provides a way to host multiple services on the same port, especially when SNI or ALPN extensions are used. Servers could even host xmpp-client and xmpp-server services on the same TLS port. For clients, this provides a virtually zero overhead way to bypass restrictive firewalls that only allow HTTP over port 80 and HTTPS over port 443, as xmpp-over-tls is indistinguishable from http-over-tls when ALPN is not used.</p>
+  <p>For server operators, this provides a way to host multiple services on the same port, especially when SNI or ALPN extensions are used. Servers could even host xmpp-client and xmpp-server services on the same TLS port. For clients, this provides a virtually zero overhead way to bypass restrictive firewalls that only allow HTTP over port 80 and HTTPS over port 443, as XMPP-over-TLS is indistinguishable from HTTP-over-TLS when ALPN is not used. For clients and servers, direct TLS saves round trips vs STARTTLS.</p>
 </section1>
 <section1 topic='Implementation Notes' anchor='impl'>
-  <p>The only overhead is the single additional SRV lookup. All clients that support STARTTLS already have support for TLS-over-tcp.</p>
-  <p>Server operators should not expect multiplexing to work in all scenarios and therefore should provide additional SRV record(s) that do not require multiplexing (either standard STARTTLS or dedicated XMPP-over-TLS).  This is a result of relying on ALPN for multiplexing, where ALPN might not be supported by all devices or may be disabled by a user due to privacy reasons.</p>
+  <p>The only overhead is the single additional SRV lookup. All clients that support STARTTLS already have support for direct TLS.</p>
+  <p>Server operators should not expect multiplexing (via ALPN) to work in all scenarios and therefore should provide additional SRV record(s) that do not require multiplexing (either standard STARTTLS or dedicated direct XMPP-over-TLS).  This is a result of relying on ALPN for multiplexing, where ALPN might not be supported by all devices or may be disabled by a user due to privacy reasons.</p>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
-    <p>TLS provides AT LEAST the same level of security as STARTTLS, and more privacy without ALPN as using STARTTLS leaks that the underlying protocol is XMPP, while any TLS stream should be indistinguishable from any other TLS stream. TLS provides more security than STARTTLS if &rfc7590; is not followed, as it isn't subject to STARTTLS stripping. All security setup and certificate validation code SHOULD be shared between the STARTTLS and TLS logic as well.</p>
+    <p>Direct TLS provides AT LEAST the same level of security as STARTTLS, and more privacy without ALPN as using STARTTLS leaks that the underlying protocol is XMPP, while any direct TLS stream should be indistinguishable from any other direct TLS stream. Direct TLS provides more security than STARTTLS if &rfc7590; is not followed, as it isn't subject to STARTTLS stripping. All security setup and certificate validation code SHOULD be shared between the STARTTLS and direct TLS logic as well. All SRV-based connection methods are subject to DNS modification/stripping/spoofing of SRV records in the absence of DNSSEC.</p>
 </section1>
 <section1 topic='IANA Considerations' anchor='iana'>
-	<p>ALPN (<cite>RFC 7301</cite>) requires registration of the new Protocol IDs, 'xmpp-client' and 'xmpp-server', specified in this document.  The registry is currently located <link url='https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids'>here</link></p>
+    <p>ALPN (<cite>RFC 7301</cite>) requires registration of new Protocol IDs.  This document specifies two Protocol IDs:</p>
+
+<p>
+Protocol: XMPP jabber:client namespace<br/>
+Identification Sequence:<br/>
+&nbsp;&nbsp;&nbsp;0x78 0x6d 0x70 0x70 0x2d 0x63 0x6c 0x69 0x65 0x6e 0x74 ("xmpp-client")<br/>
+Reference: [<link url='https://xmpp.org/extensions/xep-0368.html'>XEP-0368</link>]
+</p>
+
+<p>
+Protocol: XMPP jabber:server namespace<br/>
+Identification Sequence:<br/>
+&nbsp;&nbsp;&nbsp;0x78 0x6d 0x70 0x70 0x2d 0x73 0x65 0x72 0x76 0x65 0x72 ("xmpp-server")<br/>
+Reference: [<link url='https://xmpp.org/extensions/xep-0368.html'>XEP-0368</link>]
+</p>
+
+<p>The ALPN registry is currently located <link url='https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids'>here</link>.</p>
+
+<p>Issues with direct TLS ports mentioned in &rfc2595; <link url='https://tools.ietf.org/html/rfc2595#section-7'>Section 7</link> do not apply here for these reasons:</p>
+    <ol>
+      <li>URL scheme is unchanged.</li>
+      <li>"Security" is the same between STARTTLS and direct TLS, and post-2014 the general consensus is that no public XMPP server or client should connect without some form of TLS per the <link url='https://github.com/stpeter/manifesto/blob/master/manifesto.txt'>ubiquitous encryption manifesto</link>.</li>
+      <li>A "Use TLS when available" security model is possible here because the client could fall back to standard STARTTLS SRV records if the server administrator supplies them.</li>
+      <li>No port numbers are assigned because SRV allows using arbitrary ports at the server administrator's discretion.</li>
+    </ol>
 </section1>
 <section1 topic='XMPP Registrar Considerations' anchor='registrar'>
   <p>There are no XMPP Registrar Considerations.</p>


### PR DESCRIPTION
The only thing I'm not sure of is where the comments re: RFC 2595 belong @dwd I put them in IANA Considerations, but that somehow feels wrong, any thoughts?