### PR TITLE
XEP-0387: Add several missing XEPs / typo fixes

### DIFF
--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE xep SYSTEM 'xep.dtd' [
 <!ENTITY % ents SYSTEM 'xep.ent'>
 %ents;
-<!ENTITY forpep "<note>Necessary to support Personal Eventing Protocol (PEP).</note>">
 <!ENTITY component "<note>Support can be enabled via an external component or an internal server module/plugin.</note>">
 <!ENTITY usecases "<note>Support for the Entity Use Cases and Occupant Use Cases is REQUIRED; support for the remaining use cases is RECOMMENDED.</note>">
 <!ENTITY onlyone "<note>Only one of the recommended providers must be implemented for compliance.</note>">
@@ -110,7 +109,7 @@
           <td><strong>Feature broadcasts</strong></td>
           <td align='center'>&#10005;</td>
           <td align='center'>&#10003;</td>
-          <td align='center'>&#10003;&forpep;</td>
+          <td align='center'>&#10003;</td>
           <td align='center'>&#10003;</td>
           <td>&xep0115;</td>
         </tr>

--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -49,6 +49,19 @@
     <shortname>CS2017</shortname>
     &sam;
     <revision>
+      <version>0.2.0</version>
+      <date>2017-02-10</date>
+      <initials>ssw</initials>
+      <remark>
+        <ul>
+          <li>Add XEP-0085: Chat State Notifications</li>
+          <li>Add XEP-0249: Direct MUC Invitations</li>
+          <li>Add XEP-0368: SRV records for XMPP over TLS</li>
+          <li>Typo fixes (thanks to Georg Lucas)</li>
+        </ul>
+      </remark>
+    </revision>
+    <revision>
       <version>0.1.0</version>
       <date>2017-02-08</date>
       <initials>ssw</initials>

--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -63,7 +63,7 @@
       and software certification.
       This document specifies the 2017 compliance levels for XMPP clients and
       servers; it is hoped that this document will advance the state of the art,
-      and provide guidance and eventual certification to XMPP client and server
+      and provide guidence and eventual certification to XMPP client and server
       authors.
       Unless explicitly noted, support for the listed specifications is REQUIRED
       for compliance purposes.
@@ -96,7 +96,7 @@
           <td align='center'>&#10003;</td>
           <td align='center'>&#10003;</td>
           <td align='center'>&#10003;</td>
-          <td>&rfc7590;, &xep0368;</td>
+          <td>&rfc7590;, &xep0368;<note>Server support means having the ability to accept direct TLS connections.</note></td>
         </tr>
         <tr>
           <td><strong>Feature discovery</strong></td>

--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -40,6 +40,7 @@
       <spec>XEP-0280</spec>
       <spec>XEP-0313</spec>
       <spec>XEP-0352</spec>
+      <spec>XEP-0368</spec>
     </dependencies>
     <supersedes>
       <spec>XEP-0375</spec>
@@ -95,7 +96,7 @@
           <td align='center'>&#10003;</td>
           <td align='center'>&#10003;</td>
           <td align='center'>&#10003;</td>
-          <td>&rfc7590;</td>
+          <td>&rfc7590;, &xep0368;</td>
         </tr>
         <tr>
           <td><strong>Feature discovery</strong></td>

--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -63,7 +63,7 @@
       and software certification.
       This document specifies the 2017 compliance levels for XMPP clients and
       servers; it is hoped that this document will advance the state of the art,
-      and provide guidence and eventual certification to XMPP client and server
+      and provide guidance and eventual certification to XMPP client and server
       authors.
       Unless explicitly noted, support for the listed specifications is REQUIRED
       for compliance purposes.

--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -29,6 +29,7 @@
       <spec>XEP-0030</spec>
       <spec>XEP-0045</spec>
       <spec>XEP-0084</spec>
+      <spec>XEP-0085</spec>
       <spec>XEP-0114</spec>
       <spec>XEP-0115</spec>
       <spec>XEP-0124</spec>
@@ -36,6 +37,7 @@
       <spec>XEP-0191</spec>
       <spec>XEP-0198</spec>
       <spec>XEP-0206</spec>
+      <spec>XEP-0249</spec>
       <spec>XEP-0280</spec>
       <spec>XEP-0313</spec>
       <spec>XEP-0352</spec>
@@ -206,7 +208,7 @@
           <td align='center'>&#10003;&usecases;</td>
           <td align='center'>&#10003;&component;</td>
           <td align='center'>&#10003;&usecases;</td>
-          <td>&xep0045;<note>Implementations should take note that future versions of these compliance suites may rely on &xep0369; instead.</note></td>
+          <td>&xep0045;<note>Implementations should take note that future versions of these compliance suites may rely on &xep0369; instead.</note>, &xep0249;</td>
         </tr>
         <tr>
           <td><strong>Bookmarks</strong></td>
@@ -239,6 +241,14 @@
           <td align='center'>&#10003;</td>
           <td align='center'>&#10003;</td>
           <td>&xep0313;</td>
+        </tr>
+        <tr>
+          <td><strong>Chat States</strong></td>
+          <td align='center'>N/A</td>
+          <td align='center'>&#10005;</td>
+          <td align='center'>N/A</td>
+          <td align='center'>&#10003;</td>
+          <td>&xep0085;</td>
         </tr>
       </table>
     </section2>


### PR DESCRIPTION
* Adds direct MUC invitations to the group chat feature (for a good chat experience, we should ensure everyone can receive invitations, even people blocking traffic from non-contacts)
* Add a section for chat states that is only required for advanced client.
* Add direct TLS SRV records (and a footnote clarifying what it means to support TLS SRV records for servers)
* Typo fix (thanks @ge0rg!)