### PR TITLE
XEP-0045: Add <x/> tag to MUC-PMs

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -1903,6 +1903,7 @@
 
   <section2 topic='Sending a Private Message' anchor='privatemessage'>
     <p>Since each occupant has its own occupant JID, an occupant can send a "private message" to a selected occupant via the service by sending a message to the intended recipient's occupant JID. The message type SHOULD be "chat" and MUST NOT be "groupchat", but MAY be left unspecified (i.e., a normal message). This privilege is controlled by the "muc#roomconfig_allowpm" room configuration option.</p>
+    <p>To allow for proper synchronization of these messages to the user's other clients by &xep0280;, the sending client SHOULD add an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace to the message.</p>
     <example caption='Occupant Sends Private Message'><![CDATA[
 <message
     from='wiccarocks@shakespeare.lit/laptop'
@@ -1910,9 +1911,10 @@
     to='coven@chat.shakespeare.lit/firstwitch'
     type='chat'>
   <body>I'll give thee a wind.</body>
+  <x xmlns='http://jabber.org/protocol/muc#user' />
 </message>
 ]]></example>
-    <p>The service is responsible for changing the 'from' address to the sender's occupant JID and delivering the message to the intended recipient's full JID.</p>
+    <p>The service is responsible for changing the 'from' address to the sender's occupant JID and delivering the message to the intended recipient's full JID. The service SHOULD add the &lt;x/&gt; element if the message does not contain it already.</p>
     <example caption='Recipient Receives the Private Message'><![CDATA[
 <message
     from='coven@chat.shakespeare.lit/firstwitch'
@@ -1920,6 +1922,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='chat'>
   <body>I'll give thee a wind.</body>
+  <x xmlns='http://jabber.org/protocol/muc#user' />
 </message>
 ]]></example>
     <p>If the sender attempts to send a private message of type "groupchat" to a particular occupant, the service MUST refuse to deliver the message (since the recipient's client would expect in-room messages to be of type "groupchat") and return a &badrequest; error to the sender:</p>

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -46,6 +46,14 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.28</version>
+    <date>2017-05-31</date>
+    <initials>gl</initials>
+    <remark>
+      <p>Introduce &lt;x/&gt; tag in MUC-PMs to support better Carbon delivery.</p>
+    </remark>
+  </revision>
+  <revision>
     <version>1.27.1</version>
     <date>2016-12-03</date>
     <initials>XEP Editor: ssw</initials>

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -1904,6 +1904,7 @@
   <section2 topic='Sending a Private Message' anchor='privatemessage'>
     <p>Since each occupant has its own occupant JID, an occupant can send a "private message" to a selected occupant via the service by sending a message to the intended recipient's occupant JID. The message type SHOULD be "chat" and MUST NOT be "groupchat", but MAY be left unspecified (i.e., a normal message). This privilege is controlled by the "muc#roomconfig_allowpm" room configuration option.</p>
     <p>To allow for proper synchronization of these messages to the user's other clients by &xep0280;, the sending client SHOULD add an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace to the message.</p>
+    <p><strong>Note:</strong> because this requirement was only added in revision 1.28 of this XEP, receiving clients MUST NOT rely on the existence of the &lt;x/&gt; element on private messages for proper processing.</p>
     <example caption='Occupant Sends Private Message'><![CDATA[
 <message
     from='wiccarocks@shakespeare.lit/laptop'

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -1904,7 +1904,7 @@
   <section2 topic='Sending a Private Message' anchor='privatemessage'>
     <p>Since each occupant has its own occupant JID, an occupant can send a "private message" to a selected occupant via the service by sending a message to the intended recipient's occupant JID. The message type SHOULD be "chat" and MUST NOT be "groupchat", but MAY be left unspecified (i.e., a normal message). This privilege is controlled by the "muc#roomconfig_allowpm" room configuration option.</p>
     <p>To allow for proper synchronization of these messages to the user's other clients by &xep0280;, the sending client SHOULD add an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace to the message.</p>
-    <p><strong>Note:</strong> because this requirement was only added in revision 1.28 of this XEP, receiving clients MUST NOT rely on the existence of the &lt;x/&gt; element on private messages for proper processing.</p>
+    <p><strong>Note:</strong> because this requirement was only added in revision 1.28 of this XEP, receiving entities MUST NOT rely on the existence of the &lt;x/&gt; element on private messages for proper processing.</p>
     <example caption='Occupant Sends Private Message'><![CDATA[
 <message
     from='wiccarocks@shakespeare.lit/laptop'


### PR DESCRIPTION
To faciliate better interop with Carbons, MUC-PMs need to contain an &lt;x/&gt; tag ([rationale on standards](https://mail.jabber.org/pipermail/standards/2017-January/032048.html)).

This one is a complement to #434.