### PR TITLE
XEP-0387: Relax some requirements, and add important dependencies from 2017

### DIFF
--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -6,6 +6,7 @@
 <!ENTITY usecases "<note>Support for the Entity Use Cases and Occupant Use Cases is REQUIRED; support for the remaining use cases is RECOMMENDED.</note>">
 <!ENTITY onlyone "<note>Only one of the recommended providers must be implemented for compliance.</note>">
 <!ENTITY nocli "<note>Not required for command line or terminal based interfaces.</note>">
+<!ENTITY pushplatform "<note>Not required on platforms which don’t tend to kill user programs.</note>">
 ]>
 <?xml-stylesheet type='text/xsl' href='xep.xsl'?>
 <xep>
@@ -308,7 +309,7 @@
           <td align='center'>&#10005;</td>
           <td align='center'>&#10005;</td>
           <td align='center'>&#10003;&component;</td>
-          <td align='center'>&#10003;</td>
+          <td align='center'>&#10003;&pushplatform;</td>
           <td>&xep0357;</td>
         </tr>
       </table>

--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -29,6 +29,7 @@
       <spec>RFC 7590</spec>
       <spec>XEP-0030</spec>
       <spec>XEP-0045</spec>
+      <spec>XEP-0071</spec>
       <spec>XEP-0084</spec>
       <spec>XEP-0085</spec>
       <spec>XEP-0114</spec>
@@ -273,6 +274,14 @@
           <td align='center'>N/A</td>
           <td align='center'>&#10003;</td>
           <td>&xep0085;</td>
+        </tr>
+        <tr>
+          <td><strong>Message Formatting</strong></td>
+          <td align='center'>N/A</td>
+          <td align='center'>&#10005;</td>
+          <td align='center'>N/A</td>
+          <td align='center'>&#10003;</td>
+          <td>&xep0071;</td>
         </tr>
       </table>
     </section2>

--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -7,6 +7,7 @@
 <!ENTITY onlyone "<note>Only one of the recommended providers must be implemented for compliance.</note>">
 <!ENTITY nocli "<note>Not required for command line or terminal based interfaces.</note>">
 <!ENTITY pushplatform "<note>Not required on platforms which don’t tend to kill user programs.</note>">
+<!ENTITY orserver "<note>Some web clients may use a server-side component to establish the connection instead, in which case support for these is not required.</note>">
 ]>
 <?xml-stylesheet type='text/xsl' href='xep.xsl'?>
 <xep>
@@ -163,9 +164,9 @@
         <tr>
           <td><strong>Web Connection Mechanisms</strong></td>
           <td align='center'>&#10003;&component;</td>
-          <td align='center'>&#10003;&onlyone;</td>
+          <td align='center'>&#10003;&onlyone;&orserver;</td>
           <td align='center'>&#10003;&component;</td>
-          <td align='center'>&#10003;&onlyone;</td>
+          <td align='center'>&#10003;&onlyone;&orserver;</td>
           <td>&rfc7395;, &xep0206; (See also: &xep0124;)</td>
         </tr>
       </table>

--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -34,6 +34,7 @@
       <spec>XEP-0114</spec>
       <spec>XEP-0115</spec>
       <spec>XEP-0124</spec>
+      <spec>XEP-0156</spec>
       <spec>XEP-0163</spec>
       <spec>XEP-0191</spec>
       <spec>XEP-0198</spec>
@@ -160,6 +161,14 @@
           <th>Advanced Server</th>
           <th>Advanced Client</th>
           <th>Providers</th>
+        </tr>
+        <tr>
+          <td><strong>Web Connection Method Discovery</strong></td>
+          <td align='center'>N/A</td>
+          <td align='center'>&#10003;&orserver;</td>
+          <td align='center'>N/A</td>
+          <td align='center'>&#10003;&orserver;</td>
+          <td>&xep0156;</td>
         </tr>
         <tr>
           <td><strong>Web Connection Mechanisms</strong></td>

--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -53,6 +53,19 @@
     <shortname>CS2017</shortname>
     &sam;
     <revision>
+      <version>0.3.0</version>
+      <date>2017-02-11</date>
+      <initials>egp</initials>
+      <remark>
+        <ul>
+          <li>Add XEP-0071: XHTML-IM</li>
+          <li>Add XEP-0156: Discovering Alternative XMPP Connection Methods</li>
+          <li>Allow web clients to use a server component connecting directly with TCP.</li>
+          <li>Make XEP-0357 optional on platforms where it is unnecessary.</li>
+        </ul>
+      </remark>
+    </revision>
+    <revision>
       <version>0.2.0</version>
       <date>2017-02-10</date>
       <initials>ssw</initials>


### PR DESCRIPTION
This PR does these changes to the latest compliance suites:
- Add XEP-0156: Discovering Alternative XMPP Connection Methods for web clients.
- Add XEP-0071: XHTML-IM for message formatting.
- Allow web clients to use a server component connecting directly with TCP.
- Make XEP-0357 optional on platforms where it is unnecessary.

I can split some commits in a different PR if you decide some items should have some more discussion, but I believe these are the right way to go at least for this year.