### PR TITLE
Mix  - XEP-0369 to 0.8

### DIFF
--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -42,7 +42,7 @@
     <initials>sek</initials>
     <remark><p>
       Update after Brussels Summit;
-      Remove Explicit Client Activation;
+      Remove Explicit Client Activation and replace with client capability discovery;
       Limit Indirect to Join/Leave;
       Clarify Server use of Disco of Client;
     </p></remark>
@@ -796,7 +796,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </section2>
   <section2 topic="Discovering Client MIX Capability" anchor="mix-client-discovery">
     <p>
-      Where a client supports MIX, it MUST advertise this capability in response to a Disco request.    This will enable other entities to determine if a client supports MIX.   The following example shows a Disco response from a client that supports both MIX and MUC.
+      Where a client supports MIX, it MUST advertise this capability in response to a Disco request.    This will enable other entities to determine if a client supports MIX, and in particular it facilitates the client's server to determine client support.  This can be optimized by use of CAPS.    The following example shows a Disco response from a client that supports both MIX and MUC.
     </p>
     <example caption='Disco Response showing MIX support'><![CDATA[
 <iq from='romeo@montague.lit/orchard'
@@ -2163,64 +2163,16 @@ the participant is not be subscribed to all nodes associated with the channel (i
  &xep0376; (PAM) which follows a similar model.
   </p>
 
-  <section2 topic="MIX Client Activation" anchor="proxy-activation">
+  <section2 topic="Server Identification of MIX Capabable Clients" anchor="server-identification-mix-clients">
     <p>
-      All messages from MIX channels to participants are sent to the participant's XMPP server.   The participant's server will send on these messages to each of the user's clients that has activated the MIX service.    MIX provides capabilities for an online client to activate and de-activate MIX for that client.  A client MAY activate MIX for all the user's channels or for a selected list.   This will enable a mobile client to choose to receive only messages from selected MIX channels.    Activation uses  an IQ set with an &lt;activate&gt; element to instruct the local server to activate the client.   The server responds with a result to confirm activation.  The client MAY include one or more &lt;channel&gt; elements, to identify an explicit list of channels that are activated for the client.   If mo channels are specified, activation is for all channels where the user is a participant.  A client supporting MIX will typically activate MIX as soon as it comes online, but a client MAY also choose to only activate MIX for specific periods.
-    </p>
-    <p>
-      MIX Client activation implicitly verifies that the client's server support's MIX.   If the server does not support MIX, it will reject the activation request and the client will not be able to use MIX.
-    </p>
-
-      <example caption="Client Activates use of MIX" ><![CDATA[
-<iq from='hag66@shakespeare.example/intibo24'
-    id='lx09df27'
-    type='set'>
-  <activate xmlns='urn:xmpp:mix:0'>
-      <channel>coven@mix.shakespeare.lit</channel>
-      <channel>spells@mix.shakespeare.lit</channel>
-  </activate>
-</iq>
-
-<iq from='shakespeare.example'
-    id='lx09df27'
-    to='hag66@shakespeare.example/intibo24'
-    type='result'>
-  <activate xmlns='urn:xmpp:mix:0'/>
-</iq>
-]]></example>
-
-
-<p>
-  Following MIX activation, the participant's server will send presence status for all activated channels to the client using standard presence protocol.   This will give the client current presence status for the channel.
-</p>
-    <p>
-      A client will deactivate MIX using a corresponding deactivate command.   This will deactivate all MIX channels.   This will often be done when the client closes down, but MAY also be done at other times the client chooses. Deactivation uses  an IQ set with an &lt;deactivate&gt; element to instruct the local server to deactivate the client.
-    </p>
-
-    <example caption="Client Deactivates use of MIX" ><![CDATA[
-<iq from='hag66@shakespeare.example/intibo24'
-    id='lx09df27'
-    type='set'>
-  <deactivate xmlns='urn:xmpp:mix:0'/>
-</iq>
-
-<iq from='shakespeare.example'
-    id='lx09df27'
-    to='hag66@shakespeare.example/intibo24'
-    type='result'>
-  <deactivate xmlns='urn:xmpp:mix:0'/>
-</iq>
-]]></example>
-
-    <p>
-      If a client goes offline, the server  MUST deactivate MIX immediately for that client.   This will mean that standard client behaviour will be to activate MIX when they come online.
+    A MIX User's server MUST determine which online clients support MIX.   This will enable the server to send MIX traffic to all MIX capable clients.   A MIX capable client MAY choose to come online an not advertize MIX capability.   
     </p>
 
   </section2>
 
   <section2 topic="Messages From MIX Channels" anchor="mix-from">
     <p>
-      Messages from a MIX channel will usually go to the participant's server.   The only exception to this is where the MIX channel is responding directly to messages from the client.   Messages and presence distributed but a MIX channel will always be sent to the participant's server.  The participant's server will simply send on the messages from the channel to each of the user's clients which have activated the channel.   If there are no clients activated, the message is dropped.
+      Messages from a MIX channel will usually go to the participant's server.   The only exception to this is where the MIX channel is responding directly to messages from the client.   Messages and presence distributed but a MIX channel will always be sent to the participant's server and addressed to the user's bare JID.  The participant's server will simply send on the messages from the channel to each of the user's online clients which advertise MIX capability.   If there are no such clients activated, the message is dropped.   The mechanism for a server to discover client capability is described in <link url="#mix-client-discovery">Discovering Client MIX Capability</link>.
     </p>
     <p>
       Messages sent to the participant's sever will always be addressed to the user's bare JID.  The participant’s server will modify the recipient to the full JID of each client to which the message is forwarded.    The participant's server MUST NOT make any other modifications to each message.  The following example, repeated from earlier, shows a message distributed by a MIX channel and directed to the participant’s server with the participant's bare JID.

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -2265,7 +2265,11 @@ the participant is not be subscribed to all nodes associated with the channel (i
 ]]></example>
     
     <p>
-      When sending roster information to a client that advertises MIX capability, the server MUST return all MIX channels and MUST use this encoding.   Where a client does not advertize MIX capability, the server MUST NOT return MIX channels as roster items.
+      When sending roster information to a client that advertises MIX capability, the server MUST return all MIX channels and MUST use this encoding.  Presence  of MIX roster items MUST be set to offline (unavailable).
+    </p>
+    
+    <p>
+      Where a client does not advertize MIX capability, the server MAY choose to not return MIX channels as roster items.   If this is done care needs to be taken, in particular around support of roster versioning  &xep0237;.
     </p>
     
   </section2>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -466,7 +466,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </p>
       <table caption="Information Node Attributes">
         <tr><th>Name</th><th>Description</th><th>Field Type</th><th>Values</th><th>Default</th></tr>
-        <tr><td>'Name'</td><td>A short string providing a name for the channel.  For example "The Coven".  Typical uses of this value will be to present a user with the name of this channel in a list of channels to select from or as the header of UI display of the channel.</td><td>text-single</td><td>-</td><td>-</td></tr>
+        <tr><td>'Name'</td><td>A short string providing a name for the channel.  For example "The Coven".  Typical uses of this value will be to present a user with the name of this channel in a list of channels to select from or as the header of UI display of the channel.  It is intended for use where a short string is needed to represent the channel.</td><td>text-single</td><td>-</td><td>-</td></tr>
         <tr><td>'Description'</td><td>A longer description of the channel. For example "The Place where the Macbeth Witches Meet up".   A typical use would be to provide a user with more information about the channel, for example in tool tip.</td><td>text-single</td><td>-</td><td>-</td></tr>
         <tr><td>'Contact'</td><td>The JID or JIDs of the person or role responsible for the channel.</td><td>jid-multi</td><td>-</td><td>-</td></tr>
       </table>
@@ -2415,15 +2415,16 @@ the participant is not be subscribed to all nodes associated with the channel (i
 </section1>
 
 <section1  topic="Capabilities not provided in MIX" anchor="not-included-from45">
-  <p>This section lists a number of capabilities not specified in this version of MIX which were provided in &xep0045;.   </p>
+  <p>This section lists a number of capabilities not specified in the core MIX which are provided in &xep0045;.   These capabilities will not be added to core MIX but they could in the future be specified as independent XEPs.</p>
   <section2 topic="Password Controlled Channels" anchor="password-control">
     <p>
-      &xep0045; provides a mechanism to control access to MUC rooms using passwords.  An equivalent mechanism is not included in MIX, as it has a number of security issues.  Control of access to channels is better achieved using an explicit list of participants.
+      &xep0045; provides a mechanism to control access to MUC rooms using passwords.  An equivalent mechanism is not included in core MIX, as it has a number of security issues.  Control of access to channels is better achieved using an explicit list of participants.
     </p>
   </section2>
   <section2 topic="Voice Control" anchor="voice-control">
     <p>
-      &xep0045; defines a mechanism so that MUC moderators can control who is able to send messages to a MUC room using a "voice" mechanism.  The current version of MIX does not include this.   This might be added to a future version of this XEP or as a separate XEP if this capability becomes an agreed requirement.
+      &xep0045; defines a mechanism so that MUC moderators can control who is able to send messages to a MUC room using a "voice" mechanism.  MIX does not provide an exact functional equivalent, although access control to channels enables some of the goals of voice control to be achieved in a different manner.
+      
     </p>
   </section2>
 

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -407,8 +407,14 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         There will always be at least one owner and "anyone" will always have role occupants.   Other roles  MAY NOT have any role occupants.  Rights are defined in a strictly hierarchical manner, so that for example Owners will always have rights that Administrators have.
       </p>
     </section3>
+    
+    <section3 topic="Node Archiving" anchor="node-archiving">
+      <p>
+        Nodes MAY be archived and where this is done MAM MUST be used.  Archiving of the Messages node MUST be done as part of the MIX specification.  Archiving of other nodes is OPTIONAL.
+      </p>
+    </section3>
     <section3 topic="Messages Node" anchor="messages-node">
-      <p>Items in this node will contain a message identified by the MAM ID used for the message in the channels MAM archive.  &xep0313; rules MUST be used to ensure this ID is unique.  A MIX implementation SHOULD NOT make messages available for retrieval from this node using pubsub and MUST NOT allow direct pubsub publishing to this node.  Messages are published by sending messages to the channel. The Messages node is a transient node and so there is no PubSub history.  Message history is retrieved by use of  MAM. Users subscribe to this node to indicate that messages from the channel are to be sent to them.</p>
+      <p>Items in this node will contain a message identified by the MAM ID used for the message in the channels MAM archive.  &xep0313; rules MUST be used to ensure this ID is unique.  A MIX implementation SHOULD NOT make messages available for retrieval from this node using pubsub and MUST NOT allow direct pubsub publishing to this node.  Messages are published by sending messages to the channel. The Messages node is a transient node and so no PubSub items are held.  Message history is retrieved by use of  MAM. Users subscribe to this node to indicate that messages from the channel are to be sent to them.</p>
       <p>Private Messages are not stored in the messages node.</p>
     </section3>
 
@@ -419,7 +425,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         When a user joins a channel, the user's bare JID is added to the participants node by the MIX service.   When a user leaves a channel, they are removed from the participants node.  The participants node MUST NOT be directly modified using pubsub.
       This node MAY be subscribed to for jid-visible channels that permit subscription to this node - this will allow users to see changes to the channel participants.
       </p>
-      <p>The participants node is OPTIONAL.  If the Participants Node is not used, information on channel participants is not shared.  If there is no participants node, the access control value 'participants' MUST NOT be used.   The Participants node is a permanent node and PubSub history MAY be stored.</p>
+      <p>The participants node is OPTIONAL.  If the Participants Node is not used, information on channel participants is not shared.  If there is no participants node, the access control value 'participants' MUST NOT be used.   The Participants node is a permanent node with one item per participant.</p>
       <example caption="Value of Participants Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:participants'>
   <item id='coven+123456@mix.shakespeare.example'>
@@ -433,7 +439,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
       <p>The JID Map node is used to associate a proxy bare JID to its corresponding real bare JID.  The JID Map node MUST have one entry for each entry in the Participants node.  This value is added when a user joins the channel and is removed when the user leaves the channel.
        Each item is identified by proxy bare JID, mapping to the real bare JID.  This node is used to give administrator access to real JIDs and participant access to real JIDs in jid-visible channels.  This node MUST NOT be modified directly using pubsub.
-       In JID visible channels, all participants MAY subscribe to this node.  In JID hidden channels, only administrators can subscribe.   The JID MAP node is a permanent node and PubSub history MAY be stored.</p>
+       In JID visible channels, all participants MAY subscribe to this node.  In JID hidden channels, only administrators can subscribe.   The JID MAP node is a permanent node with one item per participant.</p>
       <example caption="Value of JID Map Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:jidmap'>
   <item id='coven+123456@mix.shakespeare.example'>
@@ -449,7 +455,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </p>
 
       <p>
-        This node MAY be subscribed to by users and this subscription MUST use the users bare JID.  So presence of online clients is sent to the user's server for each user subscribed to this node. Presence is always sent using standard presence protocol and NOT using pubsub protocol.   Clients MUST NOT directly access the presence node using pubsub.  The Presence node is a transient PubSub node.
+        This node MAY be subscribed to by users and this subscription MUST use the users bare JID.  So presence of online clients is sent to the user's server for each user subscribed to this node. Presence is always sent using standard presence protocol and NOT using pubsub protocol.   Clients MUST NOT directly access the presence node using pubsub.  The Presence node is a permanent PubSub node.
       </p>
       <example caption="Value of Presence Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:presence'>
@@ -464,8 +470,8 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     </section3>
     <section3 topic="Information Node" anchor="info-node">
 
-      <p>The Information node holds information about the channel.  The information node contains a single item with the current information.  Information node history is RECOMENDED to be held in MAM.
-        The information node is named by the date/time at which the item was created.   The information node is accessed and managed using standard pubsub.   The Information node is a transient node and so no PubSub history is stored.  Users MAY subscribe to this node to receive information updates. The Information node item MAY contain the following attributes, each of which is OPTIONAL:
+      <p>The Information node holds information about the channel.  The information node contains a single item with the current information.  
+        The information node is named by the date/time at which the item was created.   The information node is accessed and managed using standard pubsub.   The Information node is a permanent node with a maximum of one item.  Users MAY subscribe to this node to receive information updates. The Information node item MAY contain the following attributes, each of which is OPTIONAL:
       </p>
       <table caption="Information Node Attributes">
         <tr><th>Name</th><th>Description</th><th>Field Type</th><th>Values</th><th>Default</th></tr>
@@ -504,7 +510,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     
       <section3 topic="Allowed" anchor="allowed-node">
         <p>
-          This node represents a list of JIDs that are allowed to become participants. If the allowed node is not present, all JIDs are allowed. This node is accessed and managed using standard pubsub.  The allowed list is always considered in conjunction with the banned list, stored in the banned node.  Only Administrators and Owners have write permission to the allowed node and are also the only roles that are allows to subscribe to this node.   The Allowed node is a permanent node and PubSub history MAY be stored.  Each item contains a real bare JID.  The following example shows how the allowed list can specify single JIDs and domains.
+          This node represents a list of JIDs that are allowed to become participants. If the allowed node is not present, all JIDs are allowed. This node is accessed and managed using standard pubsub.  The allowed list is always considered in conjunction with the banned list, stored in the banned node.  Only Administrators and Owners have write permission to the allowed node and are also the only roles that are allows to subscribe to this node.   The Allowed node is a permanent node.  Each item contains a real bare JID.  The following example shows how the allowed list can specify single JIDs and domains.
         </p>
         <example caption="Allowed Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:allowed'>
@@ -515,7 +521,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </section3>
       <section3 topic="Banned" anchor="banned-node">
         <p>
-          This node represents a list of JIDs that are explicitly not allowed to become participants. The values in this list take priority over values in the allowed node. This node is accessed and managed using standard pubsub  Only Administrators and Owners have write permission to the allowed node and are also the only roles that are allows to subscribe to this node. Each item contains a real bare JID.   The Banned node is a permanent node and PubSub history MAY be stored.
+          This node represents a list of JIDs that are explicitly not allowed to become participants. The values in this list take priority over values in the allowed node. This node is accessed and managed using standard pubsub  Only Administrators and Owners have write permission to the allowed node and are also the only roles that are allows to subscribe to this node. Each item contains a real bare JID.   The Banned node is a permanent node.
         </p>
         <example caption="Banned Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:banned'>
@@ -526,7 +532,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </section3>
     <section3 topic="Configuration Node" anchor="config-node">
       <p>
-        The Configuration node holds the configuration of the channel as a single item, named by the date-time of the last update to the configuration.  The Configuration Node is a transient PubSub node with no history.   It is RECOMMENDED to store Configuration Node history in MAM. Previous configuration history MUST be accessed by MAM.  Users with read access to the configuration node MAY subscribe to the configuration node to get notification of configuration change.  This node is accessed and managed using standard pubsub. The configuration node is OPTIONAL for a MIX channel.  For example, configuration choices could be fixed and not exposed.   A subset of the defined configuration options MAY be used and additional non-standard configuration options MAY be added.   JIDs in the configuration MUST be real bare JIDs and not proxy JIDs.  If configuration options to control functionality of the nature described here are provided, the options defined in this standard MUST be used. The following configuration attributes are defined:
+        The Configuration node holds the configuration of the channel as a single item, named by the date-time of the last update to the configuration.  The Configuration node is a permanent node with a maximum of one item. Previous configuration history MAY be accessed by MAM.  Users with read access to the configuration node MAY subscribe to the configuration node to get notification of configuration change.  This node is accessed and managed using standard pubsub. The configuration node is OPTIONAL for a MIX channel.  For example, configuration choices could be fixed and not exposed.   A subset of the defined configuration options MAY be used and additional non-standard configuration options MAY be added.   JIDs in the configuration MUST be real bare JIDs and not proxy JIDs.  If configuration options to control functionality of the nature described here are provided, the options defined in this standard MUST be used. The following configuration attributes are defined:
 </p>
       <table caption="Configuration Node Attributes">
         <tr><th>Name</th><th>Description</th><th>Field Type</th><th>Values</th><th>Default</th></tr>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -50,6 +50,8 @@
       Clarifications of password control, voice and name/description (summit 4/5/6)
       Removal of Subject and reference future Sticky Messages XEP (summit 7);
       Use example JIDs aligned to anticipated BIND2 specification;
+      Clarify PubSub Node Type;
+      Clarify Error handling and Add Error for messages rejected by channel;
     </p></remark>
   </revision>
   <revision>
@@ -597,6 +599,17 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </section2>
 </section1>
 
+<section1 topic="Error Handling" anchor="error-handling">
+  <p>
+    The MIX specification is built on layered services that have defined errors.  This enables the core MIX specification to reflect primarily the successful use case, as in almost all cases the error reporting of the layer service provide what is needed.   A message sender MUST be prepared to handle any valid error from the layer services.   When a message receiver encounters an error situation, it MUST use the most appropriate layer server error to report this issue back to the sender.   For example a message receiver might use the "not authorized" IQ error in response to a MIX disco that is not authorized.   Errors for the following layer services need to be handled for MIX:
+  </p>
+  <ol>
+    <li>IQ.  All of the IQ errors of &rfc6120; MUST be supported.</li>
+    <li>Messages.  If a message is received and an error situation is encountered, an message of type error MUST be sent back to the message sender of type error specified in &rfc6121; containing an error defined in &rfc6120;, which is the same error set as for IQs.</li>
+    <li>Presence.  Any responses to presence messages MUST follow the rules of &rfc6121;.</li>
+    <li>PubSub.  Where MIX protocol messages use PubSub protocol, the errors defined in &xep0060; MUST be used and supported.</li>
+  </ol>
+</section1>
 <section1 topic='Discovery' anchor='discovery'>
   <section2 topic='Discovering a MIX service' anchor='disco-service'>
     <p>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -42,10 +42,13 @@
     <initials>sek</initials>
     <remark><p>
       Update after Brussels Summit;
-      Remove Explicit Client Activation and replace with client capability discovery;
+      Remove Explicit Client Activation and replace with client capability discovery (summit 3);
       Limit Indirect to Join/Leave;
       Clarify Server use of Disco of Client;
-      Add MIX capability information to Roster;
+      Add MIX capability information to Roster (summit 10);
+      MIX as Core Spec (summit 1);
+      Clarifications of password control, voice and name/description (summit 4/5/6)
+      Removal of Subject and reference future Sticky Messages XEP (summit 7);
     </p></remark>
   </revision>
   <revision>
@@ -250,6 +253,11 @@
 </section1>
 
 <section1 topic='Concepts' anchor='concepts'>
+  <section2 topic="Specification Appproach" anchor="concepts-approach">
+    <p>
+      MIX will enable a wide range of auxiliary services.  The goal of the MIX specification is to set out the core capabilities needed for MIX.   It is anticipated that additional XEPs will be written to extend the core MIX, and the core MIX specification notes some areas where this may happen.  This approach will avoid the core MIX specification becoming unduly large.   Profiles referencing sets of related MIX XEPs may be developed in the future.   
+    </p>
+  </section2>
   <section2 topic="Core Concepts" anchor="concepts-core">
   <p>The following concepts underlie the design of MIX.</p>
   <ol>
@@ -2295,7 +2303,9 @@ the participant is not be subscribed to all nodes associated with the channel (i
     </p>
     
     <example caption="Roster Item Encoding of a MIX Channel"><![CDATA[
-  <item jid='romeo@example.net'/ channel='true' xmlns='urn:xmpp:mix:0'/>    
+  <item jid='romeo@example.net'>
+      <channel xmlns=‘urn:xmpp:mix:0'/>
+  </item>
 ]]></example>
     
     <p>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -38,7 +38,7 @@
   &stpeter;
   <revision>
     <version>0.8</version>
-    <date>2017-02-XX</date>
+    <date>2017-02-12</date>
     <initials>sek</initials>
     <remark><p>
       Update after Brussels Summit;
@@ -52,6 +52,7 @@
       Use example JIDs aligned to anticipated BIND2 specification;
       Clarify PubSub Node Type;
       Add Error handling section;
+      Substantial Editorial Review;
     </p></remark>
   </revision>
   <revision>
@@ -222,7 +223,7 @@
   <p>Several reasons exist for replacing MUC:</p>
   <ul>
     <li>A number of use cases for group communication have emerged since MUC was first published.</li>
-    <li>Experience has shown that it is difficult to use MUC to build several kinds of communication applications (such as a multimedia conference focus) without undesirable adaptations.</li>
+    <li>Experience has shown that it is difficult to use MUC to build several kinds of communication applications (such as a multimedia conference) without undesirable adaptations.</li>
     <li>It is impractical to address a number of the requirements listed in the next section with MUC or with extensions to MUC. </li>
     <li>In the years after MUC was designed, both &xep0060; and &xep0313; have been developed and it is desirable to reuse these building blocks (e.g., MAM can be used for message history) rather than using the less robust methods defined in &xep0045;.</li>
   </ul>
@@ -231,7 +232,7 @@
     <li>XMPP clients can implement MUC and this specification in a way that provides a coherent user experience.</li>
     <li>XMPP servers can implement this specification and also provide a MUC interface in order to support clients that only implement MUC.</li>
   </ul>
-  <p>If a server wishes to expose both MUC and MIX representations of chatrooms, it is RECOMMENDED to do so by serving MUC and MIX on different domains, but a server MAY serve them on the same domain. The MIX service SHOULD include a reference to the MUC mirror, so that clients understanding both protocols can choose to show only one copy of the service.</p>
+  <p>If a server wishes to expose both MUC and MIX representations of chatrooms, it is RECOMMENDED to do so by serving MUC and MIX on different domains, but a server MAY serve them on the same domain.</p>
 </section1>
 
 <section1 topic='Requirements' anchor='reqs'>
@@ -249,8 +250,8 @@
     <li>A user can determine which channels they participate in.</li>
     <li>Provide extensibility regarding data formats that can be sent within a channel (files, structured data, indications about media sources in multimedia conferences, etc.) as well as flexibility regarding which data formats a user wants to receive.</li>
     <li>Enable federation of a channel across multiple servers, to provide a service equivalent to "federated MUC" &xep0289;.</li>
-    <li>To enable sharing of messages on a channel without requiring sharing of presence.</li>
-    <li>To enable sharing of presence without requiring message sending.</li>
+    <li>Enable sharing of messages on a channel without requiring sharing of presence.</li>
+    <li>Enable sharing of presence without requiring message sending.</li>
     <li>(Desirable) Make it easier to reduce duplicate traffic.</li>
  </ol>
 </section1>
@@ -265,25 +266,26 @@
   <p>The following concepts underlie the design of MIX.</p>
   <ol>
     <li>MIX channels (roughly equivalent to MUC rooms) are hosted on one or more MIX domains, (examples: 'mix.example.com'; 'conference.example.com'; 'talk.example.com'), which are discoverable through &xep0030;. Each channel on a MIX service can then be discovered and queried.</li>
-    <li> In MIX each channel (e.g., 'channel@mix.example.com') is a pubsub service. This is based on the model from &xep0163; where every user JID (e.g., 'user@example.com') is its own pubsub service. </li>
+    <li> In MIX each channel (e.g., 'channel@mix.example.com') is a specialized pubsub service. This is based on the model from &xep0163; where every user JID (e.g., 'user@example.com') is its own pubsub service. </li>
     <li>A channel's pubsub service contains a number of nodes for different event types or data formats. As described below, this document defines several standard nodes; however, future specifications or proprietary services can define their own nodes for extensibility.</li>
     <li>Affiliations with the nodes are managed by the MIX service by channel level operations, so that the user does not have to separately manage affiliations with the individual PubSub nodes.
      </li>
     <li>&xep0313; (MAM) is used for all history access, with each node being individually addressable for MAM queries. This simplifies implementation compared to MUC (which had a specialized and rather limited history retrieval mechanism).</li>
-    <li>A client can achieve a 'quick resync' of a node by requesting just those changes it has not yet received, using standard MAM protocol. This solves the old MUC issue of either receiving duplicate messages when rejoining a room or potentially missing messages.</li>
+    <li>A client can achieve a 'quick resync' of a node by requesting just those changes it has not yet received, using standard MAM protocol. This solves the MUC issue of either receiving duplicate messages when rejoining a room or potentially missing messages.</li>
     <li>Because MAM is used for history, only those nodes that have a 'current value' need to store any items in them &mdash; e.g., 'urn:xmpp:mix:nodes:presence' and 'urn:xmpp:mix:nodes:information' would store their current values (with older values being queryable through MAM), while 'urn:xmpp:mix:nodes:messages' would store no items.</li>
     <li>A user's participation in a channel outlives their client sessions. A client which is offline will not share presence within the channel, but the associated user will still be listed as an participant. </li>
-    <li>Presence is sent to all participants using bare JID, whether or not the user has an online client. </li>
+    <li>Presence is sent to participants using bare JID, whether or not the user has an online client. </li>
     <li>Online clients MAY register presence, which is then shared with participants who have subscribed to presence.</li>
     <li>MIX decouples addressing of channel participants from their nicknames, so that nickname changes do not affect addressing.</li>
     <li>Each participant is addressable by a single bare JID, which is a proxy JID (not the user's real JID) to make it straightforward to hide the user's real JID from other channel participants. Full JIDs comprised of this bare JID plus a resource (also anonymized) are then constructed, allowing visibility into the number of online resources participating in a channel.</li>
-    <li>MIX requires client support and server support from the server providing the MIX service.  Although some protocol is shared with MUC, MUC clients are not interoperable with a MIX service.  This means that where a user chooses to use MIX, all of the users clients need to support MIX.</li>
+    <li>MIX requires client support and server support from the server providing the MIX service. </li>
+    <li> Although some protocol is shared with MUC, MUC clients are not interoperable with a MIX service.  This means that where a user chooses to use MIX, all of the users clients need to support MIX.</li>
     <li>MIX requires the server to which the MIX client connects to provide functionality to support MIX.  This functionality is defined in this specification and referenced as "MIX Participant's Server Behaviour".</li>
     <li>MIX domains MUST NOT be used to host end user JIDs. </li>
   </ol>
   </section2>
   <section2 topic="MIX and PubSub" anchor="concepts-pubsub">
-    <p>MIX is based upon domains providing a MIX service, such as 'mix.shakespeare.example'. Note that although PubSub communication is used, a domain used for MIX is a MIX domain and not a standard &xep0060; domain. Like MUC, there is no requirement on the naming of these domains; the label 'mix' and the fact that it is a subdomain of a 'shakespeare.example' service are purely for example.</p>
+    <p>MIX is based upon domains providing a MIX service, such as 'mix.shakespeare.example'. Note that although PubSub communication is used, a domain used for MIX is a MIX domain and not a standard &xep0060; domain. Like MUC, there is no requirement on the naming of these domains; the label 'mix' used in examples in this specification and the fact that it is a subdomain of a 'shakespeare.example' service are purely for example.</p>
     <p>Every MIX channel is an addressable PubSub service (with additional MIX semantics) that will be addressed using a bare JID by other XMPP entities, for example coven@mix.shakespeare.example. While &xep0060; is used as the basis for the MIX model, MIX uses standard presence and groupchat messages to provide an interface to the MIX service that does not expose PubSub protocol for many of the more common functions.
 </p>
   </section2>
@@ -306,7 +308,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <li>The MIX participant's server will only send messages to online clients and will discard messages if no clients are online.
         This means that a MIX client needs to resynchronize with the MIX service when it comes online.  This message synchronization will happen between the MIX client and the MAM archive held on the MIX participant's server.</li>
       
-      <li>The MIX client will generally send management and other messages directly to the MIX channel and the MUST be done except where specifically noted.  </li>
+      <li>The MIX client will generally send management and other messages directly to the MIX channel and this MUST be done except where specifically noted.  </li>
       <li>The user's roster contains each MIX channel to which the user is subscribed and is sharing presence.   To achieve this the user's server needs to manage the roster on behalf of the user.  For this reason, MIX join and leave commands MUST be sent by a client to the user's server.   This enables the user's server to correctly manage the roster on behalf of the user.</li>
     </ol>
     <p>
@@ -318,7 +320,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </section2>
   <section2 topic="User Presence in MIX" anchor="concepts-presence">
     <p>
-      MIX channels store presence in the presence node using the proxy JID of each online client for a user.   User presence MAY be included for all or selected clients of a given user, based on client choice to publish presence.    Where a user publishes presence for multiple clients, this information is available to all users subscribing to the channel presence.
+      MIX channels store presence in the presence node using the proxy JID of each online client for a user.   User presence MAY be included based on client choice to publish presence.    Where a user publishes presence for multiple clients, this information is available to all users subscribing to the channel presence.
     </p>
     <p>
       External XMPP entities can direct stanzas to clients publishing their presence by sending them to the appropriate full proxy JID in the presence node.   These stanzas MAY be routed to the client by the MIX channel.  The choice to do this is dependent on MIX channel policy.   For example, a disco request MAY be routed through the MIX channel to the client.
@@ -332,9 +334,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       Private messages MAY be sent to channel participants if allowed by channel policy. Private messages are
  addressed to the user's bare proxy JID determined from the participants node, and routed by the MIX to the user's bare real JID, where standard distribution rules will apply.
     </p>
-    <p>
-      Private messages MAY also be sent to specific clients identified by the full proxy JID of the client in the participants list, if allowed by channel policy.
-    </p>
+    
   </section2>
   <section2 topic="Proxy JIDs and JID Visibility" anchor="proxy-jid">
     <p>
@@ -379,7 +379,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <tr><td>Configuration</td><td>'urn:xmpp:mix:nodes:config'</td><td>For storing channel configuration. </td><td>PubSub</td><td>PubSub</td></tr>
     </table>
     <p>
-      All of the standard nodes are OPTIONAL.   A channel providing a service similar to MUC will typically use all of the standard nodes, but other channels MAY use combinations of these nodes.
+      All of the standard nodes are OPTIONAL.   A channel providing a service similar to MUC will typically use all of the standard nodes, but other channels MAY use any combination of these nodes.
       MIX provides mechanisms to allow users to conveniently subscribe to a chosen set of nodes and to unsubscribe to all nodes with a single operation.  Some nodes are accessed and managed with PubSub, whereas other nodes define MIX specific mechanisms for their use, shown in the last two columns of the table.
     </p>
     <p>
@@ -406,7 +406,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         <tr><td>Anyone</td><td>Any user, including users in the banned node.</td></tr>
       </table>
       <p>
-        There will always be at least one owner and "anyone" will always have role occupants.   Other roles  MAY NOT have any role occupants.  Rights are defined in a strictly hierarchical manner, so that for example Owners will always have rights that Administrators have.
+        There MUST always be at least one owner and "anyone" will always have role occupants.   Other roles  MAY NOT have any role occupants.  Rights are defined in a strictly hierarchical manner, so that for example Owners will always have rights that Administrators have.
       </p>
     </section3>
     
@@ -416,8 +416,11 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </p>
     </section3>
     <section3 topic="Messages Node" anchor="messages-node">
-      <p>Items in this node will contain a message identified by the MAM ID used for the message in the channels MAM archive.  &xep0313; rules MUST be used to ensure this ID is unique.  A MIX implementation SHOULD NOT make messages available for retrieval from this node using pubsub and MUST NOT allow direct pubsub publishing to this node.  Messages are published by sending messages to the channel. The Messages node is a transient node and so no PubSub items are held.  Message history is retrieved by use of  MAM. Users subscribe to this node to indicate that messages from the channel are to be sent to them.</p>
-      <p>Private Messages are not stored in the messages node.</p>
+      <p>
+        The Message node is used to distribute messages.   The Messages node is a transient node and so no PubSub items are held.  Messages MUST go to the associated MAM archive and history is retrieved by use of  MAM. Users subscribe to this node to indicate that messages from the channel are to be sent to them.   Private Messages are not distributed by the messages node. 
+      
+      </p>
+      
     </section3>
 
     <section3 topic="Participants Node" anchor="participants-node">
@@ -441,7 +444,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
       <p>The JID Map node is used to associate a proxy bare JID to its corresponding real bare JID.  The JID Map node MUST have one entry for each entry in the Participants node.  This value is added when a user joins the channel and is removed when the user leaves the channel.
        Each item is identified by proxy bare JID, mapping to the real bare JID.  This node is used to give administrator access to real JIDs and participant access to real JIDs in jid-visible channels.  This node MUST NOT be modified directly using pubsub.
-       In JID visible channels, all participants MAY subscribe to this node.  In JID hidden channels, only administrators can subscribe.   The JID MAP node is a permanent node with one item per participant.</p>
+       In JID visible channels, all participants MAY subscribe to this node.  In JID hidden channels, only administrators can subscribe.   The JID Map node is a permanent node with one item per participant.</p>
       <example caption="Value of JID Map Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:jidmap'>
   <item id='coven+123456@mix.shakespeare.example'>
@@ -453,7 +456,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     </section3>
     <section3 topic="Presence Node" anchor="presence-node">
       <p>
-        The presence node contains the presence value for clients belonging to participants that choose to publish presence to the channel. A MIX channel MAY require that all participants publish presence.  Each item in the presence node is identified by the full proxy JID, and contains the current presence value for that JID.  The presence is encoded in the same way as data that would be sent in a presence stanza. The full JID is always used in this node. In MIX it is possible to have a 'presence-less channel' by not using this node. Access Control can be set to enforce that for each of the full JIDs in this list, the bare JID MUST be in the participants list.
+        The presence node contains the presence value for clients belonging to participants that choose to publish presence to the channel. A MIX channel MAY require that all participants publish presence.  Each item in the presence node is identified by the full proxy JID, and contains the current presence value for that JID.  The presence is encoded in the same way as data that would be sent in a presence stanza. The full proxy JID is always used in this node. In MIX it is possible to have a 'presence-less channel' by not using this node. Access Control MAY be set to enforce that for each of the full JIDs in this list, the bare JID MUST be in the participants list.
       </p>
 
       <p>
@@ -516,7 +519,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         </p>
         <example caption="Allowed Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:allowed'>
-  <item id='@shakespeare.lit'/>
+  <item id='shakespeare.lit'/>
   <item id='alice@wonderland.lit'/>
 </items>
 ]]></example>
@@ -613,7 +616,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 <section1 topic='Discovery' anchor='discovery'>
   <section2 topic='Discovering a MIX service' anchor='disco-service'>
     <p>
-      An entity MAY discover a MIX service or MIX services by sending a Service Discovery items ("disco#items") request to its own server.  This MUST come directly from a MIX client.
+      An entity MAY discover a MIX service or MIX services by sending a Service Discovery items ("disco#items") request to its own server.  
     </p>
     <example caption="Entity queries Server for associated services" ><![CDATA[
 <iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
@@ -635,7 +638,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </query>
 </iq>
 ]]></example>
-    <p>To determine if a domain hosts a MIX service, a &xep0030; info query SHOULD be sent in the usual manner to determine capabilities.</p>
+    <p>To determine if a domain hosts a MIX service, a &xep0030; info query is sent in the usual manner to determine capabilities.</p>
       <example caption="Entity queries a service" ><![CDATA[
 <iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     id='lx09df27'
@@ -644,7 +647,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>
 ]]></example>
-    <p>The MIX service then MUST return its identity and the features it supports, which MUST include the 'urn:xmpp:mix:0' feature, and the identity MUST have a category of 'conference' and a type of 'text'. </p>
+    <p>The MIX service then MUST return its identity and the features it supports, which MUST include the 'urn:xmpp:mix:0' feature, and the identity MUST have a category of 'conference' and a type of 'text', as shown in the following example: </p>
     <example caption="Service responds with Disco Info result" ><![CDATA[
 <iq from='mix.shakespeare.example'
     id='lx09df27'
@@ -661,7 +664,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 </iq>
 ]]></example>
     <p>
-      A MIX service MUST return the first feature listed and MAY return the other features listed:
+      A MIX service MUST return the 'urn:xmpp:mix:0' feature  and MAY return the other features listed here:
      </p>
     <ul>
       <li>'urn:xmpp:mix:0': This indicates support of MIX, and is returned by all MIX services.</li>
@@ -671,8 +674,8 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <p>A MIX service MUST NOT advertise support for &xep0313;, as MAM is supported by the channels and not by the service.   A  MIX service MUST NOT advertise support for generic &xep0060;, as although MIX makes use of PubSub it is not a generic PubSub service.</p>
   </section2>
   <section2 topic='Discovering the Channels on a Service' anchor='disco-channel-list'>
-    <p>The list of channels supported by a MIX service is obtained by a disco#items command.   The MIX service MUST only return channel that exist and that the user making the query has rights to subscribe to.  This query MUST be made directly by a client.</p>
-    <example caption='User&apos;s Server Queries for Channels on MIX Service'><![CDATA[
+    <p>The list of channels supported by a MIX service is obtained by a disco#items command.   The MIX service MUST only return channel that exist and that the user making the query has rights to subscribe to.  </p>
+    <example caption='Client Queries for Channels on MIX Service'><![CDATA[
 <iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     id='kl2fax27'
     to='mix.shakespeare.lit'
@@ -694,16 +697,16 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
   </section2>
   <section2 topic='Discovering Channel Information' anchor='disco-channel-info'>
-    <p>In order to find out more information about a given channel, a user can send a disco#info query to the channel.  This query MUST be made directly by a client.</p>
+    <p>In order to find out more information about a given channel, a user can send a disco#info query to the channel. </p>
     <example caption='Entity Queries for Information about a Specific Channel'><![CDATA[
-<iq from='hhag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     id='ik3vs715'
     to='coven@mix.shakespeare.lit'
     type='get'>
-  <query xmlns='http://jabber.org/protocol/disco#info'/>
+  <query xmlns='http://jabber.org/protocol/disco#info' node='mix'/>
 </iq>
 ]]></example>
-    <p> The channel MUST return its identity and the features it supports.  Note that a MIX channel MUST support MAM and so the response will always include both MIX and MAM support.  All disco queries on a MIX channel rad results returned MUST include node='mix'.   The reason for this is to facilitate MIX channels and &xep0045; MUC rooms sharing the same JID.   This extra parameter will enable a server to return appropriate information.</p>
+    <p> The channel MUST return its identity and the features it supports.  Note that a MIX channel MUST support MAM and so the response will always include both MIX and MAM support.  All disco queries on a MIX channel and results returned MUST include the attribute node='mix'.   The reason for this is to facilitate MIX channels and &xep0045; MUC rooms sharing the same JID.   This extra parameter will enable a server to return appropriate information.</p>
     <example caption='Channel Returns Disco Info Result'><![CDATA[
 <iq from='coven@mix.shakespeare.lit'
     id='ik3vs715'
@@ -721,7 +724,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
   </section2>
   <section2 topic='Discovering Nodes at a Channel' anchor='disco-channel-nodes'>
-    <p>Use disco#items to find the nodes associated with a channel.   The MIX service MUST only return nodes that exist and that the user making the query has rights to subscribe to. This query MUST be made directly by a client.</p>
+    <p>Use disco#items to find the nodes associated with a channel.   Discovering nodes in MIX MUST user the node='mix; attribute.  The MIX service MUST only return nodes that exist and that the user making the query has rights to subscribe to. </p>
     <example caption='Entity Queries for Nodes at a Channel'><![CDATA[
 <iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     id='kl2fax27'
@@ -749,13 +752,15 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
   </section2>
   <section2 topic="Determining Information about a Channel" anchor="find-channel-info">
-    <p>The Information Node contains various information about the channel that can be useful to the user.   This query MUST be made directly by a client.</p>
-    <example caption='User&apos;s Server Requests Channel Information'><![CDATA[
+    <p>The Information Node contains various information about the channel that can be useful to the user, that the client can access using PubSub, as shown below.</p>
+    <example caption='Client Requests Channel Information'><![CDATA[
 <iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     id='kl2fax27'
     to='coven@mix.shakespeare.lit'
     type='get'>
-  <query xmlns='urn:xmpp:mix:0#channel-info'/ node='mix'>
+  <pubsub xlns='http://jabber.org.protocol.pubsub'>
+      <items node='urn:xmpp:nodes:info'/>
+  </pubsub>
 </iq>
 ]]></example>
     <example caption='MIX Service Returns Channel Information'><![CDATA[
@@ -763,35 +768,42 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     id='kl2fax27'
     to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     type='result'>
-  <query xmlns='urn:xmpp:mix:0#channel-info' node='mix'>
-      <x xmlns='jabber:x:data' type='result'>
-        <field var='FORM_TYPE' type='hidden'>
-             <value>urn:xmpp:mix:0</value>
-        </field>
-        <field var='Name'>
-            <value>Witches Coven</value>
-        </field>
-        <field var='Description'>
-           <value>A location not far from the blasted heath where 
-           the three witches meet</value>
-         </field>
-        <field var='Contact'>
-           <value>greymalkin@shakespeare.lit</value>
-         </field>
-      </x>
-  </query>
+  <pubsub xlns='http://jabber.org.protocol.pubsub'>
+      <items node='urn:xmpp:nodes:info>>
+         <item>
+           <item id='2016-05-30T09:00:00' xmlns='urn:xmpp:mix:0'>
+              <x xmlns='jabber:x:data' type='result'>
+                 <field var='FORM_TYPE' type='hidden'>
+                     <value>urn:xmpp:mix:0</value>
+                 </field>
+                 <field var='Name'>
+                     <value>Witches Coven</value>
+                 </field>
+                 <field var='Description'>
+                    <value>A location not far from the blasted heath where 
+                          the three witches meet</value>
+                  </field>
+                  <field var='Contact'>
+                       <value>greymalkin@shakespeare.lit</value>
+                  </field>
+               </x>
+         </item>
+      </items>
+   </pubsub>
 </iq>
 ]]></example>
   </section2>
   <section2 topic='Determining the Participants in a Channel' anchor='find-channel-participants'>
     <p>
-      Online clients in the channel are determined from the presence node.   Participants in the channel are determined from the Participants Node which will give proxy JID and nick. The jidmap node is used to map to real JIDs.  An operation is provided to list channel participants.   For JID Hidden channels, only the nicks are returned.  For JID Visible channels, nicks and real JIDs are returned. This query MUST be made directly by a client.</p>
+      Online clients in the channel are determined from the presence node using PubSub.   Participants in the channel are determined from the Participants Node which will give proxy JID and nick. The jidmap node is used to map to real JIDs.    For JID Hidden channels, only the nicks are returned.  For JID Visible channels, nicks and real JIDs are returned. This query MUST be made directly by a client.</p>
     <example caption='User&apos;s Server Requests Participant List'><![CDATA[
 <iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     id='kl2fax27'
     to='coven@mix.shakespeare.lit'
     type='get'>
-  <query xmlns='urn:xmpp:mix:0#get-participants'/ node='mix'>
+     <pubsub xlns='http://jabber.org.protocol.pubsub'>
+          <items node='urn:xmpp:nodes:participants'/>
+     </pubsub>
 </iq>
 ]]></example>
     <example caption='MIX Service Returns Participant List for JID Visible Room'><![CDATA[
@@ -799,19 +811,29 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     id='kl2fax27'
     to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     type='result'>
-  <query xmlns='urn:xmpp:mix:0#get-participants' node='mix'>
+     <pubsub xlns='http://jabber.org.protocol.pubsub'>
+          <items node='urn:xmpp:nodes:participants'>
+             <item jid='hag66@shakespeare.lit' nick='thirdwitch'>
+             <item jid='hag01@shakespeare.lit' nick='top witch'>
+           </items>
+     </pubsub>
   <items>
-      <item jid='hag66@shakespeare.lit' nick='thirdwitch'>
-      <item jid='hag01@shakespeare.lit' nick='top witch'>
-</items>
 </iq>
 ]]></example>
   </section2>
   <section2 topic="Discovering Client MIX Capability" anchor="mix-client-discovery">
     <p>
-      Where a client supports MIX, it MUST advertise this capability in response to a Disco request.    This will enable other entities to determine if a client supports MIX, and in particular it facilitates the client's server to determine client support.  This can be optimized by use of CAPS.    The following example shows a Disco response from a client that supports both MIX and MUC.
+      Where a client supports MIX, it MUST advertise this capability in response to a Disco request.    This will enable other entities to determine if a client supports MIX, and in particular it facilitates the client's server to determine client support.  This can be optimized by use of CAPS.    The following example shows a Disco request to and response from a client that supports both MIX and MUC.
     </p>
-    <example caption='Disco Response showing MIX support'><![CDATA[
+    <example caption='Disco Query for MIX support'><![CDATA[
+ <iq  from='juliet@capulet.lit/46be1261-200b-4eea-8f82-e4fae46eec56/d6a85bb6-669f-471b-b55b-9a3930f5512e'
+    id='disco1'
+    to='romeo@montague.lit/14e8cb74-9082-4782-9275-8918ee5d8fcd/6983052d-3fdc-4e32-8221-79571a5210fe'
+    type='get'>
+  <query xmlns='http://jabber.org/protocol/disco#info'/>
+</iq>    
+      
+      
 <iq from='romeo@montague.lit/14e8cb74-9082-4782-9275-8918ee5d8fcd/6983052d-3fdc-4e32-8221-79571a5210fe'
     id='disco1'
     to='juliet@capulet.lit/46be1261-200b-4eea-8f82-e4fae46eec56/d6a85bb6-669f-471b-b55b-9a3930f5512e'
@@ -909,8 +931,12 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 </iq>
 ]]></example>
       <p>
-        If a user cannot be subscribed to one or more of the requested nodes (e.g., because the node does not exist), but can be subscribed to some the response simply lists the nodes successfully subscribed.    If none of the nodes requested are successfully subscribed to, an error response is sent indicating the reason that the first node requested was not subscribed to.   This response will also include other nodes requested where subscription failed for the same reason. The following response example shows a response to the initial request example where
-the participant is not be subscribed to all nodes associated with the channel (in this case only messages, participants, and information). The following example is the message from the MIX channel to the user's server, which will be modified and sent to the client.</p>
+        If a user cannot be subscribed to one or more of the requested nodes (e.g., because the node does not exist), but can be subscribed to some the response simply lists the nodes successfully subscribed.    If none of the nodes requested are successfully subscribed to, an error response is sent indicating the reason that the first node requested was not subscribed to.   This error response will also include other nodes requested where subscription failed for the same reason. </p>
+      
+      <p>
+        The following response example shows a successful response to the initial request example where
+        the participant is not be subscribed to all nodes associated with the channel (in this case only messages, participants, and information). This example shows the message from the MIX channel to the user's server, which will be modified and sent to the client.
+      </p>
       <example caption="Channel Processes Join With Some Nodes Not Subscribed To"><![CDATA[
 <iq type='result'
     from='hag66@shakespeare.example'
@@ -923,7 +949,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
   </join>
 </iq>
 ]]></example>
-      <p>The channel also adds the user to the participants node and sends a notification to subscribers to the participants node.  The following example shows such a notification.</p>
+      <p>The channel also adds the user to the participants node and sends a notification to subscribers of the participants node.  The following example shows such a notification.</p>
       <example caption="Channel Adds User to Participants Node"><![CDATA[
 <message from='coven@mix.shakespeare.example'
          to='hecate@shakespeare.example'
@@ -963,7 +989,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     </section3>
     <section3 topic="Roster Management" anchor="usecase-roster-management">
       <p>
-        As part of the channel joining process, the user's server MAY add the MIX channel to the user's roster using standard XMPP to update the roster.  This is done to share the user's presence status with the channel and so the MIX channel will get presence information from the user.  This roster entry will lead to the user's server correctly sending user's presence from all clients to the MIX channel. The roster subscription is configured with one way presence, as presence is sent to the MIX channel but no presence information is sent about the MIX channel. The user's server MUST remove this roster entry after the user leaves the channel.
+        As part of the channel joining process, the user's server MAY add the MIX channel to the user's roster using standard XMPP to update the roster.  This is done to share the user's presence status with the channel and so the MIX channel will get presence information from the user.  This roster entry will lead to the user's server correctly sending user's presence from all clients to the MIX channel. The roster subscription is configured with one way presence, as presence is sent to the MIX channel but no presence information is sent about the MIX channel to the user. The user's server MUST remove this roster entry after the user leaves the channel.
       </p>
       <p>
            If the user does not wish to publish presence information to the channel, the user will not add the roster entry.  A channel MAY require presence to be provided by all channel participants, which is controlled by the 'Participants Must Provide Presence' option.   The channel MAY check that channel participants have done this and MAY remove participants that do not do this.
@@ -974,7 +1000,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     </section3>
 
    <section3 topic="User Preferences and Additional Information" anchor="usecase-visibilty-pref">
-     <p>A channel MAY store user preferences and parameters with each user.    There are two preference options.
+     <p>A channel MAY store user preferences and parameters with each user.    There are several standard preference options.
        </p>
      <p>
        A user  JID visibility preference have the following values:
@@ -1148,7 +1174,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         The user's server will then generate a matching request to the MIX channel.
       </p>
       
-      <example caption="User Leaves a Channel"><![CDATA[
+      <example caption="User's Server sends  Leave Request to  a Channel"><![CDATA[
 <iq type='set'
     from='hag66@shakespeare.example'
     to='coven@mix.shakespeare.example'
@@ -1198,7 +1224,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 </message>
 
 <message from='coven@mix.shakespeare.example' 
-                to='hecate@shakespeare.example' id='bar'>
+                to='other-witch@shakespeare.example' id='bar'>
   <event xmlns='http://jabber.org/protocol/pubsub#event'>
     <items node='urn:xmpp:mix:nodes:presence'>
       <retract id='coven+123456@mix.shakespeare.example/8765'/>
@@ -1250,8 +1276,8 @@ the participant is not be subscribed to all nodes associated with the channel (i
 ]]></example>
     </section3>
     <section3 topic='Registering a Nick' anchor='usecase-user-register'>
-      <p>A user can register a nick with the MIX service.  Nick registration can be used ensure that a user is able to use the same nick in all channels in the service and to prevent other users from using a registered nick.   This can help achieve a consistent experience across a set of channels and prevent user confusion.  Support for nick registration by a MIX service is OPTIONAL.  Where nick registration is supported, nick registration MAY be OPTIONAL or MANDATORY.
-        Where a user has registered a Nick with the MIX service, it MAY be used by each channel according to policy for the channel. A nick is associated with the user's bare JID.
+      <p>A nick MAY be associated with the user's bare JID.  A user can register a nick with the MIX service.  Nick registration can be used ensure that a user is able to use the same nick in all channels in the service and to prevent other users from using a registered nick.   This can help achieve a consistent experience across a set of channels and prevent user confusion.  Support for nick registration by a MIX service is OPTIONAL.  Where nick registration is supported, nick registration MAY be OPTIONAL or MANDATORY.
+        Where a user has registered a Nick with the MIX service, it MAY be used by each channel according to policy for the channel.  A channel MAY enforce use of a registered nick.  A channel MUST NOT use a registered nick for any other participant. 
       </p>
       <p>
         In order to determine if a Nick is allowed to be registered, the user MAY use disco to determine capabilities of the MIX service.
@@ -1327,20 +1353,20 @@ the participant is not be subscribed to all nodes associated with the channel (i
         A user MAY share presence information with the channel, for one or more online clients.   Where a user shares presence information with a channel, the channel is entered by the user's server into the user's roster when the user subscribes to the channel.  When an XMPP client comes online or changes presence status, this will be communicated by the user to the user's server using broadcast presence.  The user's XMPP server is then responsible to share this presence information to each entry in the roster and in particular to each MIX channel in the roster.  The MIX channel will update the "urn:xmpp:mix:nodes:presence" node with any change of status and the updated presence information and then share this updated presence with users subscribed to this node, as described below.   When the user sets an explicit status, this is used to modify the presence node in the channel.   When a client being used by the user goes offline, the associated server will send presence status "unavailable" to the MIX channel, which will cause the full JID for that client to be removed from the presence node.
       </p>
       <p>
-        A channel MAY require that all channel participants share presence information with the channel, which is represented in the "urn:xmpp:mix:nodes:presence" node.   If sharing presences is needed by the channel, an XMPP client conforming to this specification SHALL share presence with the channel by including the channel in the user's roster. Note that the MIX service cannot generally enforce this, but it can require and enforce that when a message is sent to the channel, that the sender of the message is in the presence list.
+        A channel MAY require that all channel participants share presence information with the channel, which is represented in the "urn:xmpp:mix:nodes:presence" node.   If sharing presences is needed by the channel, an XMPP client conforming to this specification MUST share presence with the channel by including the channel in the user's roster. Note that the MIX service cannot generally enforce this, but it can require and enforce that when a message is sent to the channel, that the sender of the message is in the presence list.
       </p>
       <p>
-      Presence status and availability is set in a MIX channel by standard presence stanzas sent to the MIX channel by the user's server.   User's wishing to receive presence updates will subscribe to the MIX channel presence node.   Presence updates are sent out to subscribing participants using standard presence stanzas.
+      Presence status and availability is set in a MIX channel by standard presence stanzas sent to the MIX channel by the user's server.   Users wishing to receive presence updates will subscribe to the MIX channel presence node.   Presence updates are sent out to subscribing participants using standard presence stanzas.
       </p>
       <p>
-        A user setting status is now used as an example.   Unlike in &xep0045; where coming online is a special action, coming online in MIX is implicit when presence status is set.  Going offline is a achieved by setting presence status to unavailable, which removes the client full JID entry from the presence node.  When a user sets a presence status, the user's server sends updated presence to the MIX channel, and the MIX service then publishes the user's  availability to the "urn:xmpp:mix:nodes:presence" node. If there is not an item named by the full JID of the client with updated presence status, this item is created.   If there is not an item named by the full JID of the client with updated presence status, then an item is created.</p>
+        A user setting status is now used as an example.   Unlike in &xep0045; where coming online is a special action, coming online in MIX is implicit when presence status is set.  Going offline is a achieved by setting presence status to unavailable, which removes the client full JID entry from the presence node.  When a user sets a presence status, the user's server sends updated presence to the MIX channel, and the MIX service then publishes the user's  availability to the "urn:xmpp:mix:nodes:presence" node. If there is not an item named by the full JID of the client with updated presence status, this item is created.</p>
       <example caption="User Setting Presence Status">
 <![CDATA[<presence xmlns='jabber:client' from=‘hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0’ 
               to='coven@mix.shakespeare.example'>
   <show>dnd</show>
   <status>Making a Brew</status>
 </presence>]]></example>
-      <p>The user's presence information is then published by the service to the "urn:xmpp:mix:nodes:presence" node, with the 'publisher' attribute set to the user's participant identifier (the proxy JID. The MIX channel then broadcasts the presence change to all users who are subscribed to the "urn:xmpp:mix:nodes:presence" node.  The presence stanza is sent from the proxy (anonymized) full JID of the user.
+      <p>The user's presence information is then published by the service to the "urn:xmpp:mix:nodes:presence" node, with the 'publisher' attribute set to the user's participant identifier (the proxy JID). The MIX channel then broadcasts the presence change to all users who are subscribed to the "urn:xmpp:mix:nodes:presence" node.  The presence stanza is sent from the proxy (anonymized) full JID of the user.
       Note that presence is associated with a client and so will have a full JID as it comes directly from the client and not from the user's server.</p>
       <example caption="Channel Distributes Presence">
 <![CDATA[<presence from='coven+123435@mix.shakespeare.example/678'
@@ -1351,7 +1377,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
   <status>Making a Brew</status>
 </presence>]]></example>
     <p>
-     The presence is distributed to those subscribing to the MIX channel presence node using a standard XMPP presence stanza. The presence change is recorded on the "urn:xmpp:mix:nodes:presence" node in the item for the full JID of the client to which the presence relates. The history of this node will be held as PubSub format in the MAM archive, so that presence history can be viewed.
+     The presence is distributed to those subscribing to the MIX channel presence node using a standard XMPP presence stanza. The presence change is recorded on the "urn:xmpp:mix:nodes:presence" node. The history of this node will be held as PubSub format in the MAM archive, so that presence history can be viewed.
     </p>
     </section3>
 
@@ -1506,7 +1532,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
       </p>
     </section3>
     <section3 topic='Inviting another User to join a Channel that the user does not have Permission to Join' anchor='usecase-user-invite'>
-      <p> Invitation by reference, as described in the previous section, is a convenient approach to invite a user to join a channel that the user has permission to join.   This section describes the approach used when the inviter has permission to grant rights for the invitee to become a channel participant.   This might be because the inviter is an administrator of the channel or the channel  has a special mode where channel participants are allowed to grant rights for other users to join a channel ('Participation Addition by Invitation from Participant' enabled).   This approach is used to avoid cluttering the allowed node with JIDs of users who are invited to join, but do not accept the invitation.
+      <p> Invitation by reference, as described in the previous section, is a convenient approach to invite a user to join a channel that the user has permission to join.   This section describes the approach used when the inviter has permission to grant rights for the invitee to become a channel participant.   This might be because the inviter is an administrator of the channel or the channel  has a special mode where channel participants are allowed to grant rights for other users to join a channel enabled ('Participation Addition by Invitation from Participant').   This approach is used to avoid cluttering the allowed node with JIDs of users who are invited to join, but do not accept the invitation.
         When a channel participant(the inviter) invites  another user (the invitee) to join a channel, the following sequence of steps is followed:
 
       </p>
@@ -1518,15 +1544,16 @@ the participant is not be subscribed to all nodes associated with the channel (i
         <li>The invitee MAY send a response to the inviter, indicating if the invitation was accepted or declined.</li>
       </ol>
       <p>
-        The first step is for the inviter to request an invitation from the channel.   The invitation contains inviter, invitee and a token.  The channel will evaluate if the inviter has rights to issue the invitation.   This will be because the inviter is a channel administrator or if the inviter is a channel participant and the channel has 'Participation Addition by Invitation from Participant' mode enable.  If the inviter has rights to make the invitation, the channel will return a token.  The token is a string that the channel can subsequently use to validate an invitation.   The format of the token is not specified in this standard.   The encoded token MAY reflect a validity time.
+        The first step is for the inviter to request an invitation from the channel.   The invitation contains inviter, invitee and a token.  The channel will evaluate if the inviter has rights to issue the invitation.   This will be because the inviter is a channel administrator or if the inviter is a channel participant and the channel has 'Participation Addition by Invitation from Participant' mode enabled.  If the inviter has rights to make the invitation, the channel will return a token.  The token is a string that the channel can subsequently use to validate an invitation.   The format of the token is not specified in this standard.   The encoded token MAY reflect a validity time.
       </p>
       <example caption='Inviter Requests and Receives Invitation'><![CDATA[
 <iq from='hag66@shakespeare.lit/d1781be2-2b2d-4cd8-8886-bdc0e1087873/2183ee64-9c97-4eeb-bdc0-c35138b9c2b1'
     id='kl2fax27'
     to='coven@mix.shakespeare.lit'
     type='get'>
-  <query xmlns='urn:xmpp:mix:0#request-invitation'/>
-  <invitee>cat@shakespeare.lit</invitee>
+  <invite xmlns='urn:xmpp:mix:0'>
+      <invitee>cat@shakespeare.lit</invitee>
+  </invite>
 </iq>
 
 
@@ -1534,13 +1561,14 @@ the participant is not be subscribed to all nodes associated with the channel (i
     id='kl2fax27'
     to='hag66@shakespeare.lit/d1781be2-2b2d-4cd8-8886-bdc0e1087873/2183ee64-9c97-4eeb-bdc0-c35138b9c2b1'
     type='result'>
-  <query xmlns='urn:xmpp:mix:0#request-invitation'>
+  <invite xmlns='urn:xmpp:mix:0'>
         <invitation>
            <inviter>hag66@shakespeare.lit</inviter>
            <invitee>cat@shakespeare.lit</invitee>
            <channel>coven@mix.shakespeare.lit</channel>
            <token>ABCDEF</token>
         </invitation>
+  <invite/>
 </iq>
 ]]></example>
       <p>
@@ -1834,7 +1862,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
     <section3 topic='Creating a Channel for Ad Hoc Use' anchor='usecase-admin-create-adhoc'>
       <p>
-        Rooms MAY be created for ad hoc use between a set of users.  Channels of this nature will have channel name created by the server and will not be addressable or discoverable.  Here a channel is created without specifying the channel name.   Parameters for the channel MAY also be specified.
+        Channels MAY be created for ad hoc use between a set of users.  Channels of this nature will have channel name created by the server and will not be addressable or discoverable.  Here a channel is created without specifying the channel name.   Parameters for the channel MAY also be specified.
       </p>
       <example caption="Creating a Channel for Ad Hoc Use" ><![CDATA[
 <iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
@@ -1854,7 +1882,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
    </section3>
    <section3 topic="Converting a 1:1 Conversation to a Channel" anchor="usecase-admin-converting-chat">
      <p>
-       A common use case for an ad hoc channel is where two users are engaged in a 1:1 chat and wish to broaden the discussion. Prior to bringing more users into a channel, using standard invitation process, there is a need to move a dialogue.  The first step is for one of the two users to create an ad hoc channel, as described in the previous section.   The other user will then be invited, and can switch to the new channel.
+       A common use case for an ad hoc channel is where two users are engaged in a 1:1 chat and wish to broaden the discussion. Prior to bringing more users into a channel, using standard invitation process, there is a need to create and populate a channel.  The first step is for one of the two users to create an ad hoc channel, as described in the previous section.   The other user will then be invited, and can switch to the new channel.
      </p>
      <p>
        It can also be useful to share some or all of the messages from the 1:1 discussion into the new channel.  The mechanism to do this is to forward messages to be shared in the MUC using &xep0297;.  A body SHOULD NOT be used in the outer message.
@@ -2082,7 +2110,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'>
          <items node='urn:xmpp:mix:nodes:allowed'>
-            <item id='@shakespeare.lit'/>
+            <item id='shakespeare.lit'/>
             <item id='alice@wonderland.lit'/>
          </items>
     </pubsub>
@@ -2098,7 +2126,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     type='set'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'>
         <publish node='urn:xmpp:mix:nodes:allowed'>
-            <item id='@marlow.lit'/>
+            <item id='marlow.lit'/>
          </items>
     </pubsub>
 </iq>
@@ -2330,7 +2358,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
   </query>
 </iq>
 ]]></example>
-  <p>In the fully integrated service item discovery on the MIX/MUC service determines a list of channels.   The protocol used for this is the same in MUC and MIX.   Discovery actions on a channel in MIX will use 'node=mix' in the discovery which will lead to the return of MIX channel specific information.   If is not set, MUC room specific information is returned.
+  <p>In the fully integrated service item discovery on the MIX/MUC service determines a list of channels.   The protocol used for this is the same in MUC and MIX.   Discovery actions on a channel in MIX MUST use 'node=mix' attribute in the discovery which will lead to the return of MIX channel specific information, as mandated for this discovery in MIX.   If is not set, MUC room specific information is returned.
   </p>
   <p>For the partially integrated service, it will be useful for clients that support both MIX and MUC to be able to determine that the server supports both protocols.   For a MIX client, it will be useful to know the MUC service, so that this information can be shared with a MUC client invitation.   This information is provided by the initial service discovery:</p>
     <example caption="MIX Service responds with Disco Info result sharing MUC service location" ><![CDATA[

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -2217,12 +2217,11 @@ the participant is not be subscribed to all nodes associated with the channel (i
     from='hag66@shakespeare.example/pda'
     to='hag66@shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <join xmlns='urn:xmpp:mix:0'>
-    <channel jid='coven@mix.shakespeare.example'/>
+  <join xmlns='urn:xmpp:mix:0' 
+         channel='coven@mix.shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
     <subscribe node='urn:xmpp:mix:nodes:participants'/>
-    <subscribe node='urn:xmpp:mix:nodes:subject'/>
     <subscribe node='urn:xmpp:mix:nodes:config'/>
   </join>
 </iq>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -268,7 +268,7 @@
      </li>
     <li>&xep0313; (MAM) is used for all history access, with each node being individually addressable for MAM queries. This simplifies implementation compared to MUC (which had a specialized and rather limited history retrieval mechanism).</li>
     <li>A client can achieve a 'quick resync' of a node by requesting just those changes it has not yet received, using standard MAM protocol. This solves the old MUC issue of either receiving duplicate messages when rejoining a room or potentially missing messages.</li>
-    <li>Because MAM is used for history, only those nodes that have a 'current value' need to store any items in them &mdash; e.g., 'urn:xmpp:mix:nodes:presence' and 'urn:xmpp:mix:nodes:subject' would store their current values (with older values being queryable through MAM), while 'urn:xmpp:mix:nodes:messages' would store no items.</li>
+    <li>Because MAM is used for history, only those nodes that have a 'current value' need to store any items in them &mdash; e.g., 'urn:xmpp:mix:nodes:presence' and 'urn:xmpp:mix:nodes:information' would store their current values (with older values being queryable through MAM), while 'urn:xmpp:mix:nodes:messages' would store no items.</li>
     <li>A user's participation in a channel outlives their client sessions. A client which is offline will not share presence within the channel, but the associated user will still be listed as an participant. </li>
     <li>Presence is sent to all participants using bare JID, whether or not the user has an online client. </li>
     <li>Online clients MAY register presence, which is then shared with participants who have subscribed to presence.</li>
@@ -368,7 +368,6 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <tr><td>JID Map</td><td>'urn:xmpp:mix:nodes:jidmap'</td><td>For storing a list of anonymized bare JIDs from the participants node with a 1:1 mapping to the corresponding real JIDs.</td><td>Automatic</td><td>PubSub</td></tr>
       <tr><td>Presence</td><td>'urn:xmpp:mix:nodes:presence'</td><td>For storing information about the availability status of online participants, which MAY include multiple clients for a single participant.</td><td>Presence</td><td>Presence</td></tr>
       <tr><td>Information</td><td>'urn:xmpp:mix:nodes:info'</td><td>For storing general channel information, such as description. </td><td>PubSub</td><td>PubSub</td></tr>
-      <tr><td>Subject</td><td>'urn:xmpp:mix:nodes:subject'</td><td>For storing and sharing the current subject of a channel</td><td>Message</td><td>Message</td></tr>
       <tr><td>Allowed</td><td>'urn:xmpp:mix:nodes:allowed'</td><td>For storing JIDs that are allowed to be channel participants.</td><td>PubSub</td><td>PubSub</td></tr>
       <tr><td>Banned</td><td>'urn:xmpp:mix:nodes:banned'</td><td>For storing JIDs that are not allowed to be channel participants. </td><td>PubSub</td><td>PubSub</td></tr>
       <tr><td>Configuration</td><td>'urn:xmpp:mix:nodes:config'</td><td>For storing channel configuration. </td><td>PubSub</td><td>PubSub</td></tr>
@@ -471,9 +470,9 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         <tr><td>'Contact'</td><td>The JID or JIDs of the person or role responsible for the channel.</td><td>jid-multi</td><td>-</td><td>-</td></tr>
       </table>
       <p>
-        Name and Description of the channel apply to the whole channel and are will usually be changed infrequently.   This contrasts to Subject, which is more likely to change frequently and will often reflect the topic being discussed which has narrower scope than channel as a whole.
+        Name and Description of the channel apply to the whole channel and are will usually be changed infrequently.   
       </p>
-      <p>The name and description values MUST contain a "text" element and MAY contain additional text elements. Where multiple text elements are provided, each MUST posses an xml:lang attribute that describes the natural language of the subject.  The format of the Information node follows &xep0004;.  This allows configuration to be updated by MIX defined commands and that the results of update commands are the same as the PubSub node.
+      <p>The name and description values MUST contain a "text" element and MAY contain additional text elements. Where multiple text elements are provided, each MUST posses an xml:lang attribute that describes the natural language of the element.  The format of the Information node follows &xep0004;.  This allows configuration to be updated by MIX defined commands and that the results of update commands are the same as the PubSub node.
       The following example shows the format of a item in the information node for the example coven@mix.shakespeare.example channel.
       </p>
       <example caption="Information Node"><![CDATA[
@@ -498,23 +497,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 </items>
 ]]></example>
     </section3>
-    <section3 topic="Subject Node" anchor="subject-node">
-      <p>The subject node publishes the current subject of channel. Subject history is stored in MAM. A single item is stored in this node at a time which MUST contain a "text" element and MAY contain additional text elements. Where multiple text elements are provided, each MUST posses an xml:lang attribute that describes the natural language of the subject.  </p>
-      <p>
-        Setting and sharing subject uses a message with subject element, in a manner compatible with &xep0045;.  Clients MAY also write or access this node using pubsub. Writes to this node will lead to update of subject by sending messages.   Setting the subject is controlled by configuration; in some channels it MAY be set by all users and in others restricted to administrators.
-        The following example shows the format of a item in the subject node.
-      </p>
-      <example caption="Subject Node">
-        <![CDATA[<items node='urn:xmpp:mix:nodes:subject'>
-  <item>
-    <text xml:lang="en">How to use Toads</text>
-    <text xml:lang="de">Wie benutzt man Kröten</text>
-  </item>
-</items>]]></example>
-      <p>
-        When a user subscribes to the Subject Node, this will cause the channel to send Subject messages to the user's server using the user's bare JID.  This is done on initial user subscription and on subject change.   Clients MAY directly read the channel subject from the Subject Node using PubSub.
-      </p>
-    </section3>
+    
       <section3 topic="Allowed" anchor="allowed-node">
         <p>
           This node represents a list of JIDs that are allowed to become participants. If the allowed node is not present, all JIDs are allowed. This node is accessed and managed using standard pubsub.  The allowed list is always considered in conjunction with the banned list, stored in the banned node.  Only Administrators and Owners have write permission to the allowed node and are also the only roles that are allows to subscribe to this node.    Each item contains a real bare JID.  The following example shows how the allowed list can specify single JIDs and domains.
@@ -547,11 +530,11 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         <tr><td>'Owner'</td><td>Bare JIDs with Owner rights as defined in ACL node.  When a channel is created, the JID creating the channel is configured as an owner, unless this attribute is explicitly configured to another value.</td><td>jid-multi</td><td>-</td><td>-</td></tr>
         <tr><td>'Administrator'</td><td>Bare JIDs with Administrator rights.</td><td>jid-multi</td><td>-</td><td>-</td></tr>
         <tr><td>'End of Life'</td><td>The date and time at which the channel will be automatically removed by the server.   If this is not set, the channel is permanent.</td><td>text-single</td><td>-</td><td>-</td></tr>
-        <tr><td>'Nodes Present'</td><td>Specifies which nodes are present. Presence of  config nodes is implicit.  Jidmap node MUST be present if participants node is present. 'avatar' means that both Avatar Data and Avatar Metadata nodes are present.</td><td>list-multi</td><td>'participants'; 'presence'; 'subject'; 'information'; 'allowed'; 'banned'; 'avatar'</td><td>-</td></tr>
+        <tr><td>'Nodes Present'</td><td>Specifies which nodes are present. Presence of  config nodes is implicit.  Jidmap node MUST be present if participants node is present. 'avatar' means that both Avatar Data and Avatar Metadata nodes are present.</td><td>list-multi</td><td>'participants'; 'presence'; 'information'; 'allowed'; 'banned'; 'avatar'</td><td>-</td></tr>
         <tr><td>'Message Node Subscription'</td><td>Controls who can subscribe to messages node.</td><td>list-single</td><td>'participants'; 'allowed'; 'anyone'</td><td>'participants'</td></tr>
         <tr><td>'Presence Node Subscription'</td><td>Controls who can subscribe to presence node.</td><td>list-single</td><td>'participants'; 'allowed'; 'anyone'</td><td>'participants'</td></tr>
         <tr><td>'Participants Node Subscription'</td><td>Controls who can subscribe to participants node.</td><td>list-single</td><td>'participants'; 'allowed'; 'anyone'; 'nobody'; 'admins'; 'owners'</td><td>'participants'</td></tr>
-        <tr><td>'Subject Node Subscription'</td><td>Controls who can subscribe to subject node.</td><td>list-single</td><td>'participants'; 'allowed'; 'anyone' </td><td>'participants'</td></tr>
+        
         <tr><td>'Information Node Subscription'</td><td>Controls who can subscribe to the information node.</td><td>list-single</td><td>'participants'; 'allowed'; 'anyone'</td><td>'participants'</td></tr>
         <tr><td>'Allowed Node Subscription'</td><td>Controls who can subscribe to allowed node.</td><td>list-single</td><td>'participants'; 'allowed';  'nobody'; 'admins'; 'owners' </td><td>'admins'</td></tr>
         <tr><td>'Banned Node Subscription'</td><td>Controls who can subscribe to banned node.</td><td>list-single</td><td>'participants'; 'allowed';  'nobody'; 'admins'; 'owners' </td><td>'admins'</td></tr>
@@ -737,8 +720,6 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <item jid='coven@mix.shakespeare.example'
           node='urn:xmpp:mix:nodes:messages'/>
     <item jid='coven@mix.shakespeare.example'
-          node='urn:xmpp:mix:nodes:subject'/>
-    <item jid='coven@mix.shakespeare.example'
           node='urn:xmpp:mix:nodes:config'/>
   </query>
 </iq>
@@ -829,7 +810,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 <section1 topic='Use Cases' anchor='usecases'>
   <section2 topic='Common User Use Cases' anchor='usecases-user'>
     <section3 topic='Joining a Channel' anchor='usecase-user-join'>
-      <p>A user joins a channel by sending a MIX "join" command. There is no default set of nodes, so user MUST specify the set of nodes to be subscribed to. To achieve the equivalent service to MUC, a user would subscribe to messages, presence and subject.
+      <p>A user joins a channel by sending a MIX "join" command. There is no default set of nodes, so user MUST specify the set of nodes to be subscribed to. To achieve the equivalent service to MUC, a user would subscribe to messages, and presence.
          This will lead to the server subscribing the user to each of the requested nodes associated with the channel. The MIX service will also add the user to the participant list by injecting a new item into the "urn:xmpp:mix:nodes:participants" node automatically.
 
       </p>
@@ -906,7 +887,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
       <p>
         If a user cannot be subscribed to one or more of the requested nodes (e.g., because the node does not exist), but can be subscribed to some the response simply lists the nodes successfully subscribed.    If none of the nodes requested are successfully subscribed to, an error response is sent indicating the reason that the first node requested was not subscribed to.   This response will also include other nodes requested where subscription failed for the same reason. The following response example shows a response to the initial request example where
-the participant is not be subscribed to all nodes associated with the channel (in this case only messages, participants, and subject). The following example is the message from the MIX channel to the user's server, which will be modified and sent to the client.</p>
+the participant is not be subscribed to all nodes associated with the channel (in this case only messages, participants, and information). The following example is the message from the MIX channel to the user's server, which will be modified and sent to the client.</p>
       <example caption="Channel Processes Join With Some Nodes Not Subscribed To"><![CDATA[
 <iq type='result'
     from='hag66@shakespeare.example'
@@ -915,7 +896,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
   <join xmlns='urn:xmpp:mix:0' jid='coven+123456@mix.shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:participants'/>
-    <subscribe node='urn:xmpp:mix:nodes:subject'/>
+    <subscribe node='urn:xmpp:mix:nodes:info'/>
   </join>
 </iq>
 ]]></example>
@@ -1495,35 +1476,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 </message>
 ]]></example>
     </section3>
-    <section3 topic="Setting the Channel Subject" anchor="set-subject">
-      <p>
-       Setting the subject for a channel follows a similar procedure to sending a message.   An XMPP client will send a message setting the subject directly to the MIX channel.   Note that where multiple language variants are used, the subject is repeated and each subject MUST include a language reference.
-      </p>
-      <example caption="User Sets Channel Subject"><![CDATA[
-<message from='hag66@shakespeare.example/pda'
-         to='coven@mix.shakespeare.example'
-         id='92vax143g'
-         type='groupchat'>
-  <subject xml:lang="en">How to use Toads</subject>
-  <subject xml:lang="de">Wie benutzt man Kröten</subject>
-</message>
-]]></example>
-      <p>
-        This message is received by the MIX channel, which will set the Subject Node for the channel, and then distribute the message to participants that are subscribed to the Subject Node, with the message addressed to the participant’s server using the participant's bare JID.
-      </p>
-      <example caption="Channel Reflects New Subject to Participants"><![CDATA[
-<message from='coven+12345@mix.shakespeare.example/678'
-         to='hecate@shakespeare.example'
-         id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
-         type='groupchat'>
-           <subject xml:lang="en">How to use Toads</subject>
-           <subject xml:lang="de">Wie benutzt man Kröten</subject>
-</message>
-]]></example>
-      <p>
-        When a new Participant joins a channel and subscribes to the Subject Node, the channel MUST send to the participant's server (using the participant's bare JID) a message with the current subject.   An XMPP Client MAY directly read the Subject node using &xep0060;.
-      </p>
-    </section3>
+
     <section3 topic='Telling another User about a Channel' anchor='usecase-user-tell'>
       <p>
         A convenient way to reference another channel is to use &xep0372; which enables the JID of a channel to be shared.  This might be used simply to inform the message recipient about the channel or as mechanism to invite the user to join the channel.   This is useful as an invitation mechanism to a channel that any user can join or where the invitee knows that the user is allowed to join (e.g., because the channel is for all users in an organization).
@@ -1744,7 +1697,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
    </p>
     <section3 topic="Archive of Messages" anchor="use-mam-messages">
       <p>
-        Messages sent to participants MUST be archived by both the MIX channel and by the user's server.   This MUST include messages setting subject and MAY include presence messages.   Correct MIX operation relies on messages being archived.
+        Messages sent to participants MUST be archived by both the MIX channel and by the user's server.   This  MAY include presence messages.   Correct MIX operation relies on messages being archived.
       </p>
     </section3>
     <section3 topic="Retrieving Messages" anchor="use-mam-retrieve">
@@ -2270,7 +2223,6 @@ the participant is not be subscribed to all nodes associated with the channel (i
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
     <subscribe node='urn:xmpp:mix:nodes:participants'/>
-    <subscribe node='urn:xmpp:mix:nodes:subject'/>
     <subscribe node='urn:xmpp:mix:nodes:config'/>
   </join>
 </iq>
@@ -2428,10 +2380,14 @@ the participant is not be subscribed to all nodes associated with the channel (i
     </p>
   </section2>
 
+<section2 anchor="not-subject" topic="Subject">
+  <p>&xep0045; provide a Subject capability to enable setting of the current topic of discussion.   The Name and Description attributes provided by MIX enable descriptive information to be associated with a channel.   These attributes can replace Subject in the way it is used in many MUC rooms, but they do not reflect the more limited topic nature of Subject.</p>
+  <p>It is likely that a new XEP to be used with MIX will be written, perhaps using a "Sticky Messages" approach to fulfil the Subject capability using a different approach. </p>
+</section2>
 </section1>
 
 <section1 topic='Internationalization Considerations' anchor='i18n'>
-  <p>MIX allows specification of a number of human readable strings associated with a MIX channel, in particular the subject of a  MIX channel and name and description information.   These strings MAY have language set using an xml:lang attribute, and multiple values MAY be set provided that each one is distinguished using xml:lang.
+  <p>MIX allows specification of a number of human readable strings associated with a MIX channel, in particular the name and description information of a  MIX channel.   These strings MAY have language set using an xml:lang attribute, and multiple values MAY be set provided that each one is distinguished using xml:lang.
   </p>
 
   <p>Nicknames SHOULD be normalized using the "nickname" profile of the PRECIS OpaqueString class, as defined in &rfc7700;. </p>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -404,7 +404,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </p>
     </section3>
     <section3 topic="Messages Node" anchor="messages-node">
-      <p>Items in this node will contain a message identified by the MAM ID used for the message in the channels MAM archive.  &xep0313; rules MUST be used to ensure this ID is unique.  A MIX implementation SHOULD NOT make messages available for retrieval from this node using pubsub and MUST NOT allow direct pubsub publishing to this node.  Messages are published by sending messages to the channel. Zero history is held in the messages node.   Message history is retrieved by use of  MAM. Users subscribe to this node to indicate that messages from the channel are to be sent to them.</p>
+      <p>Items in this node will contain a message identified by the MAM ID used for the message in the channels MAM archive.  &xep0313; rules MUST be used to ensure this ID is unique.  A MIX implementation SHOULD NOT make messages available for retrieval from this node using pubsub and MUST NOT allow direct pubsub publishing to this node.  Messages are published by sending messages to the channel. The Messages node is a transient node and so there is no PubSub history.  Message history is retrieved by use of  MAM. Users subscribe to this node to indicate that messages from the channel are to be sent to them.</p>
       <p>Private Messages are not stored in the messages node.</p>
     </section3>
 
@@ -415,7 +415,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         When a user joins a channel, the user's bare JID is added to the participants node by the MIX service.   When a user leaves a channel, they are removed from the participants node.  The participants node MUST NOT be directly modified using pubsub.
       This node MAY be subscribed to for jid-visible channels that permit subscription to this node - this will allow users to see changes to the channel participants.
       </p>
-      <p>The participants node is OPTIONAL.  If the Participants Node is not used, information on channel participants is not shared.  If there is no participants node, the access control value 'participants' MUST NOT be used.</p>
+      <p>The participants node is OPTIONAL.  If the Participants Node is not used, information on channel participants is not shared.  If there is no participants node, the access control value 'participants' MUST NOT be used.   The Participants node is a permanent node and PubSub history MAY be stored.</p>
       <example caption="Value of Participants Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:participants'>
   <item id='coven+123456@mix.shakespeare.example'>
@@ -429,7 +429,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
       <p>The JID Map node is used to associate a proxy bare JID to its corresponding real bare JID.  The JID Map node MUST have one entry for each entry in the Participants node.  This value is added when a user joins the channel and is removed when the user leaves the channel.
        Each item is identified by proxy bare JID, mapping to the real bare JID.  This node is used to give administrator access to real JIDs and participant access to real JIDs in jid-visible channels.  This node MUST NOT be modified directly using pubsub.
-        In JID visible channels, all participants MAY subscribe to this node.  In JID hidden channels, only administrators can subscribe.  </p>
+       In JID visible channels, all participants MAY subscribe to this node.  In JID hidden channels, only administrators can subscribe.   The JID MAP node is a permanent node and PubSub history MAY be stored.</p>
       <example caption="Value of JID Map Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:jidmap'>
   <item id='coven+123456@mix.shakespeare.example'>
@@ -445,7 +445,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </p>
 
       <p>
-        This node MAY be subscribed to by users and this subscription MUST use the users bare JID.  So presence of online clients is sent to the user's server for each user subscribed to this node. Presence is always sent using standard presence protocol and NOT using pubsub protocol.   Clients MUST NOT directly access the presence node using pubsub.
+        This node MAY be subscribed to by users and this subscription MUST use the users bare JID.  So presence of online clients is sent to the user's server for each user subscribed to this node. Presence is always sent using standard presence protocol and NOT using pubsub protocol.   Clients MUST NOT directly access the presence node using pubsub.  The Presence node is a transient PubSub node.
       </p>
       <example caption="Value of Presence Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:presence'>
@@ -460,8 +460,8 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     </section3>
     <section3 topic="Information Node" anchor="info-node">
 
-      <p>The Information node holds information about the channel.  The information node contains a single item with the current information.  Information node history is held in MAM.
-        The information node is named by the date/time at which the item was created.   The information node is accessed and managed using standard pubsub.  Users MAY subscribe to this node to receive information updates. The Information node item MAY contain the following attributes, each of which is OPTIONAL:
+      <p>The Information node holds information about the channel.  The information node contains a single item with the current information.  Information node history is RECOMENDED to be held in MAM.
+        The information node is named by the date/time at which the item was created.   The information node is accessed and managed using standard pubsub.   The Information node is a transient node and so no PubSub history is stored.  Users MAY subscribe to this node to receive information updates. The Information node item MAY contain the following attributes, each of which is OPTIONAL:
       </p>
       <table caption="Information Node Attributes">
         <tr><th>Name</th><th>Description</th><th>Field Type</th><th>Values</th><th>Default</th></tr>
@@ -500,7 +500,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     
       <section3 topic="Allowed" anchor="allowed-node">
         <p>
-          This node represents a list of JIDs that are allowed to become participants. If the allowed node is not present, all JIDs are allowed. This node is accessed and managed using standard pubsub.  The allowed list is always considered in conjunction with the banned list, stored in the banned node.  Only Administrators and Owners have write permission to the allowed node and are also the only roles that are allows to subscribe to this node.    Each item contains a real bare JID.  The following example shows how the allowed list can specify single JIDs and domains.
+          This node represents a list of JIDs that are allowed to become participants. If the allowed node is not present, all JIDs are allowed. This node is accessed and managed using standard pubsub.  The allowed list is always considered in conjunction with the banned list, stored in the banned node.  Only Administrators and Owners have write permission to the allowed node and are also the only roles that are allows to subscribe to this node.   The Allowed node is a permanent node and PubSub history MAY be stored.  Each item contains a real bare JID.  The following example shows how the allowed list can specify single JIDs and domains.
         </p>
         <example caption="Allowed Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:allowed'>
@@ -511,7 +511,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </section3>
       <section3 topic="Banned" anchor="banned-node">
         <p>
-          This node represents a list of JIDs that are explicitly not allowed to become participants. The values in this list take priority over values in the allowed node. This node is accessed and managed using standard pubsub  Only Administrators and Owners have write permission to the allowed node and are also the only roles that are allows to subscribe to this node. Each item contains a real bare JID.
+          This node represents a list of JIDs that are explicitly not allowed to become participants. The values in this list take priority over values in the allowed node. This node is accessed and managed using standard pubsub  Only Administrators and Owners have write permission to the allowed node and are also the only roles that are allows to subscribe to this node. Each item contains a real bare JID.   The Banned node is a permanent node and PubSub history MAY be stored.
         </p>
         <example caption="Banned Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:banned'>
@@ -522,7 +522,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </section3>
     <section3 topic="Configuration Node" anchor="config-node">
       <p>
-        The Configuration node holds the configuration of the channel as a single item, named by the date-time of the last update to the configuration.  A single item is stored in the node, with previous configuration history accessed by MAM.  Users with read access to the configuration node MAY subscribe to the configuration node to get notification of configuration change.  This node is accessed and managed using standard pubsub. The configuration node is OPTIONAL for a MIX channel.  For example, configuration choices could be fixed and not exposed.   A subset of the defined configuration options MAY be used and additional non-standard configuration options MAY be added.   JIDs in the configuration MUST be real bare JIDs and not proxy JIDs.  If configuration options to control functionality of the nature described here are provided, the options defined in this standard MUST be used. The following configuration attributes are defined:
+        The Configuration node holds the configuration of the channel as a single item, named by the date-time of the last update to the configuration.  The Configuraton Node is a transient PubSub node with no history.   It is RECOMMENDED to store Configuraton Node history in MAM. Previous configuration history MUST be accessed by MAM.  Users with read access to the configuration node MAY subscribe to the configuration node to get notification of configuration change.  This node is accessed and managed using standard pubsub. The configuration node is OPTIONAL for a MIX channel.  For example, configuration choices could be fixed and not exposed.   A subset of the defined configuration options MAY be used and additional non-standard configuration options MAY be added.   JIDs in the configuration MUST be real bare JIDs and not proxy JIDs.  If configuration options to control functionality of the nature described here are provided, the options defined in this standard MUST be used. The following configuration attributes are defined:
 </p>
       <table caption="Configuration Node Attributes">
         <tr><th>Name</th><th>Description</th><th>Field Type</th><th>Values</th><th>Default</th></tr>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -38,7 +38,7 @@
   &stpeter;
   <revision>
     <version>0.8</version>
-    <date>2017-02-12</date>
+    <date>2017-02-13</date>
     <initials>sek</initials>
     <remark><p>
       Update after Brussels Summit;

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -51,7 +51,7 @@
       Removal of Subject and reference future Sticky Messages XEP (summit 7);
       Use example JIDs aligned to anticipated BIND2 specification;
       Clarify PubSub Node Type;
-      Clarify Error handling and Add Error for messages rejected by channel;
+      Add Error handling section;
     </p></remark>
   </revision>
   <revision>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -45,6 +45,7 @@
       Remove Explicit Client Activation and replace with client capability discovery;
       Limit Indirect to Join/Leave;
       Clarify Server use of Disco of Client;
+      Add MIX capability information to Roster;
     </p></remark>
   </revision>
   <revision>
@@ -2165,14 +2166,14 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
   <section2 topic="Server Identification of MIX Capabable Clients" anchor="server-identification-mix-clients">
     <p>
-    A MIX User's server MUST determine which online clients support MIX.   This will enable the server to send MIX traffic to all MIX capable clients.   A MIX capable client MAY choose to come online an not advertize MIX capability.   
+      A MIX User's server MUST determine which online clients support MIX.   This will enable the server to send MIX traffic to all MIX capable clients.   A MIX capable client MAY choose to come online an not advertize MIX capability.   The mechanism for a server to discover client capability is described in <link url="#mix-client-discovery">Discovering Client MIX Capability</link>.
     </p>
 
   </section2>
 
   <section2 topic="Messages From MIX Channels" anchor="mix-from">
     <p>
-      Messages from a MIX channel will usually go to the participant's server.   The only exception to this is where the MIX channel is responding directly to messages from the client.   Messages and presence distributed but a MIX channel will always be sent to the participant's server and addressed to the user's bare JID.  The participant's server will simply send on the messages from the channel to each of the user's online clients which advertise MIX capability.   If there are no such clients activated, the message is dropped.   The mechanism for a server to discover client capability is described in <link url="#mix-client-discovery">Discovering Client MIX Capability</link>.
+      Messages from a MIX channel will usually go to the participant's server.   The only exception to this is where the MIX channel is responding directly to messages from the client.   Messages and presence distributed but a MIX channel will always be sent to the participant's server and addressed to the user's bare JID.  The participant's server will simply send on the messages from the channel to each of the user's online clients which advertise MIX capability.   If there are no such clients activated, the message is dropped.   
     </p>
     <p>
       Messages sent to the participant's sever will always be addressed to the user's bare JID.  The participant’s server will modify the recipient to the full JID of each client to which the message is forwarded.    The participant's server MUST NOT make any other modifications to each message.  The following example, repeated from earlier, shows a message distributed by a MIX channel and directed to the participant’s server with the participant's bare JID.
@@ -2275,14 +2276,32 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
   <section2 topic="Roster Management" anchor="proxy-roster">
     <p>
-      The participant's server is responsible for ensuring that MIX channels are correctly entered into the user's roster.   This is provided as a generic client independent service for the user.
+      The participant's server is responsible for ensuring that MIX channels are correctly entered into the user's roster when user's join MIX channels and for removing them when they leave.   
     </p>
     <p>
-      The participant's server SHOULD ensure that only presence information from activated MIX clients is sent to the MIX channel.  So, if a user has two online clients, but only one is activated for a given MIX channel, then the channel SHOULD only receive presence information relating to the activated client.
+      The participant's server MUST ensure that only presence information from clients that advertize MIX capability is sent to the MIX channel.  So, if a user has two online clients, but only one is MIX capable, then the channel will only receive presence information relating to the MIX client.
     </p>
+    
+  </section2>
+  
+  <section2 topic="MIX Roster Item Capability Sharing" anchor="mix-roster-capability-sharing">
+    <p>It will be useful for a MIX client to know which roster members are MIX channels, as this will facilitate convenient presentation of subscribed MIX channels to the user. A standard roster item is encoded as follows.</p>
+    <example caption="Standard Roster Item Encoding"><![CDATA[
+<item jid='romeo@example.net'/>
+]]></example>
+    
     <p>
-      In order to present channels usefully to the end user a client MAY disco the domain of a roster entry to discover if it is a MIX service.   As MIX services MUST NOT support end users, this information MAY be cached help the client distinguish MIX channels in the roster.
+      MIX channels in the roster have an attribute 'channel' set to true.   
     </p>
+    
+    <example caption="Roster Item Encoding of a MIX Channel"><![CDATA[
+  <item jid='romeo@example.net'/ channel='true' xmlns='urn:xmpp:mix:0'/>    
+]]></example>
+    
+    <p>
+      When sending roster information to a client that advertises MIX capability, the server MUST return all MIX channels and MUST use this encoding.   Where a client does not advertize MIX capability, the server MUST NOT return MIX channels as roster items.
+    </p>
+    
   </section2>
 
   <section2 topic="MAM Archive Support" anchor="proxy-mam">

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -37,6 +37,14 @@
   &skille;
   &stpeter;
   <revision>
+    <version>0.8</version>
+    <date>2017-02-XX</date>
+    <initials>sek</initials>
+    <remark><p>
+      Update after Brussels Summit;
+      
+    </p></remark>
+  <revision>
     <version>0.7.1</version>
     <date>2017-01-30</date>
     <initials>sek</initials>
@@ -466,7 +474,8 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
             <value>Witches Coven</value>
         </field>
         <field var='Description'>
-           <value>A location not far from the blasted heath where the three witches meet</value>
+           <value>A location not far from the blasted heath where 
+                  the three witches meet</value>
          </field>
         <field var='Contact'>
            <value>greymalkin@shakespeare.lit</value>
@@ -746,7 +755,8 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
             <value>Witches Coven</value>
         </field>
         <field var='Description'>
-           <value>A location not far from the blasted heath where the three witches meet</value>
+           <value>A location not far from the blasted heath where 
+           the three witches meet</value>
          </field>
         <field var='Contact'>
            <value>greymalkin@shakespeare.lit</value>
@@ -996,12 +1006,16 @@ the participant is not be subscribed to all nodes associated with the channel (i
         <field var='FORM_TYPE' type='hidden'>
              <value>urn:xmpp:mix:0</value>
         </field>
-        <field type='list-single' label='Preference for JID Visibility' var='JID Visibility'>
+        <field type='list-single' label='Preference for JID Visibility' 
+                   var='JID Visibility'>
             <option label='JID Never Shown'><value>Never</value></option>
-            <option label='Default Behaviour'><value>Default</value></option>
-            <option label='Try not to show JID'><value>Prefer Not</value></option>
+            <option label='Default Behaviour'>
+                    <value>Default</value></option>
+            <option label='Try not to show JID'>
+                     <value>Prefer Not</value></option>
          </field>
-         <field type='list-single' label='Example Custom Preference' var='Custom Preference'>
+         <field type='list-single' label='Example Custom Preference' 
+                 var='Custom Preference'>
             <option label='One Option'><value>A</value></option>
             <option label='Another Option'><value>B</value></option>
          </field>
@@ -1074,7 +1088,8 @@ the participant is not be subscribed to all nodes associated with the channel (i
         Deletion from the participants and presence functions as if the item (channel participant) had been deleted using the PubSub retract mechanism with notification set to true.    Notification of the deletion is sent to clients subscribed to the participants  PubSub nodes, as shown in the example below.
         </p>
       <example caption="Reporting when User Leaves a Channel"><![CDATA[
-<message from='coven@mix.shakespeare.example' to='hecate@shakespeare.example' id='foo'>
+<message from='coven@mix.shakespeare.example' 
+                to='hecate@shakespeare.example' id='foo'>
   <event xmlns='http://jabber.org/protocol/pubsub#event'>
     <items node='urn:xmpp:mix:nodes:participants'>
       <retract id='coven+123456@mix.shakespeare.example'/>
@@ -1082,7 +1097,8 @@ the participant is not be subscribed to all nodes associated with the channel (i
   </event>
 </message>
 
-<message from='coven@mix.shakespeare.example' to='hecate@shakespeare.example' id='bar'>
+<message from='coven@mix.shakespeare.example' 
+                to='hecate@shakespeare.example' id='bar'>
   <event xmlns='http://jabber.org/protocol/pubsub#event'>
     <items node='urn:xmpp:mix:nodes:presence'>
       <retract id='coven+123456@mix.shakespeare.example/8765'/>
@@ -1219,7 +1235,8 @@ the participant is not be subscribed to all nodes associated with the channel (i
       <p>
         A user setting status is now used as an example.   Unlike in &xep0045; where coming online is a special action, coming online in MIX is implicit when presence status is set.  Going offline is a achieved by setting presence status to unavailable, which removes the client full JID entry from the presence node.  When a user sets a presence status, the user's server sends updated presence to the MIX channel, and the MIX service then publishes the user's  availability to the "urn:xmpp:mix:nodes:presence" node. If there is not an item named by the full JID of the client with updated presence status, this item is created.   If there is not an item named by the full JID of the client with updated presence status, then an item is created.</p>
       <example caption="User Setting Presence Status">
-<![CDATA[<presence xmlns='jabber:client' from=‘hag66@shakespeare.example/pda’ to='coven@mix.shakespeare.example'>
+<![CDATA[<presence xmlns='jabber:client' from=‘hag66@shakespeare.example/pda’ 
+              to='coven@mix.shakespeare.example'>
   <show>dnd</show>
   <status>Making a Brew</status>
 </presence>]]></example>
@@ -1372,8 +1389,10 @@ the participant is not be subscribed to all nodes associated with the channel (i
   <result xmlns='urn:xmpp:mam:1' queryid='f27' id='28482-98726-73623'>
     <forwarded xmlns='urn:xmpp:forward:0'>
       <delay xmlns='urn:xmpp:delay' stamp='2010-07-10T23:08:25Z'/>
-      <message xmlns='jabber:client' from="hag66@shakespeare.example" to="macbeth@shakespeare.lit">
-        <retracted xmlns='urn:xmpp:mix:0' by='hag66@shakespeare.example' time='2010-07-10T23:08:25Z'/>
+      <message xmlns='jabber:client' from="hag66@shakespeare.example" 
+                 to="macbeth@shakespeare.lit">
+        <retracted xmlns='urn:xmpp:mix:0' by='hag66@shakespeare.example' 
+                 time='2010-07-10T23:08:25Z'/>
       </message>
     </forwarded>
   </result>
@@ -1871,7 +1890,8 @@ the participant is not be subscribed to all nodes associated with the channel (i
             <value>Witches Coven</value>
         </field>
         <field var='Description'>
-           <value>A location not far from the blasted heath where the three witches meet</value>
+           <value>A location not far from the blasted heath where 
+                        the three witches meet</value>
          </field>
          <field var='Contact'>
            <value>greymalkin@shakespeare.lit</value>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -49,6 +49,7 @@
       MIX as Core Spec (summit 1);
       Clarifications of password control, voice and name/description (summit 4/5/6)
       Removal of Subject and reference future Sticky Messages XEP (summit 7);
+      Use example JIDs aligned to anticipated BIND2 specification;
     </p></remark>
   </revision>
   <revision>
@@ -355,8 +356,11 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <p>
       The primary representation of a participant in a MIX channel is a proxy JID, which is an anonymized JID using the same domain as the channel and with the name of the channel encoded, using the format "&lt;channel&gt;+&lt;generated identifier&gt;@&lt;mix domain&gt;".  They generated identifier MUST NOT contain the '+' characters.  The Channel name MAY contain the '+' character.   For example in the channel 'coven@mix.shakespeare.example',   the user 'hag66@shakespeare.example' might have a proxy JID of 'coven+123456@mix.shakespeare.example'.   The reason for the proxy JID is to support JID Hidden channels.   Proxy JIDs are also used in JID Visible channels, for consistency and to enable switching of JID visibility.  The "urn:xmpp:mix:nodes:jidmap" node maps from proxy JID to real JID.  While a user is a participant in a Channel, the mapping between real JID and proxy JID MUST NOT be changed.
     </p>
+    <p>
+      The example real full JIDs in this specification follow the anticipated new format that splits the resource into two parts.  The first part is UUID that is a stable and fixed value for the client.  The second part is server assigned and will vary with each session.   For example:  'hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'.   CITATION TO BE ADDED.  If the final specification differs from this, the examples will be updated.
+    </p>
      <p>
-       The full JIDs held in the  presence nodes are anonymized using a similar mechanism.  First the bare JID is mapped to a bare proxy JID, using the mapping held in the "urn:xmpp:mix:nodes:jidmap" node for the bare JID.  Then the resource is replaced with a generated value.   For example,   'hag66@shakespeare.example' in the channel coven might have a proxy JID of 'coven+123456@mix.shakespeare.example/789'.   There is no client visible mapping of proxy full JIDs maintained as this is not needed.   The MIX channel will need to maintain a mapping, to support directly addressing clients, such as for client to client disco#info queries.  While an anonymized JID is held in the presence node, the mapping to real JID MUST NOT be changed.  When an anonoymized full JID is added to the presence node, mapping to a real full JID that was previously in the presence node, the same anonymized JID as the previous time MAY be used or a different anonymized JID MAY be used.
+       The full JIDs held in the  presence nodes are anonymized using a similar mechanism.  First the bare JID is mapped to a bare proxy JID, using the mapping held in the "urn:xmpp:mix:nodes:jidmap" node for the bare JID.  Then the resource is replaced with a generated value.   For example,   'hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0' in the channel coven might have a proxy JID of 'coven+123456@mix.shakespeare.example/789'.   There is no client visible mapping of proxy full JIDs maintained as this is not needed.   The MIX channel will need to maintain a mapping, to support directly addressing clients, such as for client to client disco#info queries.  While an anonymized JID is held in the presence node, the mapping to real JID MUST NOT be changed.  When an anonoymized full JID is added to the presence node, mapping to a real full JID that was previously in the presence node, the same anonymized JID as the previous time MAY be used or a different anonymized JID MAY be used.
      </p>
   </section2>
   <section2 topic="Standard Nodes" anchor="concepts-nodes">
@@ -522,7 +526,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </section3>
     <section3 topic="Configuration Node" anchor="config-node">
       <p>
-        The Configuration node holds the configuration of the channel as a single item, named by the date-time of the last update to the configuration.  The Configuraton Node is a transient PubSub node with no history.   It is RECOMMENDED to store Configuraton Node history in MAM. Previous configuration history MUST be accessed by MAM.  Users with read access to the configuration node MAY subscribe to the configuration node to get notification of configuration change.  This node is accessed and managed using standard pubsub. The configuration node is OPTIONAL for a MIX channel.  For example, configuration choices could be fixed and not exposed.   A subset of the defined configuration options MAY be used and additional non-standard configuration options MAY be added.   JIDs in the configuration MUST be real bare JIDs and not proxy JIDs.  If configuration options to control functionality of the nature described here are provided, the options defined in this standard MUST be used. The following configuration attributes are defined:
+        The Configuration node holds the configuration of the channel as a single item, named by the date-time of the last update to the configuration.  The Configuration Node is a transient PubSub node with no history.   It is RECOMMENDED to store Configuration Node history in MAM. Previous configuration history MUST be accessed by MAM.  Users with read access to the configuration node MAY subscribe to the configuration node to get notification of configuration change.  This node is accessed and managed using standard pubsub. The configuration node is OPTIONAL for a MIX channel.  For example, configuration choices could be fixed and not exposed.   A subset of the defined configuration options MAY be used and additional non-standard configuration options MAY be added.   JIDs in the configuration MUST be real bare JIDs and not proxy JIDs.  If configuration options to control functionality of the nature described here are provided, the options defined in this standard MUST be used. The following configuration attributes are defined:
 </p>
       <table caption="Configuration Node Attributes">
         <tr><th>Name</th><th>Description</th><th>Field Type</th><th>Values</th><th>Default</th></tr>
@@ -593,7 +597,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       An entity MAY discover a MIX service or MIX services by sending a Service Discovery items ("disco#items") request to its own server.  This MUST come directly from a MIX client.
     </p>
     <example caption="Entity queries Server for associated services" ><![CDATA[
-<iq from='hag66@shakespeare.example/intibo24'
+<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     id='lx09df27'
     to='shakespeare.example'
     type='get'>
@@ -602,7 +606,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq from='shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/intibo24'
+    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#items'>
     <item jid='mix.shakespeare.example'
@@ -614,7 +618,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
     <p>To determine if a domain hosts a MIX service, a &xep0030; info query SHOULD be sent in the usual manner to determine capabilities.</p>
       <example caption="Entity queries a service" ><![CDATA[
-<iq from='hag66@shakespeare.example/intibo24'
+<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='get'>
@@ -625,7 +629,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <example caption="Service responds with Disco Info result" ><![CDATA[
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/intibo24'
+    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     <identity
@@ -650,7 +654,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <section2 topic='Discovering the Channels on a Service' anchor='disco-channel-list'>
     <p>The list of channels supported by a MIX service is obtained by a disco#items command.   The MIX service MUST only return channel that exist and that the user making the query has rights to subscribe to.  This query MUST be made directly by a client.</p>
     <example caption='User&apos;s Server Queries for Channels on MIX Service'><![CDATA[
-<iq from='hag66@shakespeare.lit'
+<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     id='kl2fax27'
     to='mix.shakespeare.lit'
     type='get'>
@@ -660,7 +664,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <example caption='MIX Service Returns Disco Items Result'><![CDATA[
 <iq from='mix.shakespeare.lit'
     id='kl2fax27'
-    to='hag66@shakespeare.lit'
+    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#items'>
     <item jid='coven@mix.shakespeare.example' />
@@ -673,7 +677,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <section2 topic='Discovering Channel Information' anchor='disco-channel-info'>
     <p>In order to find out more information about a given channel, a user can send a disco#info query to the channel.  This query MUST be made directly by a client.</p>
     <example caption='Entity Queries for Information about a Specific Channel'><![CDATA[
-<iq from='hag66@shakespeare.lit'
+<iq from='hhag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     id='ik3vs715'
     to='coven@mix.shakespeare.lit'
     type='get'>
@@ -684,7 +688,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <example caption='Channel Returns Disco Info Result'><![CDATA[
 <iq from='coven@mix.shakespeare.lit'
     id='ik3vs715'
-    to='hag66@shakespeare.lit'
+    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info' node='mix'>
     <identity
@@ -700,7 +704,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <section2 topic='Discovering Nodes at a Channel' anchor='disco-channel-nodes'>
     <p>Use disco#items to find the nodes associated with a channel.   The MIX service MUST only return nodes that exist and that the user making the query has rights to subscribe to. This query MUST be made directly by a client.</p>
     <example caption='Entity Queries for Nodes at a Channel'><![CDATA[
-<iq from='hag66@shakespeare.lit'
+<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     id='kl2fax27'
     to='coven@mix.shakespeare.lit'
     type='get'>
@@ -710,7 +714,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <example caption='Channel Returns Disco Items Result'><![CDATA[
 <iq from='coven@mix.shakespeare.lit'
     id='kl2fax27'
-    to='hag66@shakespeare.lit'
+    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#items' node='mix'>
     <item jid='coven@mix.shakespeare.example'
@@ -728,7 +732,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <section2 topic="Determining Information about a Channel" anchor="find-channel-info">
     <p>The Information Node contains various information about the channel that can be useful to the user.   This query MUST be made directly by a client.</p>
     <example caption='User&apos;s Server Requests Channel Information'><![CDATA[
-<iq from='hag66@shakespeare.lit'
+<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     id='kl2fax27'
     to='coven@mix.shakespeare.lit'
     type='get'>
@@ -738,7 +742,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <example caption='MIX Service Returns Channel Information'><![CDATA[
 <iq from='coven@mix.shakespeare.lit'
     id='kl2fax27'
-    to='hag66@shakespeare.lit'
+    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     type='result'>
   <query xmlns='urn:xmpp:mix:0#channel-info' node='mix'>
       <x xmlns='jabber:x:data' type='result'>
@@ -764,7 +768,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <p>
       Online clients in the channel are determined from the presence node.   Participants in the channel are determined from the Participants Node which will give proxy JID and nick. The jidmap node is used to map to real JIDs.  An operation is provided to list channel participants.   For JID Hidden channels, only the nicks are returned.  For JID Visible channels, nicks and real JIDs are returned. This query MUST be made directly by a client.</p>
     <example caption='User&apos;s Server Requests Participant List'><![CDATA[
-<iq from='hag66@shakespeare.lit'
+<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     id='kl2fax27'
     to='coven@mix.shakespeare.lit'
     type='get'>
@@ -774,7 +778,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <example caption='MIX Service Returns Participant List for JID Visible Room'><![CDATA[
 <iq from='coven@mix.shakespeare.lit'
     id='kl2fax27'
-    to='hag66@shakespeare.lit'
+    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     type='result'>
   <query xmlns='urn:xmpp:mix:0#get-participants' node='mix'>
   <items>
@@ -789,9 +793,9 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       Where a client supports MIX, it MUST advertise this capability in response to a Disco request.    This will enable other entities to determine if a client supports MIX, and in particular it facilitates the client's server to determine client support.  This can be optimized by use of CAPS.    The following example shows a Disco response from a client that supports both MIX and MUC.
     </p>
     <example caption='Disco Response showing MIX support'><![CDATA[
-<iq from='romeo@montague.lit/orchard'
+<iq from='romeo@montague.lit/14e8cb74-9082-4782-9275-8918ee5d8fcd/6983052d-3fdc-4e32-8221-79571a5210fe'
     id='disco1'
-    to='juliet@capulet.lit/chamber'
+    to='juliet@capulet.lit/46be1261-200b-4eea-8f82-e4fae46eec56/d6a85bb6-669f-471b-b55b-9a3930f5512e'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'
          node='http://code.google.com/p/exodus#QgayPKawpkPSDYmwT/WM94uAlu0='>
@@ -823,7 +827,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       
         <example caption="Client sends request to Local Server to Join a Channel"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example/pda'
+    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     to='hag66@shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <join xmlns='urn:xmpp:mix:0' 
@@ -875,7 +879,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <example caption="User's Server sends response to Client"><![CDATA[
 <iq type='result'
     from='coven@mix.shakespeare.example'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <join xmlns='urn:xmpp:mix:0' jid='coven+123456@mix.shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
@@ -920,7 +924,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
       </p>
       <example caption="User Modifies Subscription Request"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example/pda'
+    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <update-subscription xmlns='urn:xmpp:mix:0'>
@@ -930,7 +934,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq type='result'
      from='coven@mix.shakespeare.example'
-     to='hag66@shakespeare.example/pda'
+     to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <update-subscription xmlns='urn:xmpp:mix:0' jid='hag66@shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
@@ -1026,7 +1030,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
      <p>The client MAY also query the channel in order to find out which user preferences are supported and the options available.  This will allow users to set options not specified in the standard, by providing a form template in the result.   This query is direct from the client to the MIX channel.</p>
      <example caption="User Requests and Recieves Preferences Template Form"><![CDATA[
 <iq type='get'
-    from='hag66@shakespeare.example/pda'
+    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
     <user-preference xmlns='urn:xmpp:mix:0'/>
@@ -1034,7 +1038,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq type='result'
     from='coven@mix.shakespeare.example'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
     <user-preference xmlns='urn:xmpp:mix:0'>
     <x xmlns='jabber:x:data' type='form'>
@@ -1063,7 +1067,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
      </p>
      <example caption="User Updates Preferences"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example/pda'
+    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
     <user-preference xmlns='urn:xmpp:mix:0'/>
@@ -1085,7 +1089,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq type='result'
     from='coven@mix.shakespeare.example'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
     <user-preference xmlns='urn:xmpp:mix:0'>
     <x xmlns='jabber:x:data' type='result'>
@@ -1113,7 +1117,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
       
       <example caption="Client Requests to Leave a Channel"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example/pda'
+    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     to='hag66@shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <leave xmlns='urn:xmpp:mix:0'
@@ -1154,7 +1158,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
       <example caption="User's Server Confirms Leave to Client"><![CDATA[
 <iq type='result'  
     from='coven@mix.shakespeare.example'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <leave xmlns='urn:xmpp:mix:0'/>
 </iq>
@@ -1202,7 +1206,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     </p>
     <example caption="User sets Nick on Channel"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example/pda'
+    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     to='coven@mix.shakespeare.example'
     id='7nve413p'>
   <query xmlns='urn:xmpp:mix:0'>
@@ -1218,7 +1222,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     <example caption="Channel informs user of Nick"><![CDATA[
 <iq type='result'
     from='coven@mix.shakespeare.example'
-    to'hag66@shakespeare.example/pda'
+    to'hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='7nve413p'>
   <query xmlns='urn:xmpp:mix:0'>
     <nick>thirdwitch</nick>
@@ -1235,14 +1239,14 @@ the participant is not be subscribed to all nodes associated with the channel (i
       </p>
       <example caption="User Determines features of the MIX service"><![CDATA[
 <iq type='get'
-    from='hag66@shakespeare.example/pda'
+    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     to='mix.shakespeare.example'
     id='7nve413p'>
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>
 
 <iq type='result'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     from='mix.shakespeare.example'
     id='7nve413p'>
     <query xmlns='http://jabber.org/protocol/disco#info'/>
@@ -1258,7 +1262,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
  a &lt;register/&gt; command to the service. </p>
       <example caption="User Registers with Service"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example/pda'
+    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     to='mix.shakespeare.example'
     id='7nve413p'>
   <register xmlns='urn:xmpp:mix:0'>
@@ -1270,7 +1274,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
       <example caption="Service Returns User of Nick"><![CDATA[
 <iq type='result'
     to='mix.shakespeare.example'
-    from='hag66@shakespeare.example/pda'
+    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='7nve413p'>
   <register xmlns='urn:xmpp:mix:0'>
     <nick>thirdwitch</nick>
@@ -1281,7 +1285,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
       <example caption="Nick is Taken">
 <![CDATA[<iq type='error'
     to='mix.shakespeare.example'
-    from='hag66@shakespeare.example/pda'
+    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='7nve413p'>
   <error type='cancel'>
     <conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
@@ -1312,7 +1316,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
       <p>
         A user setting status is now used as an example.   Unlike in &xep0045; where coming online is a special action, coming online in MIX is implicit when presence status is set.  Going offline is a achieved by setting presence status to unavailable, which removes the client full JID entry from the presence node.  When a user sets a presence status, the user's server sends updated presence to the MIX channel, and the MIX service then publishes the user's  availability to the "urn:xmpp:mix:nodes:presence" node. If there is not an item named by the full JID of the client with updated presence status, this item is created.   If there is not an item named by the full JID of the client with updated presence status, then an item is created.</p>
       <example caption="User Setting Presence Status">
-<![CDATA[<presence xmlns='jabber:client' from=‘hag66@shakespeare.example/pda’ 
+<![CDATA[<presence xmlns='jabber:client' from=‘hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0’ 
               to='coven@mix.shakespeare.example'>
   <show>dnd</show>
   <status>Making a Brew</status>
@@ -1378,7 +1382,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
       <p>When a client goes offline, this presence update is sent by the client's server to the MIX channel.   From the client perspective, this is the same as any other presence change.   Handling by the MIX channel is slightly different.</p>
       <example caption="Client Goes Offline in the Channel"><![CDATA[
 <presence type='unavailable'
-          from='hag66@shakespeare.example/pda'
+          from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
           to='coven@mix.shakespeare.example'/>
 ]]></example>
       <p>The MIX channel will retract (remove) the item in the presence node of the MIX channel identified by the client's full JID.  The MIX channel will notify subscribers to the presence node of the user going offline by sending a presence stanza to the full proxy JID of each client.</p>
@@ -1401,7 +1405,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     <section3 topic='Sending a Message' anchor='usecase-user-message'>
       <p>A client sends a message directly to a MIX channel as a standard groupchat message, in exactly the same way as for &xep0045;. Messages are sent directly to the MIX channel from the user's client. The message id is selected by the client.</p>
       <example caption="User Sends Message to Channel"><![CDATA[
-<message from='hag66@shakespeare.example/pda'
+<message from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
          to='coven@mix.shakespeare.example'
          id='92vax143g'
          type='groupchat'>
@@ -1442,7 +1446,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         A MIX channel MAY support message retraction, where the sender of a messages or an authorized administrator deletes a message.   If this is done the original message MAY be replaced by a tombstone.  The protocol to request retraction does this by a message with a &lt;retract&gt; element as shown in the following example.
       </p>
       <example caption="User Retracts a Message"><![CDATA[
-<message from='hag66@shakespeare.example/pda'
+<message from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
          to='coven@mix.shakespeare.example'
          id='92vax143g'>
   <retract id='28482-98726-73623' xmlns='urn:xmpp:mix:0'/>
@@ -1462,7 +1466,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         With this approach, the original message &lt;body&gt; is removed and replaced with a tombstone using the &lt;retracted&gt; element that shows the JID of user performing the retraction and the time of the retraction.
       </p>
       <example caption="Retracted message tombstone in a MAM result"><![CDATA[
-<message id='aeb213' to='juliet@capulet.lit/chamber'>
+<message id='aeb213' to='juliet@capulet.lit/46be1261-200b-4eea-8f82-e4fae46eec56/d6a85bb6-669f-471b-b55b-9a3930f5512e'>
   <result xmlns='urn:xmpp:mam:1' queryid='f27' id='28482-98726-73623'>
     <forwarded xmlns='urn:xmpp:forward:0'>
       <delay xmlns='urn:xmpp:delay' stamp='2010-07-10T23:08:25Z'/>
@@ -1498,7 +1502,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         The first step is for the inviter to request an invitation from the channel.   The invitation contains inviter, invitee and a token.  The channel will evaluate if the inviter has rights to issue the invitation.   This will be because the inviter is a channel administrator or if the inviter is a channel participant and the channel has 'Participation Addition by Invitation from Participant' mode enable.  If the inviter has rights to make the invitation, the channel will return a token.  The token is a string that the channel can subsequently use to validate an invitation.   The format of the token is not specified in this standard.   The encoded token MAY reflect a validity time.
       </p>
       <example caption='Inviter Requests and Receives Invitation'><![CDATA[
-<iq from='hag66@shakespeare.lit/pda'
+<iq from='hag66@shakespeare.lit/d1781be2-2b2d-4cd8-8886-bdc0e1087873/2183ee64-9c97-4eeb-bdc0-c35138b9c2b1'
     id='kl2fax27'
     to='coven@mix.shakespeare.lit'
     type='get'>
@@ -1509,7 +1513,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='coven@mix.shakespeare.lit'
     id='kl2fax27'
-    to='hag66@shakespeare.lit/pda'
+    to='hag66@shakespeare.lit/d1781be2-2b2d-4cd8-8886-bdc0e1087873/2183ee64-9c97-4eeb-bdc0-c35138b9c2b1'
     type='result'>
   <query xmlns='urn:xmpp:mix:0#request-invitation'>
         <invitation>
@@ -1524,7 +1528,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         The inviter can now send the invitee a message containing the invitation, as shown in the following example.
       </p>
       <example caption='Inviter sends Invitation to Invitee'><![CDATA[
-<message from='hag66@shakespeare.lit/pda'
+<message from='hag66@shakespeare.lit/d1781be2-2b2d-4cd8-8886-bdc0e1087873/2183ee64-9c97-4eeb-bdc0-c35138b9c2b1'
     id='foo'
     to='cat@shakespeare.lit'>
     <body>Would you like to join the coven?<body>
@@ -1560,9 +1564,9 @@ the participant is not be subscribed to all nodes associated with the channel (i
         <li>'Acknowledged': The invitation is acknowledged, without information on action taken or planned.</li>
       </ul>
       <example caption='Invitee sends Acknowledgement to Inviter'><![CDATA[
-<message from='cat@shakespeare.lit/miaow'
+<message from='cat@shakespeare.lit/066923ad-9f06-474d-8cc9-085d14af0554/4974bd01-d991-4bf8-ac4e-18b10160ba46'
     id='bar'
-    to='hag66@shakespeare.lit/pda'>
+    to='hag66@shakespeare.lit/d1781be2-2b2d-4cd8-8886-bdc0e1087873/2183ee64-9c97-4eeb-bdc0-c35138b9c2b1'>
     <body>No Thanks - too busy chasing mice....<body>
     <invitation-ack xmlns='urn:xmpp:mix:0'>
         <value>Declined</value>
@@ -1601,7 +1605,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     <section3 topic="Requesting vCard" anchor="usecase-vcard">
       <p>A user MAY request the vCard of a channel participant by sending a request through the channel.  The request MAY be sent directly by the client or MAY be sent by the user's server on behalf of the user.  The MIX channel MAY pass this request on or MAY block it.  vCard requests MAY use &xep0054; (vcard-temp) or &xep0292; (vCard4 over XMPP).  Where a MIX service supports one or both of these protocols, the protocol MUST be advertized as a feature of the MIX service.   In the following example, using vcard-temp, the requesting client sends a message to the anonymized bare JID of the channel participant for which the vCard is desired.</p>
       <example caption="Client directly requests vCard through channel" ><![CDATA[
-<iq from='hag66@shakespeare.example/intibo24'
+<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     id='lx09df27'
     to='coven+989898@mix.shakespeare.example'
     type='get'>
@@ -1644,7 +1648,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
       <example caption="MIX Channel sends vCard responst to Client" ><![CDATA[
 <iq from='coven+989898@mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/intibo24'
+    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     type='result'>
  <vCard xmlns='vcard-temp'>
     <FN>Peter Saint-Andre</FN>
@@ -1725,7 +1729,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         MIX does not standardize an access control model for creating and deleting MIX channels.    The choice is left to the MIX implementer, and could be a very simple or complex approach.  A client can determine if it has permission to create a channel on a MIX service, which MAY be used to control options presented to the user.   This is achieved by a disco command on the MIX service.   If the 'create-channel' feature is returned, the user is able to create a channel.
       </p>
         <example caption="Client determines Capability to Create a Channel" ><![CDATA[
- <iq from='hag66@shakespeare.example/intibo24'
+ <iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='get'>
@@ -1734,7 +1738,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/intibo24'
+    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     <identity
@@ -1752,7 +1756,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         A client creates a channel by sending a simple request to the MIX service.   A channel MAY be created with default parameters, as shown in the following example.   The result MUST include the name of the channel which MUST match the channel name in the request (if present).  Creating and destroying a channel is done direct from a client.
       </p>
         <example caption="Creating a Channel with Default Parameters" ><![CDATA[
-<iq from='hag66@shakespeare.example/pda'
+<iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -1761,7 +1765,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     type='result'>
   <create channel='coven' xmlns='urn:xmpp:mix:0'/>
 </iq>
@@ -1770,7 +1774,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         The client MAY also include parameters in &xep0004; format as part of channel creation.    If the client wishes to inspect configuration, channel administration procedures SHOULD be used.
       </p>
       <example caption="Creating a Channel with Client Specified Parameters" ><![CDATA[
-<iq from='hag66@shakespeare.example/pda'
+<iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -1800,7 +1804,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     type='result'>
   <create channel='coven' xmlns='urn:xmpp:mix:0'/>
 </iq>
@@ -1814,7 +1818,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         Rooms MAY be created for ad hoc use between a set of users.  Channels of this nature will have channel name created by the server and will not be addressable or discoverable.  Here a channel is created without specifying the channel name.   Parameters for the channel MAY also be specified.
       </p>
       <example caption="Creating a Channel for Ad Hoc Use" ><![CDATA[
-<iq from='hag66@shakespeare.example/pda'
+<iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -1823,7 +1827,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     type='result'>
   <create channel='A1B2C345' xmlns='urn:xmpp:mix:0'/>
 </iq>
@@ -1838,7 +1842,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
        This will generally be done by the user creating the channel before the other user is invited, but MAY be sent by either the user creating the channel or the 1:1 chat partner at any time subsequently.
      </p>
      <example caption="Forwarding a message to create History" ><![CDATA[
-<message from='hag66@shakespeare.example/pda'
+<message from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
          to='A1B2C345@mix.shakespeare.example'
          id='92vax143g'
          type='groupchat'>
@@ -1846,7 +1850,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
           <delay xmlns='urn:xmpp:delay' stamp='2010-07-10T23:08:25Z'/>
           <message from='hag67@shakespeare.example/pda'
                    id='0202197'
-                   to='hag66@shakespeare.example/pda'
+                   to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
                    type='chat'
                    xmlns='jabber:client'>
               <body>Harpier cries: 'tis time, 'tis time.</body>
@@ -1864,7 +1868,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         A client destroys a channel using a simple set operation, as shown in the following example.
       </p>
       <example caption="Client Destroys a Channel" ><![CDATA[
- <iq from='hag66@shakespeare.example/pda'
+ <iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -1873,7 +1877,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     type='result'>
 </iq>
 ]]></example>
@@ -1887,7 +1891,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     <section3 topic='Modifying Channel Information' anchor='usecase-admin-information'>
       <p>Authorized users, typically owners and sometimes administrators, MAY modify the channel information.   The client MAY issue a pubsub get command to obtain a form that will facilitate update of the information node.   The values in the form show current values, which be defaults or MAY have been explicitly set.  In the following example, the channel name was previously set, but other values were not. </p>
       <example caption="Getting Information Form" ><![CDATA[
- <iq from='hag66@shakespeare.example/pda'
+ <iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='get'>
@@ -1898,7 +1902,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/'>
      <items node='urn:xmpp:mix:nodes:info'>
@@ -1925,7 +1929,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 ]]></example>
       <p>  Updating the information node is done using a pubsub set command.  The MIX channel MUST update the fields with values provided, leaving other fields unchanged.  The result returns the id used in the information node item, which is the date/time of the modification. </p>
       <example caption="Modifying Channel Information" ><![CDATA[
- <iq from='hag66@shakespeare.example/pda'
+ <iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -1952,7 +1956,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'>
       <publish node='urn:xmpp:mix:nodes:info'>
@@ -1966,7 +1970,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
       <p>Channel owners are allowed to modify the channel configuration.    The client MAY issue a pubsub get command to obtain a form that will facilitate update of the configuration node.  Other clients MAY be authorized to use this command to see the channel configuration, but only owners MAY update the configuration.   The values in the form show current values, which MAY be defaults or MAY have been explicitly set.  The following example shows a short form returned to illustrate the syntax.   A typical configuration form will be much larger with many fields.  Modifying channel configuration is done directly by a client.
       </p>
       <example caption="Getting Configuration Form" ><![CDATA[
- <iq from='hag66@shakespeare.example/pda'
+ <iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='get'>
@@ -1977,7 +1981,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     type='result'>
      <pubsub xmlns='http://jabber.org/protocol/pubsub'>
       <items xmlns='urn:xmpp:mix:0'  node='urn:xmpp:mix:nodes:config'>
@@ -1996,7 +2000,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 ]]></example>
       <p>  Updating the information node is done using a pubsub set command.  The MIX channel MUST update the fields with values provided, leaving other fields unchanged.  The result returns the id used in the configuration node item, which is the date/time of the modification. </p>
       <example caption="Modifying Channel Configuration" ><![CDATA[
- <iq from='hag66@shakespeare.example/pda'
+ <iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -2028,7 +2032,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'>
       <publish node='urn:xmpp:mix:nodes:config'>
@@ -2044,7 +2048,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
        Allowed and Banned lists MAY be read by PubSub get of the Banned and Allowed Nodes.  This operation MAY be used by users as controlled by 'Allowed Node Subscription' and 'Banned Node Subscription' configuration node options (default Administrators).  
       </p>
       <example caption="Client Reads Allowed Node" ><![CDATA[
-<iq from='hag66@shakespeare.example/pda'
+<iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='get'>
@@ -2055,7 +2059,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'>
          <items node='urn:xmpp:mix:nodes:allowed'>
@@ -2069,7 +2073,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         JIDs can be added to the  Allowed and Banned nodes  by a pubsub set command.  This is used to add one item to a node.
       </p>
  <example caption="Client Adds a JID to the Allowed Node" ><![CDATA[
-<iq from='hag66@shakespeare.example/pda'
+<iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -2082,7 +2086,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'/>
 </iq>
@@ -2091,7 +2095,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         JIDs can be removed from the Allowed and Banned nodes by pubsub retract command.
       </p>
     <example caption="Client Removes a JID to the Banned Node" ><![CDATA[
-<iq from='hag66@shakespeare.example/pda'
+<iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -2104,7 +2108,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'/>
 </iq>
@@ -2156,7 +2160,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
     <example caption="Participant's Server Sends Modified Message to two Clients"><![CDATA[
 <message from='coven@mix.shakespeare.example'
-         to='hecate@shakespeare.example/pda3'
+         to='hecate@shakespeare.example/473c6613-fc5b-40f1-9984-a27887d406c9/7afcdb49-b08a-4617-a372-f3b4cff75c6a'
          id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
          type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
@@ -2199,7 +2203,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     
   <example caption="Client sends request to local server to Join a MIX Channel"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example/pda'
+    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
     to='hag66@shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <join xmlns='urn:xmpp:mix:0' 
@@ -2286,7 +2290,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
   <example caption="Service responds with Disco Info result showing MIX and MUC support" ><![CDATA[
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/intibo24'
+    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     <identity
@@ -2309,7 +2313,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     <example caption="MIX Service responds with Disco Info result sharing MUC service location" ><![CDATA[
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/intibo24'
+    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     <identity
@@ -2335,7 +2339,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
   <example caption="MUC Service responds with Disco Info result sharing MIX service location" ><![CDATA[
 <iq from='chat.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/intibo24'
+    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     <identity

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -42,8 +42,11 @@
     <initials>sek</initials>
     <remark><p>
       Update after Brussels Summit;
-      
+      Remove Explicit Client Activation;
+      Limit Indirect to Join/Leave;
+      Clarify Server use of Disco of Client;
     </p></remark>
+  </revision>
   <revision>
     <version>0.7.1</version>
     <date>2017-01-30</date>
@@ -283,15 +286,16 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
        There are a number of MIX requirements on behaviour of the MIX Participant's server, which are summarized here:
      </p>
     <ol>
-      <li>Each MIX client will activate MIX capability with the local server when it comes online.  A key benefit of this approach is that MIX messages will only be sent to clients that support MIX.   This enables a user to use of clients that do not use MIX in conjunction with clients that use MIX.</li>
-      <li>MIX Service and Channel subscription and management is handled through the participant's server so that the participant's server can track all subscription changes and share subscription information between MIX clients.   To achieve this, a MIX client of a MIX channel participant sends these MIX management queries to the participant's server and received responses back from the participant’s server.   The MIX participant’s server will communicate these requests to a MIX channel with messages from the user's bare JID.   Because the participant's server is aware of subscription information, it can provide integrated support to a set of MIX clients.</li>
+
+   
       <li>Messages from a MIX client to a MIX channel will go direct to the MIX service.  They are relayed, but not modified, by the participant's server.</li>
       <li>Messages from a MIX channel to a MIX client are always sent to the MIX participants server (addressed by bare JID) and MUST be handled by the MIX participant's server.</li>
       <li>All messages received by the MIX participant's server MUST be stored using MAM.</li>
       <li>The MIX participant's server will only send messages to online clients and will discard messages if no clients are online.
         This means that a MIX client needs to resynchronize with the MIX service when it comes online.  This message synchronization will happen between the MIX client and the MAM archive held on the MIX participant's server.</li>
-      <li>The MIX participant's server  handles channel registration and de-registration in the user's roster.</li>
-      <li>Enabling different clients to access different sets of channels (e.g., a mobile client only accesses a subset of the channels in which a user is interested).   MIX Client Activation allows the participant's server to support this.</li>
+      
+      <li>The MIX client will generally send management and other messages directly to the MIX channel and the MUST be done except where specifically noted.  </li>
+      <li>The user's roster contains each MIX channel to which the user is subscribed and is sharing presence.   To achieve this the user's server needs to manage the roster on behalf of the user.  For this reason, MIX join and leave commands MUST be sent by a client to the user's server.   This enables the user's server to correctly manage the roster on behalf of the user.</li>
     </ol>
     <p>
    Messages being sent from MIX channel to a MIX participant’s server (which will be of type=groupchat)  and presence information are sent to the bare JID.  This means that the MIX participant's server  MUST support a modification of the standard &rfc6121; rules.
@@ -652,7 +656,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <p>A MIX service MUST NOT advertise support for &xep0313;, as MAM is supported by the channels and not by the service.   A  MIX service MUST NOT advertise support for generic &xep0060;, as although MIX makes use of PubSub it is not a generic PubSub service.</p>
   </section2>
   <section2 topic='Discovering the Channels on a Service' anchor='disco-channel-list'>
-    <p>The list of channels supported by a MIX service is obtained by a disco#items command.   The MIX service MUST only return channel that exist and that the user making the query has rights to subscribe to.  This query MUST be made indirectly by the user's server.</p>
+    <p>The list of channels supported by a MIX service is obtained by a disco#items command.   The MIX service MUST only return channel that exist and that the user making the query has rights to subscribe to.  This query MUST be made directly by a client.</p>
     <example caption='User&apos;s Server Queries for Channels on MIX Service'><![CDATA[
 <iq from='hag66@shakespeare.lit'
     id='kl2fax27'
@@ -675,7 +679,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
   </section2>
   <section2 topic='Discovering Channel Information' anchor='disco-channel-info'>
-    <p>In order to find out more information about a given channel, a user can send a disco#info query to the channel.  This query MUST be made indirectly by the user's server and not the end client.</p>
+    <p>In order to find out more information about a given channel, a user can send a disco#info query to the channel.  This query MUST be made directly by a client.</p>
     <example caption='Entity Queries for Information about a Specific Channel'><![CDATA[
 <iq from='hag66@shakespeare.lit'
     id='ik3vs715'
@@ -684,7 +688,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>
 ]]></example>
-    <p>Note that this query comes from the bare JID to the MIX channel, as it will always be sent to the MIX service by the user's server.  The channel MUST return its identity and the features it supports.  Note that a MIX channel MUST support MAM and so the response will always include both MIX and MAM support.  All disco queries on a MIX channel rad results returned MUST include node='mix'.   The reason for this is to facilitate MIX channels and &xep0045; MUC rooms sharing the same JID.   This extra parameter will enable a server to return appropriate information.</p>
+    <p> The channel MUST return its identity and the features it supports.  Note that a MIX channel MUST support MAM and so the response will always include both MIX and MAM support.  All disco queries on a MIX channel rad results returned MUST include node='mix'.   The reason for this is to facilitate MIX channels and &xep0045; MUC rooms sharing the same JID.   This extra parameter will enable a server to return appropriate information.</p>
     <example caption='Channel Returns Disco Info Result'><![CDATA[
 <iq from='coven@mix.shakespeare.lit'
     id='ik3vs715'
@@ -702,7 +706,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
   </section2>
   <section2 topic='Discovering Nodes at a Channel' anchor='disco-channel-nodes'>
-    <p>Use disco#items to find the nodes associated with a channel.   The MIX service MUST only return nodes that exist and that the user making the query has rights to subscribe to. This query MUST be made by the user's server and not the end client.</p>
+    <p>Use disco#items to find the nodes associated with a channel.   The MIX service MUST only return nodes that exist and that the user making the query has rights to subscribe to. This query MUST be made directly by a client.</p>
     <example caption='Entity Queries for Nodes at a Channel'><![CDATA[
 <iq from='hag66@shakespeare.lit'
     id='kl2fax27'
@@ -732,7 +736,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
   </section2>
   <section2 topic="Determining Information about a Channel" anchor="find-channel-info">
-    <p>The Information Node contains various information about the channel that can be useful to the user.   This query MUST be made indirectly by the user's server using the user's bare JID.</p>
+    <p>The Information Node contains various information about the channel that can be useful to the user.   This query MUST be made directly by a client.</p>
     <example caption='User&apos;s Server Requests Channel Information'><![CDATA[
 <iq from='hag66@shakespeare.lit'
     id='kl2fax27'
@@ -768,7 +772,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </section2>
   <section2 topic='Determining the Participants in a Channel' anchor='find-channel-participants'>
     <p>
-      Online clients in the channel are determined from the presence node.   Participants in the channel are determined from the Participants Node which will give proxy JID and nick. The jidmap node is used to map to real JIDs.  An operation is provided to list channel participants.   For JID Hidden channels, only the nicks are returned.  For JID Visible channels, nicks and real JIDs are returned. This query MUST be made indirectly by the user's server using the user's bare JID.</p>
+      Online clients in the channel are determined from the presence node.   Participants in the channel are determined from the Participants Node which will give proxy JID and nick. The jidmap node is used to map to real JIDs.  An operation is provided to list channel participants.   For JID Hidden channels, only the nicks are returned.  For JID Visible channels, nicks and real JIDs are returned. This query MUST be made directly by a client.</p>
     <example caption='User&apos;s Server Requests Participant List'><![CDATA[
 <iq from='hag66@shakespeare.lit'
     id='kl2fax27'
@@ -821,7 +825,32 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
       </p>
       <p>The default MIX model is that only channel participants are allowed to subscribe to nodes.    A MIX channel MAY allow non-participant subscription.   This will be handled by clients directly subscribing to the desired PubSub nodes.</p>
-        <example caption="User Joins a Channel"><![CDATA[
+      
+      <p>
+        The user's server needs to make roster changes as part of the join functionality.   Because of this, the join and leave operations need to operate indirectly.
+        For this reason the initial join request is sent to the local server with the MIX channel specified as an attribute to the join.
+      </p>
+      
+        <example caption="Client sends request to Local Server to Join a Channel"><![CDATA[
+<iq type='set'
+    from='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example'
+    id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
+  <join xmlns='urn:xmpp:mix:0' 
+         channel='coven@mix.shakespeare.example'>
+    <subscribe node='urn:xmpp:mix:nodes:messages'/>
+    <subscribe node='urn:xmpp:mix:nodes:presence'/>
+    <subscribe node='urn:xmpp:mix:nodes:participants'/>
+    <subscribe node='urn:xmpp:mix:nodes:config'/>
+  </join>
+</iq>
+]]></example>
+      
+      <p>
+        The user’s server will then pass the request to the MIX channel, with the request coming from the user's bare JID.    
+      </p>
+      
+      <example caption="User's Server sends  Join request to MIX Channel"><![CDATA[
 <iq type='set'
     from='hag66@shakespeare.example'
     to='coven@mix.shakespeare.example'
@@ -830,13 +859,12 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
     <subscribe node='urn:xmpp:mix:nodes:participants'/>
-    <subscribe node='urn:xmpp:mix:nodes:subject'/>
     <subscribe node='urn:xmpp:mix:nodes:config'/>
   </join>
 </iq>
 ]]></example>
-      <p>The channel responds with an IQ-result. This stanza includes the nodes to which the user has been successfully subscribed, as well as the bare JID that will be used for the user in this channel and added to the participant list.  The JID returned in the join is the user's bare proxy JID.  The following example shows the result of the above request when the request is completed in full. </p>
-      <example caption="Channel Processes Join Request in Full"><![CDATA[
+      <p>The channel responds to the user's sever with an IQ-result addressed to the user's bare JID. This stanza includes the nodes to which the user has been successfully subscribed, as well as the bare JID that will be used for the user in this channel and added to the participant list.  The JID returned in the join is the user's bare proxy JID.  The following example shows the result of the above request when the request is completed in full. </p>
+      <example caption="Channel responds to User's Server"><![CDATA[
 <iq type='result'
     from='coven@mix.shakespeare.example'
     to='hag66@shakespeare.example'
@@ -845,14 +873,31 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
     <subscribe node='urn:xmpp:mix:nodes:participants'/>
-    <subscribe node='urn:xmpp:mix:nodes:subject'/>
+    <subscribe node='urn:xmpp:mix:nodes:config'/>
+  </join>
+</iq>
+]]></example>
+      
+      <p>
+     The user's server will then send the join response back to the client that made the join request.   The only change is that the incoming message is addressed to bare JID and the outgoing message is addressed to client's full JID.   Prior to sending this response, the user's server will make roster modifications as set out in the next section.
+      </p>
+      
+      <example caption="User's Server sends response to Client"><![CDATA[
+<iq type='result'
+    from='coven@mix.shakespeare.example'
+    to='hag66@shakespeare.example/pda'
+    id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
+  <join xmlns='urn:xmpp:mix:0' jid='coven+123456@mix.shakespeare.example'>
+    <subscribe node='urn:xmpp:mix:nodes:messages'/>
+    <subscribe node='urn:xmpp:mix:nodes:presence'/>
+    <subscribe node='urn:xmpp:mix:nodes:participants'/>
     <subscribe node='urn:xmpp:mix:nodes:config'/>
   </join>
 </iq>
 ]]></example>
       <p>
         If a user cannot be subscribed to one or more of the requested nodes (e.g., because the node does not exist), but can be subscribed to some the response simply lists the nodes successfully subscribed.    If none of the nodes requested are successfully subscribed to, an error response is sent indicating the reason that the first node requested was not subscribed to.   This response will also include other nodes requested where subscription failed for the same reason. The following response example shows a response to the initial request example where
-the participant is not be subscribed to all nodes associated with the channel (in this case only messages, participants, and subject).</p>
+the participant is not be subscribed to all nodes associated with the channel (in this case only messages, participants, and subject). The following example is the message from the MIX channel to the user's server, which will be modified and sent to the client.</p>
       <example caption="Channel Processes Join With Some Nodes Not Subscribed To"><![CDATA[
 <iq type='result'
     from='hag66@shakespeare.example'
@@ -865,7 +910,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
   </join>
 </iq>
 ]]></example>
-      <p>The channel also adds the user to the participants node and sends a notification to subscribers to the participants node.</p>
+      <p>The channel also adds the user to the participants node and sends a notification to subscribers to the participants node.  The following example shows such a notification.</p>
       <example caption="Channel Adds User to Participants Node"><![CDATA[
 <message from='coven@mix.shakespeare.example'
          to='hecate@shakespeare.example'
@@ -879,13 +924,13 @@ the participant is not be subscribed to all nodes associated with the channel (i
   </event>
 </message>
 ]]></example>
-      <p>The user that has been added to the channel is identified by the item id of the item added to the pubsub node, which is the proxy JID of the new channel participant. Note that the &lt;participant&gt; element does not include a nick of the user being added. The nick MAY be set after the join.</p>
+      <p>The user that has been added to the channel is identified by the item id of the item added to the pubsub node, which is the proxy JID of the new channel participant. Note that the &lt;participant&gt; element MUST NOT include a nick of the user being added. The nick MAY be set after the join.</p>
       <p>
-        A user MAY subsequently modify subscription to nodes in a channel by sending a subscription modification request, as shown in the following example.
+        A user MAY subsequently modify subscription to nodes in a channel by sending a subscription modification request, as shown in the following example.  This modification goes directly from client to MIX channel, as this change does not impact the roster and so does not need any local action.
       </p>
       <example caption="User Modifies Subscription Request"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example'
+    from='hag66@shakespeare.example/pda'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <update-subscription xmlns='urn:xmpp:mix:0'>
@@ -894,8 +939,8 @@ the participant is not be subscribed to all nodes associated with the channel (i
 </iq>
 
 <iq type='result'
-    from='hag66@shakespeare.example'
-    to='coven@mix.shakespeare.example'
+     from='coven@mix.shakespeare.example'
+     to='hag66@shakespeare.example/pda'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <update-subscription xmlns='urn:xmpp:mix:0' jid='hag66@shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
@@ -905,7 +950,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     </section3>
     <section3 topic="Roster Management" anchor="usecase-roster-management">
       <p>
-        After the user has jointed the channel, the user's server MAY add the MIX channel to the user's roster using standard XMPP to update the roster.  This is done to share the user's presence status with the channel and so the MIX channel will get presence information from the user.  This roster entry will lead to the user's server correctly sending user's presence from all clients to the MIX channel. The roster subscription is configured with one way presence, as presence is sent to the MIX channel but no presence information is sent about the MIX channel. The user's server MUST remove this roster entry after the user leaves the channel.
+        As part of the channel joining process, the user's server MAY add the MIX channel to the user's roster using standard XMPP to update the roster.  This is done to share the user's presence status with the channel and so the MIX channel will get presence information from the user.  This roster entry will lead to the user's server correctly sending user's presence from all clients to the MIX channel. The roster subscription is configured with one way presence, as presence is sent to the MIX channel but no presence information is sent about the MIX channel. The user's server MUST remove this roster entry after the user leaves the channel.
       </p>
       <p>
            If the user does not wish to publish presence information to the channel, the user will not add the roster entry.  A channel MAY require presence to be provided by all channel participants, which is controlled by the 'Participants Must Provide Presence' option.   The channel MAY check that channel participants have done this and MAY remove participants that do not do this.
@@ -942,7 +987,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
        <tr><td>'vCard'</td><td>'Allow', 'Block'</td> <td>'Block'</td></tr>
        <tr><td>'Presence'</td><td>'Share', 'Not Share'</td><td>'Share'</td></tr>
      </table>
-     <p>When joining a channel, the client MAY specify one or more preference options as a &xep0004; form.   In the response, the  server MUST specify all of the user preferences supported by the server, with default values if the user has not requested a different value.  The following example shows joining a channel and setting a preference.</p>
+     <p>When joining a channel, the client MAY specify one or more preference options as a &xep0004; form.   In the response, the  server MUST specify all of the user preferences supported by the server, with default values if the user has not requested a different value.  The following example shows joining a channel and setting a preference.  The following example shows the message sent from the user's server to the MIX channel.</p>
      <example caption="User Joins a Channel and Specifies a preference"><![CDATA[
 <iq type='set'
     from='hag66@shakespeare.example'
@@ -962,7 +1007,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
   </join>
 </iq>
 ]]></example>
-     <p>The following example shows a successful join, which also reports all the user preferences. </p>
+     <p>The following example shows a successful join, which also reports all the user preferences. This is the message coming from the MIX channel to the user's server.  All join operations are addressed by a client to the user's server.</p>
      <example caption="Channel Successfully Processes Join and returns the preferences set"><![CDATA[
 <iq type='result'
     from='coven@mix.shakespeare.example'
@@ -988,10 +1033,10 @@ the participant is not be subscribed to all nodes associated with the channel (i
   </join>
 </iq>
 ]]></example>
-     <p>The client MAY also query the channel in order to find out which user preferences are supported and the options available.  This will allow users to set options not specified in the standard, by providing a form template in the result.</p>
+     <p>The client MAY also query the channel in order to find out which user preferences are supported and the options available.  This will allow users to set options not specified in the standard, by providing a form template in the result.   This query is direct from the client to the MIX channel.</p>
      <example caption="User Requests and Recieves Preferences Template Form"><![CDATA[
 <iq type='get'
-    from='hag66@shakespeare.example'
+    from='hag66@shakespeare.example/pda'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
     <user-preference xmlns='urn:xmpp:mix:0'/>
@@ -999,7 +1044,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq type='result'
     from='coven@mix.shakespeare.example'
-    to='hag66@shakespeare.example'
+    to='hag66@shakespeare.example/pda'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
     <user-preference xmlns='urn:xmpp:mix:0'>
     <x xmlns='jabber:x:data' type='form'>
@@ -1028,7 +1073,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
      </p>
      <example caption="User Updates Preferences"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example'
+    from='hag66@shakespeare.example/pda'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
     <user-preference xmlns='urn:xmpp:mix:0'/>
@@ -1050,7 +1095,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq type='result'
     from='coven@mix.shakespeare.example'
-    to='hag66@shakespeare.example'
+    to='hag66@shakespeare.example/pda'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
     <user-preference xmlns='urn:xmpp:mix:0'>
     <x xmlns='jabber:x:data' type='result'>
@@ -1073,11 +1118,53 @@ the participant is not be subscribed to all nodes associated with the channel (i
    </section3>
 
     <section3 topic='Leaving a Channel' anchor='usecase-user-leaving'>
-      <p>Users generally remain in a channel for an extended period of time.  In particular the user remains as a participant the channel does not change when the user goes offline as happens with &xep0045;. So, leaving the channel is a permanent action for a user across all clients, not just a matter of telling the channel that the user is not currently available or for a single client.  In order to  leave a channel, a user sends a MIX "leave" command to the channel. When a user leaves the channel, the user's client will remove the channel from the user's roster.</p>
+      <p>Users generally remain in a channel for an extended period of time.  In particular the user remains as a participant the channel does not change when the user goes offline as happens with &xep0045;. So, leaving the channel is a permanent action for a user across all clients, not just a matter of telling the channel that the user is not currently available or for a single client.  In order to  leave a channel, a user sends a MIX "leave" command to the channel. When a user leaves the channel, the user's server will remove the channel from the user's roster.   Leave commands are sent indirectly through the user's server, to enable roster removal.   Leaving is initiated by a client request, as</p>
+      
+      
+      <example caption="Client Requests to Leave a Channel"><![CDATA[
+<iq type='set'
+    from='hag66@shakespeare.example/pda'
+    to='hag66@shakespeare.example'
+    id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
+  <leave xmlns='urn:xmpp:mix:0'
+          channel=`coven@mix.shakespeare.example`/>
+</iq>
+]]></example>
+      
+      <p>
+        The user's server will then generate a matching request to the MIX channel.
+      </p>
+      
       <example caption="User Leaves a Channel"><![CDATA[
 <iq type='set'
     from='hag66@shakespeare.example'
     to='coven@mix.shakespeare.example'
+    id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
+  <leave xmlns='urn:xmpp:mix:0'/>
+</iq>
+]]></example>
+      
+    <p>
+      The MIX channel will then remove the user from the channel, as described below.   A response is sent to the user's server.
+    </p>  
+      <example caption="Channel Confirms Leave to User's Server"><![CDATA[
+<iq type='result'  
+    from='coven@mix.shakespeare.example'
+    to='hag66@shakespeare.example'
+    id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
+  <leave xmlns='urn:xmpp:mix:0'/>
+</iq>
+]]></example>
+      
+      
+      <p>
+        After receiving the confirmation that the user has left the MIX channel, the user's server will remove the MIX channel entry from the user's roster.   The user's server will then notify the client that requested to leave.
+      </p>
+      
+      <example caption="User's Server Confirms Leave to Client"><![CDATA[
+<iq type='result'  
+    from='coven@mix.shakespeare.example'
+    to='hag66@shakespeare.example/pda'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <leave xmlns='urn:xmpp:mix:0'/>
 </iq>
@@ -1125,7 +1212,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     </p>
     <example caption="User sets Nick on Channel"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example'
+    from='hag66@shakespeare.example/pda'
     to='coven@mix.shakespeare.example'
     id='7nve413p'>
   <query xmlns='urn:xmpp:mix:0'>
@@ -1140,8 +1227,8 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
     <example caption="Channel informs user of Nick"><![CDATA[
 <iq type='result'
-    from='hag66@shakespeare.example'
-    to='coven@mix.shakespeare.example'
+    from='coven@mix.shakespeare.example'
+    to'hag66@shakespeare.example/pda'
     id='7nve413p'>
   <query xmlns='urn:xmpp:mix:0'>
     <nick>thirdwitch</nick>
@@ -1181,7 +1268,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
  a &lt;register/&gt; command to the service. </p>
       <example caption="User Registers with Service"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example'
+    from='hag66@shakespeare.example/pda'
     to='mix.shakespeare.example'
     id='7nve413p'>
   <register xmlns='urn:xmpp:mix:0'>
@@ -1193,7 +1280,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
       <example caption="Service Returns User of Nick"><![CDATA[
 <iq type='result'
     to='mix.shakespeare.example'
-    from='hag66@shakespeare.example'
+    from='hag66@shakespeare.example/pda'
     id='7nve413p'>
   <register xmlns='urn:xmpp:mix:0'>
     <nick>thirdwitch</nick>
@@ -1204,7 +1291,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
       <example caption="Nick is Taken">
 <![CDATA[<iq type='error'
     to='mix.shakespeare.example'
-    from='hag66@shakespeare.example'
+    from='hag66@shakespeare.example/pda'
     id='7nve413p'>
   <error type='cancel'>
     <conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
@@ -1700,10 +1787,10 @@ the participant is not be subscribed to all nodes associated with the channel (i
     </section3>
     <section3 topic='Creating a Channel' anchor='usecase-admin-create'>
       <p>
-        A client creates a channel by sending a simple request to the MIX service.   A channel MAY be created with default parameters, as shown in the following example.   The result MUST include the name of the channel which MUST match the channel name in the request (if present).  Creating and destroying a channel MUST be done indirectly by the user's server using the user's bare JID.
+        A client creates a channel by sending a simple request to the MIX service.   A channel MAY be created with default parameters, as shown in the following example.   The result MUST include the name of the channel which MUST match the channel name in the request (if present).  Creating and destroying a channel is done direct from a client.
       </p>
         <example caption="Creating a Channel with Default Parameters" ><![CDATA[
-<iq from='hag66@shakespeare.example'
+<iq from='hag66@shakespeare.example/pda'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -1712,7 +1799,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example'
+    to='hag66@shakespeare.example/pda'
     type='result'>
   <create channel='coven' xmlns='urn:xmpp:mix:0'/>
 </iq>
@@ -1721,7 +1808,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         The client MAY also include parameters in &xep0004; format as part of channel creation.    If the client wishes to inspect configuration, channel administration procedures SHOULD be used.
       </p>
       <example caption="Creating a Channel with Client Specified Parameters" ><![CDATA[
-<iq from='hag66@shakespeare.example'
+<iq from='hag66@shakespeare.example/pda'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -1751,7 +1838,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example'
+    to='hag66@shakespeare.example/pda'
     type='result'>
   <create channel='coven' xmlns='urn:xmpp:mix:0'/>
 </iq>
@@ -1765,7 +1852,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         Rooms MAY be created for ad hoc use between a set of users.  Channels of this nature will have channel name created by the server and will not be addressable or discoverable.  Here a channel is created without specifying the channel name.   Parameters for the channel MAY also be specified.
       </p>
       <example caption="Creating a Channel for Ad Hoc Use" ><![CDATA[
-<iq from='hag66@shakespeare.example'
+<iq from='hag66@shakespeare.example/pda'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -1774,7 +1861,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example'
+    to='hag66@shakespeare.example/pda'
     type='result'>
   <create channel='A1B2C345' xmlns='urn:xmpp:mix:0'/>
 </iq>
@@ -1815,7 +1902,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         A client destroys a channel using a simple set operation, as shown in the following example.
       </p>
       <example caption="Client Destroys a Channel" ><![CDATA[
- <iq from='hag66@shakespeare.example'
+ <iq from='hag66@shakespeare.example/pda'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -1824,7 +1911,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example'
+    to='hag66@shakespeare.example/pda'
     type='result'>
 </iq>
 ]]></example>
@@ -1838,7 +1925,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
     <section3 topic='Modifying Channel Information' anchor='usecase-admin-information'>
       <p>Authorized users, typically owners and sometimes administrators, MAY modify the channel information.   The client MAY issue a pubsub get command to obtain a form that will facilitate update of the information node.   The values in the form show current values, which be defaults or MAY have been explicitly set.  In the following example, the channel name was previously set, but other values were not. </p>
       <example caption="Getting Information Form" ><![CDATA[
- <iq from='hag66@shakespeare.example'
+ <iq from='hag66@shakespeare.example/pda'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='get'>
@@ -1849,7 +1936,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example'
+    to='hag66@shakespeare.example/pda'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/'>
      <items node='urn:xmpp:mix:nodes:info'>
@@ -1876,7 +1963,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 ]]></example>
       <p>  Updating the information node is done using a pubsub set command.  The MIX channel MUST update the fields with values provided, leaving other fields unchanged.  The result returns the id used in the information node item, which is the date/time of the modification. </p>
       <example caption="Modifying Channel Information" ><![CDATA[
- <iq from='hag66@shakespeare.example'
+ <iq from='hag66@shakespeare.example/pda'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -1903,7 +1990,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example'
+    to='hag66@shakespeare.example/pda'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'>
       <publish node='urn:xmpp:mix:nodes:info'>
@@ -1914,10 +2001,10 @@ the participant is not be subscribed to all nodes associated with the channel (i
 ]]></example>
     </section3>
     <section3 topic='Modifying Channel Configuration' anchor='usecase-admin-information'>
-      <p>Channel owners are allowed to modify the channel configuration.    The client MAY issue a pubsub get command to obtain a form that will facilitate update of the configuration node.  Other clients MAY be authorized to use this command to see the channel configuration, but only owners MAY update the configuration.   The values in the form show current values, which MAY be defaults or MAY have been explicitly set.  The following example shows a short form returned to illustrate the syntax.   A typical configuration form will be much larger with many fields.  Modifying channel configuration MUST be done indirectly by the user's server.
+      <p>Channel owners are allowed to modify the channel configuration.    The client MAY issue a pubsub get command to obtain a form that will facilitate update of the configuration node.  Other clients MAY be authorized to use this command to see the channel configuration, but only owners MAY update the configuration.   The values in the form show current values, which MAY be defaults or MAY have been explicitly set.  The following example shows a short form returned to illustrate the syntax.   A typical configuration form will be much larger with many fields.  Modifying channel configuration is done directly by a client.
       </p>
       <example caption="Getting Configuration Form" ><![CDATA[
- <iq from='hag66@shakespeare.example'
+ <iq from='hag66@shakespeare.example/pda'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='get'>
@@ -1928,7 +2015,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example'
+    to='hag66@shakespeare.example/pda'
     type='result'>
      <pubsub xmlns='http://jabber.org/protocol/pubsub'>
       <items xmlns='urn:xmpp:mix:0'  node='urn:xmpp:mix:nodes:config'>
@@ -1947,7 +2034,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 ]]></example>
       <p>  Updating the information node is done using a pubsub set command.  The MIX channel MUST update the fields with values provided, leaving other fields unchanged.  The result returns the id used in the configuration node item, which is the date/time of the modification. </p>
       <example caption="Modifying Channel Configuration" ><![CDATA[
- <iq from='hag66@shakespeare.example'
+ <iq from='hag66@shakespeare.example/pda'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -1979,7 +2066,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example'
+    to='hag66@shakespeare.example/pda'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'>
       <publish node='urn:xmpp:mix:nodes:config'>
@@ -1992,10 +2079,10 @@ the participant is not be subscribed to all nodes associated with the channel (i
     <section3 topic='Controlling Channel Partipcipants' anchor='usecase-admin-participants'>
       <p>
        Owners and Administrators are allowed to  control which users can participate in a channel by use of Allowed and Banned lists using PubSub.  These operations follow &xep0060; which sets out detailed protocol use and error handling.
-       Allowed and Banned lists MAY be read by PubSub get of the Banned and Allowed Nodes.  This operation MAY be used by users as controlled by 'Allowed Node Subscription' and 'Banned Node Subscription' configuration node options (default Administrators).  This MUST be done indirectly by the user's server.
+       Allowed and Banned lists MAY be read by PubSub get of the Banned and Allowed Nodes.  This operation MAY be used by users as controlled by 'Allowed Node Subscription' and 'Banned Node Subscription' configuration node options (default Administrators).  
       </p>
       <example caption="Client Reads Allowed Node" ><![CDATA[
-<iq from='hag66@shakespeare.example'
+<iq from='hag66@shakespeare.example/pda'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='get'>
@@ -2006,7 +2093,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example'
+    to='hag66@shakespeare.example/pda'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'>
          <items node='urn:xmpp:mix:nodes:allowed'>
@@ -2020,7 +2107,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         JIDs can be added to the  Allowed and Banned nodes  by a pubsub set command.  This is used to add one item to a node.
       </p>
  <example caption="Client Adds a JID to the Allowed Node" ><![CDATA[
-<iq from='hag66@shakespeare.example'
+<iq from='hag66@shakespeare.example/pda'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -2033,7 +2120,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example'
+    to='hag66@shakespeare.example/pda'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'/>
 </iq>
@@ -2042,7 +2129,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
         JIDs can be removed from the Allowed and Banned nodes by pubsub retract command.
       </p>
     <example caption="Client Removes a JID to the Banned Node" ><![CDATA[
-<iq from='hag66@shakespeare.example'
+<iq from='hag66@shakespeare.example/pda'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -2055,7 +2142,7 @@ the participant is not be subscribed to all nodes associated with the channel (i
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example'
+    to='hag66@shakespeare.example/pda'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'/>
 </iq>
@@ -2175,43 +2262,27 @@ the participant is not be subscribed to all nodes associated with the channel (i
 ]]></example>
   </section2>
 
-  <section2 topic="Messages To MIX Channels" anchor="mix-to">
+  <section2 topic="Messages To MIX Channels" anchor="user-server-to">
     <p>
       Messages sent by a MIX channel participant to the MIX channel are always sent from a MIX client directly to the channel. The participant's server relays the message but does not modify the messages.
     </p>
   </section2>
-
+  
+  
+  <section2 topic="MIX Management and Discovery" anchor="user-server-disco">
+    <p>
+      Most interaction between  a MIX client and a MIX channel is directly between the client channel. The participant's server relays the message but does not modify the messages.   In particular configuration management and discovery is direct.   Interaction will be direct, unless explicitly stated otherwise.
+    </p>
+  </section2>
   <section2 topic="IQ Support on Local Server" anchor="mix-diso">
   <p>
-    The MIX specification requires that some IQ messages MUST or MAY come from the participant's server, and not directly from the client.
-   This indirect operation enables the participant's server to use information from the client to improve the service provided to the client.
-    The following table shows which IQs are direct from client, indirect through the local server.
+    Channel Join and Leave functions operate indirectly through the participant's server.  The reason for this is that where a channel shares user presence, the channel is included in the user's roster which is managed in the local server.  The Join and Leave functions lead to roster changes and so they MUST go through the participant's server.   This is included in each of the operations that work in this manner.   The general mechanism to achieve this is illustrated by example in this section.
+    The client addresses indirect messages to the user's own bare JID, indicating the channel with the channel attribute.  This is illustrated below. 
+    
   </p>
 
-    <table caption="IQ Direct vs Indirect">
-      <tr><th>Action</th><th>Direct or Indirect</th></tr>
-
-       <tr><td>MIX Service Discovery</td><td>Direct</td></tr>
-      <tr><td>MIX Service Information Discovery</td><td>Direct</td></tr>
-      <tr><td>MIX Channel Discovery</td><td>Indirect</td></tr>
-      <tr><td>Discovering Channel Information</td><td>Indirect</td></tr>
-      <tr><td>Discovering Channel Nodes</td><td>Indirect</td></tr>
-      <tr><td>Determining Channel Information from Information Node</td><td>Indirect</td></tr>
-      <tr><td>Determining Channel Participants</td><td>Indirect</td></tr>
-      <tr><td>Joining a Channel</td><td>Indirect</td></tr>
-      <tr><td>Preference Setting</td><td>Indirect</td></tr>
-      <tr><td>Leaving MIX Channel</td><td>Indirect</td></tr>
-      <tr><td>Nick Setting</td><td>Indirect</td></tr>
-      <tr><td>Nick Registration</td><td>Indirect</td></tr>
-      <tr><td>Channel Creation and Destruction</td><td>Indirect</td></tr>
-      <tr><td>Channel Configuration Management</td><td>Indirect</td></tr>
-    </table>
-    <p>
-      The rest of this section describes how indirect discovery is achieved, using channel join as an example.
-
-      The client addresses indirect messages to the user's own bare JID, indicating the channel with the channel attribute.  This is illustrated below.
-
-    </p>
+  
+    
   <example caption="Client sends request to local server to Join a MIX Channel"><![CDATA[
 <iq type='set'
     from='hag66@shakespeare.example/pda'


### PR DESCRIPTION
 Update after Brussels Summit;
      Remove Explicit Client Activation and replace with client capability discovery (summit 3);
      Limit Indirect to Join/Leave;
      Clarify Server use of Disco of Client;
      Add MIX capability information to Roster (summit 10);
      MIX as Core Spec (summit 1);
      Clarifications of password control, voice and name/description (summit 4/5/6)
      Removal of Subject and reference future Sticky Messages XEP (summit 7);
      Use example JIDs aligned to anticipated BIND2 specification;
      Clarify PubSub Node Type;
      Add Error handling section;
      Substantial Editorial Review;