### PR TITLE
Clarify CSI and Carbons state after SM resumption

### DIFF
--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -22,6 +22,7 @@
     <spec>XEP-0030</spec>
     <spec>XEP-0085</spec>
     <spec>XEP-0296</spec>
+    <spec>XEP-0334</spec>
   </dependencies>
   <supersedes>
     <spec>XEP-0259</spec>
@@ -40,6 +41,14 @@
     <email>linuxwolf@outer-planes.net</email>
     <jid>linuxwolf@outer-planes.net</jid>
   </author>
+  <revision>
+    <version>0.11.1</version>
+    <date>2017-02-05</date>
+    <initials>fs</initials>
+    <remark>
+      <p>Clarify that the Carbons state is restored when the stream is resumed and remove the 'private' element in favor of the 'no-copy' element from <cite>XEP-0334</cite>.</p>
+    </remark>
+  </revision>
   <revision>
     <version>0.11.0</version>
     <date>2017-01-27</date>
@@ -157,7 +166,7 @@
   </ul>
 </section1>
 <section1 topic='Discovering Support' anchor='disco'>
-  <p>An entity advertises support for this protocol by including the "urn:xmpp:carbons:2" feature in its service discovery information features as specified in &xep0030; or section 6.3 of &xep0115;.</p>
+  <p>An entity advertises support for this protocol by including the "urn:xmpp:carbons:3" feature in its service discovery information features as specified in &xep0030; or section 6.3 of &xep0115;.</p>
   <example caption='Client requests information about its own server'><![CDATA[
 <iq xmlns='jabber:client'
     from='romeo@montague.example/garden'
@@ -174,20 +183,20 @@
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     ...
-    <feature var='urn:xmpp:carbons:2'/>
+    <feature var='urn:xmpp:carbons:3'/>
     ...
   </query>
 </iq>]]></example>
 </section1>
 
 <section1 topic='Enabling Carbons' anchor='enabling'>
-  <p>When a client wants to participate in the Carbons protocol, it enables the protocol by sending an IQ-set containing a child element &lt;enable/&gt; qualified by the namespace "urn:xmpp:carbons:2":</p>
+  <p>When a client wants to participate in the Carbons protocol, it enables the protocol by sending an IQ-set containing a child element &lt;enable/&gt; qualified by the namespace "urn:xmpp:carbons:3":</p>
   <example caption='Client enables Carbons'><![CDATA[
 <iq xmlns='jabber:client'
     from='romeo@montague.example/garden'
     id='enable1'
     type='set'>
-  <enable xmlns='urn:xmpp:carbons:2'/>
+  <enable xmlns='urn:xmpp:carbons:3'/>
 </iq>]]></example>
     <p>The server will respond with an IQ-result when Carbons are enabled:</p>
     <example caption='Server acknowledges enabling Carbons'><![CDATA[
@@ -218,13 +227,13 @@
 </section1>
 
 <section1 topic='Disabling Carbons' anchor='disabling'>
-  <p>Some clients might want to disable Carbons.  To disable Carbons, the client sends an IQ-set containing a child element &lt;disable/&gt; qualified by the namespace "urn:xmpp:carbons:2":</p>
+  <p>Some clients might want to disable Carbons.  To disable Carbons, the client sends an IQ-set containing a child element &lt;disable/&gt; qualified by the namespace "urn:xmpp:carbons:3":</p>
   <example caption='Client disables Carbons'><![CDATA[
 <iq xmlns='jabber:client'
     from='romeo@montague.example/garden'
     id='disable1'
     type='set'>
-  <disable xmlns='urn:xmpp:carbons:2'/>
+  <disable xmlns='urn:xmpp:carbons:3'/>
 </iq>]]></example>
   <p>The server will respond with an IQ-result when Carbons are disabled:</p>
   <example caption='Server acknowledges disabling Carbons'><![CDATA[
@@ -270,7 +279,7 @@
 
 <section1 topic='Receiving Messages' anchor='inbound'>
   <p>When the server receives a &MESSAGE; <link url='#which-messages'>eligible for carbons delivery</link> addressed to a client JID (either bare or full), it delivers the &MESSAGE; according to <cite>RFC 6121</cite> § 8.5.3, and then delivers a forwarded copy to each Carbons-enabled resource for the matching bare JID recipient that did not receive it under the RFC 6121 delivery rules.</p>
-  <p>Each forwarded copy is wrapped using &xep0297;. The wrapping message SHOULD maintain the same 'type' attribute value; the 'from' attribute MUST be the Carbons-enabled user's bare JID (e.g., "localpart@domainpart"); and the 'to' attribute MUST be the full JID of the resource receiving the copy. The content of the wrapping message MUST contain a &lt;received/&gt; element qualified by the namespace "urn:xmpp:carbons:2", which itself contains a &lt;forwarded/&gt; element qualified by the namespace "urn:xmpp:forward:0" that contains the original &MESSAGE;.</p>
+  <p>Each forwarded copy is wrapped using &xep0297;. The wrapping message SHOULD maintain the same 'type' attribute value; the 'from' attribute MUST be the Carbons-enabled user's bare JID (e.g., "localpart@domainpart"); and the 'to' attribute MUST be the full JID of the resource receiving the copy. The content of the wrapping message MUST contain a &lt;received/&gt; element qualified by the namespace "urn:xmpp:carbons:3", which itself contains a &lt;forwarded/&gt; element qualified by the namespace "urn:xmpp:forward:0" that contains the original &MESSAGE;.</p>
 
   <example caption='Juliet sends Romeo a directed message'><![CDATA[
 <message xmlns='jabber:client'
@@ -286,7 +295,7 @@
          from='romeo@montague.example'
          to='romeo@montague.example/home'
          type='chat'>
-  <received xmlns='urn:xmpp:carbons:2'>
+  <received xmlns='urn:xmpp:carbons:3'>
     <forwarded xmlns='urn:xmpp:forward:0'>
       <message xmlns='jabber:client'
                from='juliet@capulet.example/balcony'
@@ -304,7 +313,7 @@
 </section1>
 <section1 topic='Sending Messages' anchor='outbound'>
   <p>When a client sends a &MESSAGE; <link url='#which-messages'>eligible for carbons delivery</link>, its sending server delivers the &MESSAGE; according to <cite>RFC 6120</cite> and <cite>RFC 6121</cite>, and delivers a forwarded copy to each Carbons-enabled resource for the matching bare JID sender, excluding the sending client. Note that this happens irrespective of whether the sending client has carbons enabled.</p>
-  <p>Each forwarded copy is wrapped using &xep0297;. The wrapping message SHOULD maintain the same 'type' attribute value; the 'from' attribute MUST be the Carbons-enabled user's bare JID (e.g., "localpart@domainpart"); and the 'to' attribute SHOULD be the full JID of the resource receiving the copy. The content of the wrapping message MUST contain a &lt;sent/&gt; element qualified by the namespace "urn:xmpp:carbons:2", which itself contains a &lt;forwarded/&gt; qualified by the namespace "urn:xmpp:forward:0" that contains the original &MESSAGE; stanza.</p>
+  <p>Each forwarded copy is wrapped using &xep0297;. The wrapping message SHOULD maintain the same 'type' attribute value; the 'from' attribute MUST be the Carbons-enabled user's bare JID (e.g., "localpart@domainpart"); and the 'to' attribute SHOULD be the full JID of the resource receiving the copy. The content of the wrapping message MUST contain a &lt;sent/&gt; element qualified by the namespace "urn:xmpp:carbons:3", which itself contains a &lt;forwarded/&gt; qualified by the namespace "urn:xmpp:forward:0" that contains the original &MESSAGE; stanza.</p>
   <example caption='Romeo responds to Juliet'><![CDATA[
 <message xmlns='jabber:client'
          from='romeo@montague.example/home'
@@ -320,7 +329,7 @@
         from='romeo@montague.example'
         to='romeo@montague.example/garden'
         type='chat'>
-  <sent xmlns='urn:xmpp:carbons:2'>
+  <sent xmlns='urn:xmpp:carbons:3'>
     <forwarded xmlns='urn:xmpp:forward:0'>
       <message xmlns='jabber:client'
                to='juliet@capulet.example/balcony'
@@ -343,12 +352,11 @@
     This might be useful for clients sending end-to-end encrypted messages, for
     example.
     The sending client MAY exclude a &MESSAGE; from being forwarded to other
-    Carbons-enabled resources, by adding a &lt;private/&gt; element qualified by
-    the namespace "urn:xmpp:carbons:2" and a &lt;no-copy/&gt; hint as described
+    Carbons-enabled resources, by adding a &lt;no-copy/&gt; hint as described
     in &xep0334; as child elements of the &MESSAGE; stanza.
   </p>
 
-  <p><strong>Note:</strong> use of the private mechanism might lead to partial conversations on other devices. This is the intended effect.</p>
+  <p><strong>Note:</strong> Use of the no-copy mechanism might lead to partial conversations on other devices. This is the intended effect.</p>
 
   <example caption='Romeo sends to Juliet, excluding Carbons'><![CDATA[
 <message xmlns='jabber:client'
@@ -357,7 +365,6 @@
          type='chat'>
   <body>Neither, fair saint, if either thee dislike.</body>
   <thread>0e3141cd80894871a68e6fe6b1ec56fa</thread>
-  <private xmlns='urn:xmpp:carbons:2'/>
   <no-copy xmlns='urn:xmpp:hints'/>
 </message>]]></example>
 
@@ -368,11 +375,10 @@
          type='chat'>
   <body>Neither, fair saint, if either thee dislike.</body>
   <thread>0e3141cd80894871a68e6fe6b1ec56fa</thread>
-  <private xmlns='urn:xmpp:carbons:2'/>
   <no-copy xmlns='urn:xmpp:hints'/>
 </message>]]></example>
-  <p>The sending server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resources of the sender. The receiving server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resource of the recipient, and SHOULD remove the &lt;private/&gt; element before delivering to the recipient.</p>
-  <p><strong>Note:</strong> if the private &MESSAGE; stanza is addressed to a bare JID, the receiving server still delivers it according to <cite>RFC 6121</cite>. This might result in a copy being delivered to each resource for the recipient, which effectively negates the behavior of the &lt;private/&gt; element for recipients.</p>
+  <p>The sending server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resources of the sender. The receiving server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resource of the recipient.</p>
+  <p><strong>Note:</strong> if the no-copy &MESSAGE; stanza is addressed to a bare JID, the receiving server still delivers it according to <cite>RFC 6121</cite>. This might result in a copy being delivered to each resource for the recipient, which effectively negates the behavior of the &lt;no-copy/&gt; element for recipients.</p>
 </section1>
 <section1 topic='Business Rules' anchor='bizrules'>
   <section2 topic='Handling Multiple Enable/Disable Requests' anchor='bizrules-multi'>
@@ -399,6 +405,10 @@
   <section2 topic='Mobile Considerations' anchor='bizrules-mobile'>
     <p>Enabling this protocol on mobile devices needs to be undertaken with care. This protocol can result in additional bandwidth and power usage, possibly decreasing battery lifetime and increasing monetary costs.  Additional mechanisms for controlling the Carbon-copying or forking of individual conversations might need to be added to deal with mobile clients in the future.</p>
   </section2>
+  <section2 topic='Interaction with Stream Resumption' anchor='stream-resumption'>
+	<p>After a previous stream was resumed using mechanisms like
+	&xep0198;, the previous carbons state is also restored.</p>
+  </section2>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
   <p>The security model assumed by this document is that all of the resources for a single user are in the same trust boundary. Any forwarded copies received by a Carbons-enabled client MUST be from that user's bare JID; any copies that do not meet this requirement MUST be ignored.</p>
@@ -411,7 +421,7 @@
   <section2 topic='Protocol Namespaces' anchor='registrar-ns'>
     <p>This specification defines the following XML namespace:</p>
     <ul>
-      <li>urn:xmpp:carbons:2</li>
+      <li>urn:xmpp:carbons:3</li>
     </ul>
     <p>Upon advancement of this specification from a status of Experimental to a status of Draft, the &REGISTRAR; shall add the foregoing namespace to the registry located at &NAMESPACES;, as described in Section 4 of &xep0053;.</p>
   </section2>
@@ -425,15 +435,13 @@
 
 <xs:schema
     xmlns:xs='http://www.w3.org/2001/XMLSchema'
-    targetNamespace='urn:xmpp:carbons:2'
-    xmlns='urn:xmpp:carbons:2'
+    targetNamespace='urn:xmpp:carbons:3'
+    xmlns='urn:xmpp:carbons:3'
     elementFormDefault='qualified'>
 
   <xs:element name='disable' type='empty'/>
 
   <xs:element name='enable' type='empty'/>
-
-  <xs:element name='private' type='empty'/>
 
   <xs:element name='received' type='forward-container'/>
 
@@ -458,6 +466,6 @@
 ]]></code>
 </section1>
 <section1 topic='Acknowledgements' anchor='ack'>
-  <p>The authors wish to thank Patrick Barry, Teh Chang, Jack Erwin, Craig Kaes, Kathleen McMurry, Tory Patnoe, Peter Saint-Andre, Ben Schumacher, and Kevin Smith for their feedback.</p>
+  <p>The authors wish to thank Patrick Barry, Teh Chang, Jack Erwin, Craig Kaes, Kathleen McMurry, Tory Patnoe, Peter Saint-Andre, Ben Schumacher, Kevin Smith, and Florian Schmaus for their feedback.</p>
 </section1>
 </xep>

--- a/xep-0352.xml
+++ b/xep-0352.xml
@@ -23,6 +23,12 @@
   <shortname>NOT_YET_ASSIGNED</shortname>
   &mwild;
   <revision>
+	<version>0.2.1</version>
+	<date>2017-02-05</date>
+	<initials>fs</initials>
+	<remark><p>Clarify that the CSI state is not restored when the stream is resumed</p></remark>
+  </revision>
+  <revision>
     <version>0.2</version>
     <date>2015-10-02</date>
     <initials>XEP Editor (mam)</initials>
@@ -144,6 +150,12 @@ e.g. by flushing out queued stanzas to the client.
 and responds to the ping with a pong -->
 <iq to='juliet@capulet.lit/baclony' from='capulet.lit' id='ping1' type='result'/>
 <!-- Stream state is now 'active' -->]]></example>
+  </section2>
+  <section2 topic='Interaction with Stream Resumption' anchor='stream-resumption'>
+	<p>After a previous stream was resumed using mechanisms like
+	&xep0198;, the CSI state is <em>not</em> restored. Therefore it is
+	recommended that clients set their CSI state right after the
+	stream got resumed.</p>
   </section2>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>


### PR DESCRIPTION
And since this needs a namespace bump of carbons anyway, also remove
the <private/> element in favor of <no-copy/>.

Same as #402, but without the change to XEP-0198.

Pinging @linuxwolf and @mwild1