### PR TITLE
XEP-0313: server MAY add the id to incoming messages

### DIFF
--- a/xep-0313.xml
+++ b/xep-0313.xml
@@ -28,6 +28,14 @@
   &mwild;
   &ksmith;
   <revision>
+    <version>0.5.2</version>
+    <date>2016-10-30</date>
+    <initials>dg</initials>
+    <remark>
+      <p>Added method for server to communicate the archive id</p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.5.1</version>
     <date>2016-03-07</date>
     <initials>XEP Editor (ssw)</initials>
@@ -168,6 +176,17 @@
 	</section2>
 	<section2 topic='Querying Entities' anchor='entities'>
 		<p>While this document talks about 'clients' and 'servers', as these are the common cases, the querying entity (referred to as a 'client') need not be an XMPP client as defined by RFC6120, but could potentially be any type of entity, and the queried entity (referred to as a 'server') need not be an XMPP server as defined by RFC6120, although access controls might prohibit any given entity from being able to access an archive.</p>
+	</section2>
+	<section2 topic='Communicating the archive ID' anchor='archives_id'>
+		<p>When an incoming message is archived, the server MAY add an &lt;stanza-id/&gt; element as defined in &xep0359; to the message, which informs the client of where and under what ID the message is stored. When doing this the server MUST follow the business rules defined in XEP-0359. The 'by'-attribute MUST be set to the address of the archive. For regular users that’s the bare JID of the account and for MUC that’s the bare JID of the room.</p>
+		<p>Servers MUST NOT include the &lt;stanza-id/&gt; element in messages addressed to JIDs that do not have permissions to access the archive, such as a users’s outgoing messages to their contacts. However servers MAY include the element as a child of the forwarded message when using &xep0280;</p>
+		<example caption='Client receives a message that has been archived'><![CDATA[
+<message to='juliet@capulet.lit/balcony'
+	 from='romeo@montague.lit/orchard'
+         type='chat'>
+  <body>Call me but love, and I'll be new baptized; Henceforth I never will be Romeo.</body>
+  <stanza-id xmlns='urn:xmpp:sid:0' by='juliet@capulet.lit' id='28482-98726-73623' />
+</message>]]></example>
 	</section2>
 </section1>
 


### PR DESCRIPTION
Hi,

I want to urge everybody to get this merged. I mean no disrespect to the original author but the fact is that nothing has happened on this front for months.

Here are my arguments on why this should be merged ASAP
* There is no argument that injecting the MAM id into live messages is a good thing. The only open question is on whether to do this in the MAM namespace (which would require a NS bump) or with stanza-ids (where the general consensus is that we can stick with the `urn:xmpp:mam:1` namespace
* The suggested changes do not stand in the way of potential future changes from the author. Even if the original author decides to bump the NS later for other reason those stanza-ids don't hurt.
* The changes described here actually reflect the reality of the implementations. Both ejabberd and prosody (the internal MAM in 0.10) do inject stanza-ids
* The author doesn't seem to have general objects to the idea; If I understood him correctly these changes were more or less part of some bigger changes he had already done (But never committed!)

I also cleaned up the 'should add to carbons' phrasing and changed that to MAY as well.