### PR TITLE
XEP-0280: Clarify the Carbons state after SM resumption.

### DIFF
--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -23,6 +23,7 @@
     <spec>XEP-0030</spec>
     <spec>XEP-0085</spec>
     <spec>XEP-0296</spec>
+    <spec>XEP-0334</spec>
   </dependencies>
   <supersedes>
     <spec>XEP-0259</spec>
@@ -41,6 +42,14 @@
     <email>linuxwolf@outer-planes.net</email>
     <jid>linuxwolf@outer-planes.net</jid>
   </author>
+  <revision>
+    <version>0.13.0</version>
+    <date>2017-02-18</date>
+    <initials>fs</initials>
+    <remark>
+      <p>Clarify that the Carbons state is restored when the stream is resumed and remove the 'private' element in favor of the 'no-copy' element from <cite>XEP-0334</cite>.</p>
+    </remark>
+  </revision>
   <revision>
     <version>0.12.0</version>
     <date>2017-02-16</date>
@@ -167,7 +176,7 @@
   </ul>
 </section1>
 <section1 topic='Discovering Support' anchor='disco'>
-  <p>An entity advertises support for this protocol by including the "urn:xmpp:carbons:2" feature in its service discovery information features as specified in &xep0030; or section 6.3 of &xep0115;.</p>
+  <p>An entity advertises support for this protocol by including the "urn:xmpp:carbons:3" feature in its service discovery information features as specified in &xep0030; or section 6.3 of &xep0115;.</p>
   <example caption='Client requests information about its own server'><![CDATA[
 <iq xmlns='jabber:client'
     from='romeo@montague.example/garden'
@@ -184,20 +193,20 @@
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     ...
-    <feature var='urn:xmpp:carbons:2'/>
+    <feature var='urn:xmpp:carbons:3'/>
     ...
   </query>
 </iq>]]></example>
 </section1>
 
 <section1 topic='Enabling Carbons' anchor='enabling'>
-  <p>When a client wants to participate in the Carbons protocol, it enables the protocol by sending an IQ-set containing a child element &lt;enable/&gt; qualified by the namespace "urn:xmpp:carbons:2":</p>
+  <p>When a client wants to participate in the Carbons protocol, it enables the protocol by sending an IQ-set containing a child element &lt;enable/&gt; qualified by the namespace "urn:xmpp:carbons:3":</p>
   <example caption='Client enables Carbons'><![CDATA[
 <iq xmlns='jabber:client'
     from='romeo@montague.example/garden'
     id='enable1'
     type='set'>
-  <enable xmlns='urn:xmpp:carbons:2'/>
+  <enable xmlns='urn:xmpp:carbons:3'/>
 </iq>]]></example>
     <p>The server will respond with an IQ-result when Carbons are enabled:</p>
     <example caption='Server acknowledges enabling Carbons'><![CDATA[
@@ -228,13 +237,13 @@
 </section1>
 
 <section1 topic='Disabling Carbons' anchor='disabling'>
-  <p>Some clients might want to disable Carbons.  To disable Carbons, the client sends an IQ-set containing a child element &lt;disable/&gt; qualified by the namespace "urn:xmpp:carbons:2":</p>
+  <p>Some clients might want to disable Carbons.  To disable Carbons, the client sends an IQ-set containing a child element &lt;disable/&gt; qualified by the namespace "urn:xmpp:carbons:3":</p>
   <example caption='Client disables Carbons'><![CDATA[
 <iq xmlns='jabber:client'
     from='romeo@montague.example/garden'
     id='disable1'
     type='set'>
-  <disable xmlns='urn:xmpp:carbons:2'/>
+  <disable xmlns='urn:xmpp:carbons:3'/>
 </iq>]]></example>
   <p>The server will respond with an IQ-result when Carbons are disabled:</p>
   <example caption='Server acknowledges disabling Carbons'><![CDATA[
@@ -306,7 +315,7 @@
          from='romeo@montague.example'
          to='romeo@montague.example/home'
          type='chat'>
-  <received xmlns='urn:xmpp:carbons:2'>
+  <received xmlns='urn:xmpp:carbons:3'>
     <forwarded xmlns='urn:xmpp:forward:0'>
       <message xmlns='jabber:client'
                from='juliet@capulet.example/balcony'
@@ -328,7 +337,7 @@
     <li>The wrapping message SHOULD maintain the same 'type' attribute value;</li>
     <li>the 'from' attribute MUST be the Carbons-enabled user's bare JID (e.g., "localpart@domainpart");</li>
     <li>and the 'to' attribute SHOULD be the full JID of the resource receiving the copy.</li>
-    <li>The content of the wrapping message MUST contain a &lt;sent/&gt; element qualified by the namespace "urn:xmpp:carbons:2", which itself contains a &lt;forwarded/&gt; qualified by the namespace "urn:xmpp:forward:0" that contains the original &MESSAGE; stanza.</li>
+    <li>The content of the wrapping message MUST contain a &lt;sent/&gt; element qualified by the namespace "urn:xmpp:carbons:3", which itself contains a &lt;forwarded/&gt; qualified by the namespace "urn:xmpp:forward:0" that contains the original &MESSAGE; stanza.</li>
   </ul>
 
   <p>The sending server SHOULD NOT send a forwarded copy to the sending full JID if it is a Carbons-enabled resource.</p>
@@ -348,7 +357,7 @@
         from='romeo@montague.example'
         to='romeo@montague.example/garden'
         type='chat'>
-  <sent xmlns='urn:xmpp:carbons:2'>
+  <sent xmlns='urn:xmpp:carbons:3'>
     <forwarded xmlns='urn:xmpp:forward:0'>
       <message xmlns='jabber:client'
                to='juliet@capulet.example/balcony'
@@ -371,15 +380,15 @@
   </p>
 
   <ul>
-    <li> The sending client MAY exclude a &MESSAGE; from being forwarded to other Carbons-enabled resources, by adding a &lt;private/&gt; element qualified by the namespace "urn:xmpp:carbons:2" and a &lt;no-copy/&gt; hint as described in &xep0334; as child elements of the &MESSAGE; stanza.</li>
+    <li> The sending client MAY exclude a &MESSAGE; from being forwarded to other Carbons-enabled resources, by adding a &lt;no-copy/&gt; hint as described in &xep0334; as child elements of the &MESSAGE; stanza.</li>
     <li>The sending server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resources of the sender.</li>
     <li>The receiving server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resource of the recipient,</li>
-    <li>and the receiving server SHOULD remove the &lt;private/&gt; element before delivering to the recipient.</li>
+    <li>and the receiving server SHOULD remove the &lt;no-copy/&gt; element before delivering to the recipient.</li>
   </ul>
 
   <p><strong>Note:</strong>
     Use of the private mechanism might lead to partial conversations on other devices. This is the intended effect.
-    If the private &MESSAGE; stanza is addressed to a bare JID, the receiving server still delivers it according to <cite>RFC 6121</cite>. This might result in a copy being delivered to each resource for the recipient, which effectively negates the behavior of the &lt;private/&gt; element for recipients.</p>
+    If the private &MESSAGE; stanza is addressed to a bare JID, the receiving server still delivers it according to <cite>RFC 6121</cite>. This might result in a copy being delivered to each resource for the recipient, which effectively negates the behavior of the &lt;no-copy/&gt; element for recipients.</p>
 
   <example caption='Romeo sends to Juliet, excluding Carbons'><![CDATA[
 <message xmlns='jabber:client'
@@ -388,7 +397,6 @@
          type='chat'>
   <body>Neither, fair saint, if either thee dislike.</body>
   <thread>0e3141cd80894871a68e6fe6b1ec56fa</thread>
-  <private xmlns='urn:xmpp:carbons:2'/>
   <no-copy xmlns='urn:xmpp:hints'/>
 </message>]]></example>
 
@@ -399,7 +407,6 @@
          type='chat'>
   <body>Neither, fair saint, if either thee dislike.</body>
   <thread>0e3141cd80894871a68e6fe6b1ec56fa</thread>
-  <private xmlns='urn:xmpp:carbons:2'/>
   <no-copy xmlns='urn:xmpp:hints'/>
 </message>]]></example>
 </section1>
@@ -439,6 +446,10 @@
   <section2 topic='Mobile Considerations' anchor='bizrules-mobile'>
     <p>Enabling this protocol on mobile devices needs to be undertaken with care. This protocol can result in additional bandwidth and power usage, possibly decreasing battery lifetime and increasing monetary costs.  Additional mechanisms for controlling the Carbon-copying of individual conversations might need to be added to deal with mobile clients in the future.</p>
   </section2>
+  <section2 topic='Interaction with Stream Resumption' anchor='stream-resumption'>
+	<p>After a previous stream was resumed using mechanisms like
+	&xep0198;, the previous carbons state is also restored.</p>
+  </section2>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
   <p>The security model assumed by this document is that all of the resources for a single user are in the same trust boundary.</p>
@@ -455,7 +466,7 @@
   <section2 topic='Protocol Namespaces' anchor='registrar-ns'>
     <p>This specification defines the following XML namespace:</p>
     <ul>
-      <li>urn:xmpp:carbons:2</li>
+      <li>urn:xmpp:carbons:3</li>
     </ul>
     <p>Upon advancement of this specification from a status of Experimental to a status of Draft, the &REGISTRAR; shall add the foregoing namespace to the registry located at &NAMESPACES;, as described in Section 4 of &xep0053;.</p>
   </section2>
@@ -469,15 +480,13 @@
 
 <xs:schema
     xmlns:xs='http://www.w3.org/2001/XMLSchema'
-    targetNamespace='urn:xmpp:carbons:2'
-    xmlns='urn:xmpp:carbons:2'
+    targetNamespace='urn:xmpp:carbons:3'
+    xmlns='urn:xmpp:carbons:3'
     elementFormDefault='qualified'>
 
   <xs:element name='disable' type='empty'/>
 
   <xs:element name='enable' type='empty'/>
-
-  <xs:element name='private' type='empty'/>
 
   <xs:element name='received' type='forward-container'/>
 
@@ -502,6 +511,6 @@
 ]]></code>
 </section1>
 <section1 topic='Acknowledgements' anchor='ack'>
-  <p>The authors wish to thank Patrick Barry, Teh Chang, Jack Erwin, Craig Kaes, Kathleen McMurry, Tory Patnoe, Peter Saint-Andre, Ben Schumacher, and Kevin Smith for their feedback.</p>
+  <p>The authors wish to thank Patrick Barry, Teh Chang, Jack Erwin, Craig Kaes, Kathleen McMurry, Tory Patnoe, Peter Saint-Andre, Ben Schumacher, Kevin Smith, and Florian Schmaus for their feedback.</p>
 </section1>
 </xep>


### PR DESCRIPTION
And since this needs a namespace bump of carbons anyway, also remove
the &lt;private/&gt; element in favor of &lt;no-copy/&gt;.