### PR TITLE
XEP-280: Improve readability

### DIFF
--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -255,8 +255,10 @@
 </section1>
 
 <section1 topic='Messages Eligible for Carbons Delivery' anchor='which-messages'>
-    <p>The focus of this specification is instant messaging applications and so those (and only those) &MESSAGE; stanzas used for instant messaging SHOULD be delivered as Carbons. Defining precisely which messages are used for instant messaging and which are not is difficult, as future specifications may add additional payloads used for, or not used for, instant messaging; as such, the rules for which messages are eligible for carbons delivery is left as an implementation detail for servers. The following is a suggested set of rules a server MAY use, or it MAY use its own; in either case it SHOULD follow the general intent of these rules:</p>
-    <p>Possible delivery rules:</p>
+  <p>The focus of this specification is instant messaging applications and so those (and only those) &MESSAGE; stanzas used for instant messaging SHOULD be delivered as Carbons.</p>
+
+  <p>Defining precisely which messages are used for instant messaging and which are not is difficult, as future specifications may add additional payloads used for, or not used for, instant messaging; as such, the rules for which messages are eligible for carbons delivery is left as an implementation detail for servers.</p>
+  <p>The following is a suggested set of rules a server MAY use, or it MAY use its own; in either case it SHOULD follow the general intent of these rules:</p>
     <ul>
       <li>A &MESSAGE; is eligible for carbons delivery if it is of type "chat".</li>
       <li>A &MESSAGE; is eligible for carbons delivery if it is of type "normal" and it contains a &lt;body&gt; element.</li>
@@ -266,7 +268,7 @@
     </ul>
     <p>As this is a implementation detail of servers, clients MUST NOT rely on the server implementing a particular set of rules for which messages are eligible for Carbons delivery.</p>
     <p>Future specifications may have more precise requirements on which messages need to be eligible for carbons delivery; such future specifications will provide their own discovery and negotiation mechanisms, such that a client negotiating Carbons using the protocol defined in this specification will cause the server to consider messages eligible for Carbons delivery based on the requirements described herein.</p>
-    <p>Note: previous versions of this specification limited eligible messages to those of type "chat" - however, this was generally found to be inadequate due to the proliferation of type "normal" messages used in instant messaging.</p>
+    <p><strong>Note:</strong> previous versions of this specification limited eligible messages to those of type "chat" - however, this was generally found to be inadequate due to the proliferation of type "normal" messages used in instant messaging.</p>
 </section1>
 
 <section1 topic='Receiving Messages' anchor='inbound'>

--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -419,7 +419,7 @@
     <p>The following rules prevent some of the half-failure modes that have been an issue in other protocols:</p>
     <ul>
       <li>When a server attempts to deliver a (locally generated) carbon copy, and that carbon copy bounces with an error for any reason, the server MUST NOT forward that error back to the original sender.</li>
-      <li>The server can use the &lt;sent/&gt; or &lt;received/&gt; element in the bounce to determine that an error is from a carbon-copied message.</li>
+      <li>The server MUST NOT rely on the &lt;sent/&gt; or &lt;received/&gt; elements in the bounce to determine that an error is from a carbon-copied message, because entities are not required to include the original XML in their error replies as per <cite>RFC 6120</cite>, §8.3.1.</li>
     </ul>
   </section2>
   <section2 topic='Auto-responses' anchor='bizrules-autoresponses'>

--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -314,7 +314,16 @@
 </section1>
 <section1 topic='Sending Messages' anchor='outbound'>
   <p>When a client sends a &MESSAGE; <link url='#which-messages'>eligible for carbons delivery</link>, its sending server delivers the &MESSAGE; according to <cite>RFC 6120</cite> and <cite>RFC 6121</cite>, and delivers a forwarded copy to each Carbons-enabled resource for the matching bare JID sender, excluding the sending client. Note that this happens irrespective of whether the sending client has carbons enabled.</p>
-  <p>Each forwarded copy is wrapped using &xep0297;. The wrapping message SHOULD maintain the same 'type' attribute value; the 'from' attribute MUST be the Carbons-enabled user's bare JID (e.g., "localpart@domainpart"); and the 'to' attribute SHOULD be the full JID of the resource receiving the copy. The content of the wrapping message MUST contain a &lt;sent/&gt; element qualified by the namespace "urn:xmpp:carbons:2", which itself contains a &lt;forwarded/&gt; qualified by the namespace "urn:xmpp:forward:0" that contains the original &MESSAGE; stanza.</p>
+  <p>Each forwarded copy is wrapped using &xep0297; with the following properties:</p>
+  <ul>
+    <li>The wrapping message SHOULD maintain the same 'type' attribute value;</li>
+    <li>the 'from' attribute MUST be the Carbons-enabled user's bare JID (e.g., "localpart@domainpart");</li>
+    <li>and the 'to' attribute SHOULD be the full JID of the resource receiving the copy.</li>
+    <li>The content of the wrapping message MUST contain a &lt;sent/&gt; element qualified by the namespace "urn:xmpp:carbons:2", which itself contains a &lt;forwarded/&gt; qualified by the namespace "urn:xmpp:forward:0" that contains the original &MESSAGE; stanza.</li>
+  </ul>
+
+  <p>The sending server SHOULD NOT send a forwarded copy to the sending full JID if it is a Carbons-enabled resource.</p>
+
   <example caption='Romeo responds to Juliet'><![CDATA[
 <message xmlns='jabber:client'
          from='romeo@montague.example/home'
@@ -343,7 +352,6 @@
   </sent>
 </message>]]></example>
 
-  <p>The sending server SHOULD NOT send a forwarded copy to the sending full JID if it is a Carbons-enabled resource.</p>
 
 </section1>
 <section1 topic='Avoiding Carbons for a single message' anchor='avoiding'>

--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -350,15 +350,19 @@
   <p>
     Some clients might want to avoid Carbons on a single message, while still
     keeping all of the other semantics of Carbon support.
-    This might be useful for clients sending end-to-end encrypted messages, for
-    example.
-    The sending client MAY exclude a &MESSAGE; from being forwarded to other
-    Carbons-enabled resources, by adding a &lt;private/&gt; element qualified by
-    the namespace "urn:xmpp:carbons:2" and a &lt;no-copy/&gt; hint as described
-    in &xep0334; as child elements of the &MESSAGE; stanza.
+    This might be useful for clients sending end-to-end encrypted messages.
   </p>
 
-  <p><strong>Note:</strong> use of the private mechanism might lead to partial conversations on other devices. This is the intended effect.</p>
+  <ul>
+    <li> The sending client MAY exclude a &MESSAGE; from being forwarded to other Carbons-enabled resources, by adding a &lt;private/&gt; element qualified by the namespace "urn:xmpp:carbons:2" and a &lt;no-copy/&gt; hint as described in &xep0334; as child elements of the &MESSAGE; stanza.</li>
+    <li>The sending server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resources of the sender.</li>
+    <li>The receiving server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resource of the recipient,</li>
+    <li>and the receiving server SHOULD remove the &lt;private/&gt; element before delivering to the recipient.</li>
+  </ul>
+
+  <p><strong>Note:</strong>
+    Use of the private mechanism might lead to partial conversations on other devices. This is the intended effect.
+    If the private &MESSAGE; stanza is addressed to a bare JID, the receiving server still delivers it according to <cite>RFC 6121</cite>. This might result in a copy being delivered to each resource for the recipient, which effectively negates the behavior of the &lt;private/&gt; element for recipients.</p>
 
   <example caption='Romeo sends to Juliet, excluding Carbons'><![CDATA[
 <message xmlns='jabber:client'
@@ -381,8 +385,6 @@
   <private xmlns='urn:xmpp:carbons:2'/>
   <no-copy xmlns='urn:xmpp:hints'/>
 </message>]]></example>
-  <p>The sending server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resources of the sender. The receiving server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resource of the recipient, and SHOULD remove the &lt;private/&gt; element before delivering to the recipient.</p>
-  <p><strong>Note:</strong> if the private &MESSAGE; stanza is addressed to a bare JID, the receiving server still delivers it according to <cite>RFC 6121</cite>. This might result in a copy being delivered to each resource for the recipient, which effectively negates the behavior of the &lt;private/&gt; element for recipients.</p>
 </section1>
 <section1 topic='Business Rules' anchor='bizrules'>
   <section2 topic='Handling Multiple Enable/Disable Requests' anchor='bizrules-multi'>

--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -418,17 +418,17 @@
   <section2 topic='Handling of Errors' anchor='bizrules-errors'>
     <p>The following rules prevent some of the half-failure modes that have been an issue in other prototocols:</p>
     <ul>
-      <li>When a receiving server attempts to deliver a forked message, and that message bounces with an error for any reason, the receiving server MUST NOT forward that error back to the original sender.</li>
-      <li>The receiving server SHOULD use the sent element in the bounce to determine that an error is from a forked message.</li>
+      <li>When a server attempts to deliver a (locally generated) carbon copy, and that carbon copy bounces with an error for any reason, the server MUST NOT forward that error back to the original sender.</li>
+      <li>The server can use the &lt;sent/&gt; or &lt;received/&gt; element in the bounce to determine that an error is from a carbon-copied message.</li>
     </ul>
   </section2>
   <section2 topic='Auto-responses' anchor='bizrules-autoresponses'>
     <p>Clients that automatically respond to messages for any reason (e.g., when in the "dnd" presence show state) MUST take adequate care when enabling Carbons in order to prevent storms or loops.</p>
-    <p>Carbon copies of messages MUST NOT be auto-replied to under any circumstances.</p>
-    <p>Forked inbound messages MUST NOT be auto-replied to unless the client has some way of ensuring no more than one auto-reply is sent from all of its user's resources.</p>
+    <p>Forwarded outbound messages MUST NOT be auto-replied to under any circumstances.</p>
+    <p>Forwarded inbound messages MUST NOT be auto-replied to unless the client has some way of ensuring no more than one auto-reply is sent from all of its user's resources.</p>
   </section2>
   <section2 topic='Mobile Considerations' anchor='bizrules-mobile'>
-    <p>Enabling this protocol on mobile devices needs to be undertaken with care. This protocol can result in additional bandwidth and power usage, possibly decreasing battery lifetime and increasing monetary costs.  Additional mechanisms for controlling the Carbon-copying or forking of individual conversations might need to be added to deal with mobile clients in the future.</p>
+    <p>Enabling this protocol on mobile devices needs to be undertaken with care. This protocol can result in additional bandwidth and power usage, possibly decreasing battery lifetime and increasing monetary costs.  Additional mechanisms for controlling the Carbon-copying of individual conversations might need to be added to deal with mobile clients in the future.</p>
   </section2>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>

--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -416,7 +416,7 @@
     </ul>
   </section2>
   <section2 topic='Handling of Errors' anchor='bizrules-errors'>
-    <p>The following rules prevent some of the half-failure modes that have been an issue in other prototocols:</p>
+    <p>The following rules prevent some of the half-failure modes that have been an issue in other protocols:</p>
     <ul>
       <li>When a server attempts to deliver a (locally generated) carbon copy, and that carbon copy bounces with an error for any reason, the server MUST NOT forward that error back to the original sender.</li>
       <li>The server can use the &lt;sent/&gt; or &lt;received/&gt; element in the bounce to determine that an error is from a carbon-copied message.</li>

--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -273,7 +273,15 @@
 
 <section1 topic='Receiving Messages' anchor='inbound'>
   <p>When the server receives a &MESSAGE; <link url='#which-messages'>eligible for carbons delivery</link> addressed to a client JID (either bare or full), it delivers the &MESSAGE; according to <cite>RFC 6121</cite> § 8.5.3, and then delivers a forwarded copy to each Carbons-enabled resource for the matching bare JID recipient that did not receive it under the RFC 6121 delivery rules.</p>
-  <p>Each forwarded copy is wrapped using &xep0297;. The wrapping message SHOULD maintain the same 'type' attribute value; the 'from' attribute MUST be the Carbons-enabled user's bare JID (e.g., "localpart@domainpart"); and the 'to' attribute MUST be the full JID of the resource receiving the copy. The content of the wrapping message MUST contain a &lt;received/&gt; element qualified by the namespace "urn:xmpp:carbons:2", which itself contains a &lt;forwarded/&gt; element qualified by the namespace "urn:xmpp:forward:0" that contains the original &MESSAGE;.</p>
+  <p>Each forwarded copy is wrapped using &xep0297; with the following properties:</p>
+  <ul>
+    <li>The wrapping message SHOULD maintain the same 'type' attribute value;</li>
+    <li>the 'from' attribute MUST be the Carbons-enabled user's bare JID (e.g., "localpart@domainpart");</li>
+    <li>and the 'to' attribute MUST be the full JID of the resource receiving the copy.</li>
+    <li>The content of the wrapping message MUST contain a &lt;received/&gt; element qualified by the namespace "urn:xmpp:carbons:2", which itself contains a &lt;forwarded/&gt; element qualified by the namespace "urn:xmpp:forward:0" that contains the original &MESSAGE;.</li>
+  </ul>
+
+  <p>The receiving server MUST NOT send a forwarded copy to the client(s) the original &MESSAGE; stanza was addressed to, as these recipients receive the original &MESSAGE; stanza.</p>
 
   <example caption='Juliet sends Romeo a directed message'><![CDATA[
 <message xmlns='jabber:client'
@@ -303,7 +311,6 @@
 </message>
 ]]></example>
 
-  <p>The receiving server MUST NOT send a forwarded copy to the client(s) the original &MESSAGE; stanza was addressed to, as these recipients receive the original &MESSAGE; stanza.</p>
 </section1>
 <section1 topic='Sending Messages' anchor='outbound'>
   <p>When a client sends a &MESSAGE; <link url='#which-messages'>eligible for carbons delivery</link>, its sending server delivers the &MESSAGE; according to <cite>RFC 6120</cite> and <cite>RFC 6121</cite>, and delivers a forwarded copy to each Carbons-enabled resource for the matching bare JID sender, excluding the sending client. Note that this happens irrespective of whether the sending client has carbons enabled.</p>

--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -396,25 +396,36 @@
 </section1>
 <section1 topic='Business Rules' anchor='bizrules'>
   <section2 topic='Handling Multiple Enable/Disable Requests' anchor='bizrules-multi'>
-    <p>If a client is permitted to enable Carbons during its login session, the server MUST allow the client to enable and disable the protocol multiple times within a session.  The server SHOULD NOT treat multiple enable requests (without an intermediate disable request) as an error; it SHOULD simply return an IQ-result (if the protocol is already enabled) or an IQ-error (if the client is not permitted to enable Carbons) for any subsequent requests after the first. Similarly, the server SHOULD NOT treat multiple disable requests (without an intermediate enable request) as an error; it SHOULD return an IQ-result (if the protocols is already disabled) or an IQ-error (if the client's request failed previously) for any subsequent requests after the first.</p>
+    <p>Handling multiple enable/disable request must adhere to the following rules:</p>
+    <ul>
+      <li>If a client is permitted to enable Carbons during its login session, the server MUST allow the client to enable and disable the protocol multiple times within a session.</li>
+      <li>The server SHOULD NOT treat multiple enable requests (without an intermediate disable request) as an error;</li>
+      <li>the server SHOULD simply return an IQ-result (if the protocol is already enabled) or an IQ-error (if the client is not permitted to enable Carbons) for any subsequent requests after the first.</li>
+      <li>Similarly, the server SHOULD NOT treat multiple disable requests (without an intermediate enable request) as an error;</li>
+      <li>the server SHOULD return an IQ-result (if the protocols is already disabled) or an IQ-error (if the client's request failed previously) for any subsequent requests after the first.</li>
+    </ul>
   </section2>
   <section2 topic='Interaction with Chat States' anchor='bizrules-chatstates'>
-    <p>Note that &xep0085; recommends sending chat state
-    notifications as chat type messages, which means that they will be
-    subject to Carbon-copying.  This is intentional.</p>
+    <p><strong>Note: </strong>&xep0085; recommends sending chat state notifications as chat type messages, which means that they will be subject to Carbon-copying.  This is intentional.</p>
     <p>Additionally, there are other considerations for clients that implement Carbons and <cite>XEP-0085</cite>:</p>
     <ul>
       <li>Upon receiving an inbound or outbound &lt;gone/&gt; chat state (as a carbon copy) for a given conversation, the client SHOULD visually indicate the conversation is terminated.</li>
-      <li>In order to prevent unwanted termination of conversations on other resources, clients SHOULD NOT send &lt;gone/&gt; chat states on logout, but instead SHOULD count on the broadcast of unavailable presence to convey the change in attention.</li>
+      <li>In order to prevent unwanted termination of conversations on other resources, clients SHOULD NOT send &lt;gone/&gt; chat states on logout, instead</li>
+      <li>clients SHOULD count on the broadcast of unavailable presence to convey the change in attention.</li>
       <li>Upon receiving an outbound notification of any chat state other than &lt;gone/&gt;, the copied client MAY conclude that the sending client has taken responsibility for the conversation, and make appropriate user interface modifications.  For example, notifications could be suppressed on devices receiving the Carbon copies.</li>
     </ul>
   </section2>
   <section2 topic='Handling of Errors' anchor='bizrules-errors'>
-    <p>When a receiving server attempts to deliver a forked message, and that message bounces with an error for any reason, the receiving server MUST NOT forward that error back to the original sender.  The receiving server SHOULD use the sent element in the bounce to determine that an error is from a forked message.</p>
-    <p>This rule is used to prevent some of the half-failure modes that have been an issue in other prototocols.</p>
+    <p>The following rules prevent some of the half-failure modes that have been an issue in other prototocols:</p>
+    <ul>
+      <li>When a receiving server attempts to deliver a forked message, and that message bounces with an error for any reason, the receiving server MUST NOT forward that error back to the original sender.</li>
+      <li>The receiving server SHOULD use the sent element in the bounce to determine that an error is from a forked message.</li>
+    </ul>
   </section2>
   <section2 topic='Auto-responses' anchor='bizrules-autoresponses'>
-    <p>Clients that automatically respond to messages for any reason (e.g., when in the "dnd" presence show state) MUST take adequate care when enabling Carbons in order to prevent storms or loops.  Carbon copies of messages MUST NOT be auto-replied to under any circumstances.  Forked inbound messages MUST NOT be auto-replied to unless the client has some way of ensuring no more than one auto-reply is sent from all of its user's resources.</p>
+    <p>Clients that automatically respond to messages for any reason (e.g., when in the "dnd" presence show state) MUST take adequate care when enabling Carbons in order to prevent storms or loops.</p>
+    <p>Carbon copies of messages MUST NOT be auto-replied to under any circumstances.</p>
+    <p>Forked inbound messages MUST NOT be auto-replied to unless the client has some way of ensuring no more than one auto-reply is sent from all of its user's resources.</p>
   </section2>
   <section2 topic='Mobile Considerations' anchor='bizrules-mobile'>
     <p>Enabling this protocol on mobile devices needs to be undertaken with care. This protocol can result in additional bandwidth and power usage, possibly decreasing battery lifetime and increasing monetary costs.  Additional mechanisms for controlling the Carbon-copying or forking of individual conversations might need to be added to deal with mobile clients in the future.</p>

--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -42,11 +42,20 @@
     <jid>linuxwolf@outer-planes.net</jid>
   </author>
   <revision>
+    <version>0.12.0</version>
+    <date>2017-02-16</date>
+    <initials>gl</initials>
+    <remark>
+      <p>Improved readability by restructuring long sentences (Stefan Haun).</p>
+      <p>Removed ambiguous "forking" term; forbidden the reliance of error handling on the content of a bounced message.</p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.11.0</version>
     <date>2017-01-27</date>
     <initials>gl (XEP Editor: ssw)</initials>
     <remark>
-      <p>Add &lt;no-copy/&gt; hint.</p>
+      <p>Added &lt;no-copy/&gt; hint.</p>
     </remark>
   </revision>
   <revision>
@@ -63,7 +72,7 @@
     <initials>mm (editor)</initials>
     <remark>
       <p>Removed distinction between full-JID and bare-JID when receiving messages (Georg Lukas).</p>
-      <p>Define rules around "elible messages", and provide reasonable default guidelines (Kevin Smith).</p>
+      <p>Define rules around "eligible messages", and provide reasonable default guidelines (Kevin Smith).</p>
     </remark>
   </revision>
   <revision>

--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -432,7 +432,11 @@
   </section2>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
-  <p>The security model assumed by this document is that all of the resources for a single user are in the same trust boundary. Any forwarded copies received by a Carbons-enabled client MUST be from that user's bare JID; any copies that do not meet this requirement MUST be ignored.</p>
+  <p>The security model assumed by this document is that all of the resources for a single user are in the same trust boundary.</p>
+  <ul>
+    <li>Any forwarded copies received by a Carbons-enabled client MUST be from that user's bare JID;</li>
+    <li>any copies that do not meet this requirement MUST be ignored.</li>
+  </ul>
   <p>Outbound chat messages that are encrypted end-to-end are not often useful to receive on other resources.  As such, they should use the &lt;private/&gt; element specified above to avoid such copying, unless the encryption mechanism is able to accommodate this protocol.</p>
 </section1>
 <section1 topic='IANA Considerations' anchor='iana'>


### PR DESCRIPTION
In light of [CVE-2017-5589+ Multiple XMPP Clients User Impersonation Vulnerability](https://rt-solutions.de/en/2017/02/CVE-2017-5589_xmpp_carbons/) and after a chat with @ge0rg I came to the conclusion that similar mishaps can be avoided by improving readability of the requirements.

This PR is a proposal for restructuring the XEP so that each single requirement can be easily discerned from other requirements, i.e. each structural element does not contain more than one requirement (so you can check them each and cross them off the list), while still keeping overall readability as a document.

There are no changes to the actual content. I only moved some things around within a section, e.g. single short paragraphs after a screen full of examples, which could be easily overlooked. Here and there I changed some minor details for style reasons.

Please consider this PR as my contribution for helping others to better understand the intentions and boundaries of the XEP and to avoid security mishaps due to misunderstandings or omissions while implementing the XEP.