### PR TITLE
XEP-0280: Rewrite of the 'Messages Eligible for Carbons Delivery' section

### DIFF
--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -268,15 +268,15 @@
 <section1 topic='Messages Eligible for Carbons Delivery' anchor='which-messages'>
   <p>The focus of this specification is instant messaging applications and so those (and only those) &MESSAGE; stanzas used for instant messaging SHOULD be delivered as Carbons.</p>
 
-  <p>Defining precisely which messages are used for instant messaging and which are not is difficult, as future specifications may add additional payloads used for, or not used for, instant messaging; as such, the rules for which messages are eligible for carbons delivery is left as an implementation detail for servers.</p>
-  <p>The following is a suggested set of rules a server MAY use, or it MAY use its own; in either case it SHOULD follow the general intent of these rules. A &MESSAGE; is eligible for carbons delivery if and only if at least one the following is true:</p>
+  <p>The following is the set of rules that a server implementation SHOULD use to determine which messages should be carbon-copied. Future specifications MAY add or override rules, though they are generally advised to use &xep0334;.</p>
+  <p>A &MESSAGE; is only eligible for carbons delivery if it does not contain a &lt;no-copy/&gt; child according to <cite>XEP-0334</cite> and if at least one the following is true:</p>
     <ul>
       <li>it is of type "chat".</li>
       <li>it is of type "normal" and contains a &lt;body&gt; element.</li>
       <li>it is of type "error" and it was sent in response to a &MESSAGE; that was eligible for carbons delivery (Note that as this would require message tracking and correlation on the server, it is unlikely to be generally appropriate for most implementations).</li>
       <li>it matches the MUC-related rules outlined below.</li>
     </ul>
-    <p>To properly handle messages exchanged with a MUC (or similar service), the server must be able to identify MUC-related messages. This can be accomplished by tracking the clients' presence in MUCs, or by checking for the <tt>&lt;x xmlns="http://jabber.org/protocol/muc#user"&gt;</tt> element in messages. The following rules are suggested for MUC-related messages:
+    <p>To properly handle messages exchanged with a MUC (or similar service), the server must be able to identify MUC-related messages. This can be accomplished by tracking the clients' presence in MUCs, or by checking for the <tt>&lt;x xmlns="http://jabber.org/protocol/muc#user"&gt;</tt> element in messages. The following rules apply to MUC-related messages:
     </p>
     <ul>
       <li>A &MESSAGE; of type "groupchat" SHOULD NOT be carbon-copied.</li>

--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -274,6 +274,16 @@
       <li>it is of type "chat".</li>
       <li>it is of type "normal" and contains a &lt;body&gt; element.</li>
       <li>it is of type "error" and it was sent in response to a &MESSAGE; that was eligible for carbons delivery (Note that as this would require message tracking and correlation on the server, it is unlikely to be generally appropriate for most implementations).</li>
+      <li>it matches the MUC-related rules outlined below.</li>
+    </ul>
+    <p>To properly handle messages exchanged with a MUC (or similar service), the server must be able to identify MUC-related messages. This can be accomplished by tracking the clients' presence in MUCs, or by checking for the <tt>&lt;x xmlns="http://jabber.org/protocol/muc#user"&gt;</tt> element in messages. The following rules are suggested for MUC-related messages:
+    </p>
+    <ul>
+      <li>A &MESSAGE; of type "groupchat" SHOULD NOT be carbon-copied.</li>
+      <li>A &MESSAGE; containing a &xep0249; SHOULD be carbon-copied.</li>
+      <li>A &MESSAGE; containing a <link url='https://xmpp.org/extensions/xep-0045.html#invite-mediated'>Mediated Invitation</link> SHOULD be carbon-copied.</li>
+      <li>A private &MESSAGE; from a local user to a MUC participant (sent to a full JID) SHOULD be carbon-copied<note>The server SHOULD limit carbon-copying to the clients sharing a <strong>Multi-Session Nick</strong> in that MUC, and MAY inject the &lt;x/&gt; element into such carbon copies. Clients SHOULD ignore carbon-copies of MUC-PMs related to a MUC they are not joined to.</note>.</li>
+      <li>A private &MESSAGE; from a MUC participant (received from a full JID) to a local user SHOULD NOT be carbon-copied (these messages are already replicated by the MUC service to all joined client instances).</li>
     </ul>
     <p>As this is a implementation detail of servers, clients MUST NOT rely on the server implementing a particular set of rules for which messages are eligible for Carbons delivery.</p>
     <p>Future specifications may have more precise requirements on which messages need to be eligible for carbons delivery; such future specifications will provide their own discovery and negotiation mechanisms, such that a client negotiating Carbons using the protocol defined in this specification will cause the server to consider messages eligible for Carbons delivery based on the requirements described herein.</p>

--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE xep SYSTEM 'xep.dtd' [
   <!ENTITY % ents SYSTEM 'xep.ent'>
 %ents;
+<!ENTITY xep0334stricter "<note>This 'MUST NOT' rule imposes a stronger requirement than the 'should not' defined for &lt;no-copy/&gt; in <cite>XEP-0334</cite>.</note>">
 ]>
 <?xml-stylesheet type='text/xsl' href='xep.xsl'?>
 <xep>
@@ -23,6 +24,7 @@
     <spec>XEP-0030</spec>
     <spec>XEP-0085</spec>
     <spec>XEP-0296</spec>
+    <spec>XEP-0334</spec>
   </dependencies>
   <supersedes>
     <spec>XEP-0259</spec>
@@ -371,15 +373,14 @@
   </p>
 
   <ul>
-    <li> The sending client MAY exclude a &MESSAGE; from being forwarded to other Carbons-enabled resources, by adding a &lt;private/&gt; element qualified by the namespace "urn:xmpp:carbons:2" and a &lt;no-copy/&gt; hint as described in &xep0334; as child elements of the &MESSAGE; stanza.</li>
-    <li>The sending server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resources of the sender.</li>
-    <li>The receiving server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resource of the recipient,</li>
-    <li>and the receiving server SHOULD remove the &lt;private/&gt; element before delivering to the recipient.</li>
+    <li> The sending client MAY exclude a &MESSAGE; from being forwarded to other Carbons-enabled resources by adding a &lt;no-copy/&gt; hint as described in &xep0334; to the &MESSAGE; stanza (this can be done even if the sending client and/or server do not use carbons).</li>
+    <li>The sending server MUST NOT carbon-copy &MESSAGE;s with a &lt;no-copy/&gt; element to the other Carbons-enabled resources of the sender&xep0334stricter;.</li>
+    <li>The receiving server MUST NOT carbon-copy &MESSAGE;s with a &lt;no-copy/&gt; element to the other Carbons-enabled resources of the recipient&xep0334stricter;.</li>
   </ul>
 
   <p><strong>Note:</strong>
-    Use of the private mechanism might lead to partial conversations on other devices. This is the intended effect.
-    If the private &MESSAGE; stanza is addressed to a bare JID, the receiving server still delivers it according to <cite>RFC 6121</cite>. This might result in a copy being delivered to each resource for the recipient, which effectively negates the behavior of the &lt;private/&gt; element for recipients.</p>
+    Use of the &lt;no-copy/&gt; mechanism might lead to partial conversations on other devices. This is the intended effect.
+    If such a &MESSAGE; is addressed to a bare JID, the receiving server still delivers it according to <cite>RFC 6121</cite>. This might result in a copy being delivered to each resource for the recipient, which effectively negates the behavior of the &lt;no-copy/&gt; element for recipients.</p>
 
   <example caption='Romeo sends to Juliet, excluding Carbons'><![CDATA[
 <message xmlns='jabber:client'
@@ -388,7 +389,6 @@
          type='chat'>
   <body>Neither, fair saint, if either thee dislike.</body>
   <thread>0e3141cd80894871a68e6fe6b1ec56fa</thread>
-  <private xmlns='urn:xmpp:carbons:2'/>
   <no-copy xmlns='urn:xmpp:hints'/>
 </message>]]></example>
 
@@ -399,7 +399,6 @@
          type='chat'>
   <body>Neither, fair saint, if either thee dislike.</body>
   <thread>0e3141cd80894871a68e6fe6b1ec56fa</thread>
-  <private xmlns='urn:xmpp:carbons:2'/>
   <no-copy xmlns='urn:xmpp:hints'/>
 </message>]]></example>
 </section1>
@@ -446,7 +445,7 @@
     <li>Any forwarded copies received by a Carbons-enabled client MUST be from that user's bare JID;</li>
     <li>any copies that do not meet this requirement MUST be ignored.</li>
   </ul>
-  <p>Outbound chat messages that are encrypted end-to-end are not often useful to receive on other resources.  As such, they should use the &lt;private/&gt; element specified above to avoid such copying, unless the encryption mechanism is able to accommodate this protocol.</p>
+  <p>Outbound chat messages that are encrypted end-to-end are not often useful to receive on other resources.  As such, they should use the &lt;no-copy/&gt; element specified above to avoid such copying, unless the encryption mechanism is able to accommodate this protocol.</p>
 </section1>
 <section1 topic='IANA Considerations' anchor='iana'>
   <p>This document requires no interaction with &IANA;.</p>
@@ -476,8 +475,6 @@
   <xs:element name='disable' type='empty'/>
 
   <xs:element name='enable' type='empty'/>
-
-  <xs:element name='private' type='empty'/>
 
   <xs:element name='received' type='forward-container'/>
 

--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -285,7 +285,7 @@
       <li>A private &MESSAGE; from a local user to a MUC participant (sent to a full JID) SHOULD be carbon-copied<note>The server SHOULD limit carbon-copying to the clients sharing a <strong>Multi-Session Nick</strong> in that MUC, and MAY inject the &lt;x/&gt; element into such carbon copies. Clients SHOULD ignore carbon-copies of MUC-PMs related to a MUC they are not joined to.</note>.</li>
       <li>A private &MESSAGE; from a MUC participant (received from a full JID) to a local user SHOULD NOT be carbon-copied (these messages are already replicated by the MUC service to all joined client instances).</li>
     </ul>
-    <p>As this is a implementation detail of servers, clients MUST NOT rely on the server implementing a particular set of rules for which messages are eligible for Carbons delivery.</p>
+    <p>As the above is an implementation detail of servers, clients MUST NOT rely on the server implementing a particular set of rules for which messages are eligible for Carbons delivery.</p>
     <p>Future specifications may have more precise requirements on which messages need to be eligible for carbons delivery; such future specifications will provide their own discovery and negotiation mechanisms, such that a client negotiating Carbons using the protocol defined in this specification will cause the server to consider messages eligible for Carbons delivery based on the requirements described herein.</p>
     <p><strong>Note:</strong> previous versions of this specification limited eligible messages to those of type "chat" - however, this was generally found to be inadequate due to the proliferation of type "normal" messages used in instant messaging.</p>
 </section1>

--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -269,13 +269,11 @@
   <p>The focus of this specification is instant messaging applications and so those (and only those) &MESSAGE; stanzas used for instant messaging SHOULD be delivered as Carbons.</p>
 
   <p>Defining precisely which messages are used for instant messaging and which are not is difficult, as future specifications may add additional payloads used for, or not used for, instant messaging; as such, the rules for which messages are eligible for carbons delivery is left as an implementation detail for servers.</p>
-  <p>The following is a suggested set of rules a server MAY use, or it MAY use its own; in either case it SHOULD follow the general intent of these rules:</p>
+  <p>The following is a suggested set of rules a server MAY use, or it MAY use its own; in either case it SHOULD follow the general intent of these rules. A &MESSAGE; is eligible for carbons delivery if and only if at least one the following is true:</p>
     <ul>
-      <li>A &MESSAGE; is eligible for carbons delivery if it is of type "chat".</li>
-      <li>A &MESSAGE; is eligible for carbons delivery if it is of type "normal" and it contains a &lt;body&gt; element.</li>
-      <li>A &MESSAGE; is eligible for carbons delivery if it is of type "error" and sent in response to a &MESSAGE; that was itself eligible for carbons delivery (Note that as this would require message tracking and correlation on the server, it is unlikely to be generally appropriate for most implementations).</li>
-      <li>A &MESSAGE; is not eligible for carbons delivery if it is determined to have been sent by a MUC room or service, even if it would be otherwise eligible (this also includes private messages from MUC participants).</li>
-      <li>A &MESSAGE; is not eligible for carbons delivery if it does not meet any of these criteria.</li>
+      <li>it is of type "chat".</li>
+      <li>it is of type "normal" and contains a &lt;body&gt; element.</li>
+      <li>it is of type "error" and it was sent in response to a &MESSAGE; that was eligible for carbons delivery (Note that as this would require message tracking and correlation on the server, it is unlikely to be generally appropriate for most implementations).</li>
     </ul>
     <p>As this is a implementation detail of servers, clients MUST NOT rely on the server implementing a particular set of rules for which messages are eligible for Carbons delivery.</p>
     <p>Future specifications may have more precise requirements on which messages need to be eligible for carbons delivery; such future specifications will provide their own discovery and negotiation mechanisms, such that a client negotiating Carbons using the protocol defined in this specification will cause the server to consider messages eligible for Carbons delivery based on the requirements described herein.</p>

--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -282,7 +282,7 @@
       <li>A &MESSAGE; of type "groupchat" SHOULD NOT be carbon-copied.</li>
       <li>A &MESSAGE; containing a &xep0249; SHOULD be carbon-copied.</li>
       <li>A &MESSAGE; containing a <link url='https://xmpp.org/extensions/xep-0045.html#invite-mediated'>Mediated Invitation</link> SHOULD be carbon-copied.</li>
-      <li>A private &MESSAGE; from a local user to a MUC participant (sent to a full JID) SHOULD be carbon-copied<note>The server SHOULD limit carbon-copying to the clients sharing a <strong>Multi-Session Nick</strong> in that MUC, and MAY inject the &lt;x/&gt; element into such carbon copies. Clients SHOULD ignore carbon-copies of MUC-PMs related to a MUC they are not joined to.</note>.</li>
+      <li>A private &MESSAGE; from a local user to a MUC participant (sent to a full JID) SHOULD be carbon-copied<note>The server SHOULD limit carbon-copying to the clients sharing a <strong>Multi-Session Nick</strong> in that MUC, and MAY inject the &lt;x/&gt; element into such carbon copies. Clients can not respond to carbon-copies of MUC-PMs related to a MUC they are not joined to. Therefore, they SHOULD either ignore such carbon copies, or provide a way for the user to join the MUC before answering.</note>.</li>
       <li>A private &MESSAGE; from a MUC participant (received from a full JID) to a local user SHOULD NOT be carbon-copied (these messages are already replicated by the MUC service to all joined client instances).</li>
     </ul>
     <p>As the above is an implementation detail of servers, clients MUST NOT rely on the server implementing a particular set of rules for which messages are eligible for Carbons delivery.</p>


### PR DESCRIPTION
Hi,

this PR combines multiple changes, again ordered by level of controversy.

* https://github.com/xsf/xeps/commit/aac8f94b0df64b250f7d5320d9f2e5e76b38d2ff Removal of the `private` element, as +1ed by @linuxwolf [on standards@](https://mail.jabber.org/pipermail/standards/2017-February/032271.html) - **this requires a version bump IMO**, as it changes the server behavior when parsing messages with only the `private` element present.
* https://github.com/xsf/xeps/commit/f0e432c15ee3b811a4065abc4baa158ba5fae0c9 Improvement of the "Messages Eligible for Carbons Delivery" section that conveys the same set of rules in less words
* https://github.com/xsf/xeps/commit/7f529e1fb8841cdc16b122bb62539f8e727650b0 addition of clear MUC / MUC-PM instructions, as [suggested on standards@](https://mail.jabber.org/pipermail/standards/2017-January/032048.html)
* https://github.com/xsf/xeps/commit/c60ec805134b6059ab46a1f75a8802b77fca5a1b minor wording correction to accomodiate the above changes
* https://github.com/xsf/xeps/commit/9c388a51c61541507c599832038b6562f3d01841 **controversial** change of the "Messages Eligible for Carbons Delivery" languge from "serves MAY do this" to "servers SHOULD do this" (based on field experience with running Carbons in the wild). The language in the old XEP is very vague and non-binding, and this patch attempts to make clearly defined rules for clear use cases, so that clients can expect consistent behavior (even though they may not rely on it).

If we are doing a version bump, we should make the most out of it (without nonzas, at least).