### PR TITLE
XEP-0387: several changes

### DIFF
--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -39,6 +39,7 @@
       <spec>XEP-0280</spec>
       <spec>XEP-0313</spec>
       <spec>XEP-0352</spec>
+      <spec>XEP-0368</spec>
     </dependencies>
     <supersedes>
       <spec>XEP-0375</spec>
@@ -95,6 +96,14 @@
           <td align='center'>&#10003;</td>
           <td align='center'>&#10003;</td>
           <td>&rfc7590;</td>
+        </tr>
+        <tr>
+          <td><strong>Direct TLS</strong></td>
+          <td align='center'>&#10005;</td>
+          <td align='center'>&#10005;</td>
+          <td align='center'>&#10003;</td>
+          <td align='center'>&#10003;</td>
+          <td>&xep0368;</td>
         </tr>
         <tr>
           <td><strong>Feature discovery</strong></td>

--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -188,7 +188,7 @@
         <tr>
           <td><strong>User Avatars</strong></td>
           <td align='center'>N/A</td>
-          <td align='center'>&#10003;&nocli;</td>
+          <td align='center'>&#10005;</td>
           <td align='center'>N/A</td>
           <td align='center'>&#10003;&nocli;</td>
           <td>&xep0084;</td>

--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -61,7 +61,7 @@
       and software certification.
       This document specifies the 2017 compliance levels for XMPP clients and
       servers; it is hoped that this document will advance the state of the art,
-      and provide guidence and eventual certification to XMPP client and server
+      and provide guidance and eventual certification to XMPP client and server
       authors.
       Unless explicitly noted, support for the listed specifications is REQUIRED
       for compliance purposes.


### PR DESCRIPTION
This PR contains three diffs to XEP-0387, in increasing order of controversy:

1. a minor typo fix
2. Addition of [XEP-0368: SRV records for XMPP over TLS](https://xmpp.org/extensions/xep-0368.html) as an Advanced Core feature
3. Removal of 'User Avatars' from IM-Core, making it IM-Advanced only.

Please feel free to apply any subset of these. I think that (3) is the most controversial one and needs the strongest rationale, so here it is:

* avatars require a graphical display to make sense (this is slightly mitigated by footnote 20)
* avatars consume network bandwidth
* avatars are more of a cosmetic element than a functional one (not having them will not cause your messages to get lost in transmission)
* there are interop problems with file formats (some clients insist on using webp :-P )
* there are interop problems with MUC

I'd rather see 0198 and [XEP-0184: Message Delivery Receipts](https://xmpp.org/extensions/xep-0184.html) as core features, before addressing avatars.