### PR TITLE
Mix

### DIFF
--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -38,7 +38,7 @@
   &stpeter;
   <revision>
     <version>0.8.2</version>
-    <date>2017-03-xx</date>
+    <date>2017-03-3</date>
     <initials>sek</initials>
     <remark><p>
      Make example ids pseudo-random;

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -42,6 +42,7 @@
     <initials>sek</initials>
     <remark><p>
      Make example ids pseudo-random;
+     Shorten the example BIND2 resources;
     </p></remark>
   </revision>
   <revision>
@@ -378,10 +379,10 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       The primary representation of a participant in a MIX channel is a proxy JID, which is an anonymized JID using the same domain as the channel and with the name of the channel encoded, using the format "&lt;channel&gt;+&lt;generated identifier&gt;@&lt;mix domain&gt;".  They generated identifier MUST NOT contain the '+' characters.  The Channel name MAY contain the '+' character.   For example in the channel 'coven@mix.shakespeare.example',   the user 'hag66@shakespeare.example' might have a proxy JID of 'coven+123456@mix.shakespeare.example'.   The reason for the proxy JID is to support JID Hidden channels.   Proxy JIDs are also used in JID Visible channels, for consistency and to enable switching of JID visibility.  The "urn:xmpp:mix:nodes:jidmap" node maps from proxy JID to real JID.  While a user is a participant in a Channel, the mapping between real JID and proxy JID MUST NOT be changed.
     </p>
     <p>
-      The example real full JIDs in this specification follow the anticipated new format that splits the resource into two parts.  The first part is UUID that is a stable and fixed value for the client.  The second part is server assigned and will vary with each session.   For example:  'hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'.   CITATION TO BE ADDED.  If the final specification differs from this, the examples will be updated.   It is intended to use shorter values if possible, as long as this complies with recommendations of the specifications.
+      The example real full JIDs in this specification are aligned the anticipated new format that splits the resource into two parts.  The first part is UUID that is a stable and fixed value for the client and is anticipated to be a fixed format which may well be UUID 4.  The second part is server assigned and will vary with each session.    A realistic JID with resource is:  'hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f2cd'.   This specification uses examples of the style:  'hag66@shakespeare.example/UUID-a1j/7533' which are aligned to real resources, but more compact.     CITATION TO BE ADDED.  If the final specification differs from this, the examples will be updated.   
     </p>
      <p>
-       The full JIDs held in the  presence nodes are anonymized using a similar mechanism.  First the bare JID is mapped to a bare proxy JID, using the mapping held in the "urn:xmpp:mix:nodes:jidmap" node for the bare JID.  Then the resource is replaced with a generated value.   For example,   'hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0' in the channel coven might have a proxy JID of 'coven+123456@mix.shakespeare.example/789'.   There is no client visible mapping of proxy full JIDs maintained as this is not needed.   The MIX channel will need to maintain a mapping, to support directly addressing clients, such as for client to client disco#info queries.  While an anonymized JID is held in the presence node, the mapping to real JID MUST NOT be changed.  When an anonoymized full JID is added to the presence node, mapping to a real full JID that was previously in the presence node, the same anonymized JID as the previous time MAY be used or a different anonymized JID MAY be used.
+       The full JIDs held in the  presence nodes are anonymized using a similar mechanism.  First the bare JID is mapped to a bare proxy JID, using the mapping held in the "urn:xmpp:mix:nodes:jidmap" node for the bare JID.  Then the resource is replaced with a generated value.   For example,   'hag66@shakespeare.example/UUID-a1j/7533' in the channel coven might have a proxy JID of 'coven+123456@mix.shakespeare.example/789'.   There is no client visible mapping of proxy full JIDs maintained as this is not needed.   The MIX channel will need to maintain a mapping, to support directly addressing clients, such as for client to client disco#info queries.  While an anonymized JID is held in the presence node, the mapping to real JID MUST NOT be changed.  When an anonoymized full JID is added to the presence node, mapping to a real full JID that was previously in the presence node, the same anonymized JID as the previous time MAY be used or a different anonymized JID MAY be used.
      </p>
   </section2>
   <section2 topic="Standard Nodes" anchor="concepts-nodes">
@@ -638,7 +639,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       An entity MAY discover a MIX service or MIX services by sending a Service Discovery items ("disco#items") request to its own server.
     </p>
     <example caption="Entity queries Server for associated services" ><![CDATA[
-<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+<iq from='hag66@shakespeare.example/UUID-c8y/1573'
     id='lx09df27'
     to='shakespeare.example'
     type='get'>
@@ -647,7 +648,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq from='shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+    to='hag66@shakespeare.example/UUID-c8y/1573'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#items'>
     <item jid='mix.shakespeare.example'
@@ -659,7 +660,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
     <p>To determine if a domain hosts a MIX service, a &xep0030; info query is sent in the usual manner to determine capabilities.</p>
       <example caption="Entity queries a service" ><![CDATA[
-<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+<iq from='hag66@shakespeare.example/UUID-c8y/1573'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='get'>
@@ -670,7 +671,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <example caption="Service responds with Disco Info result" ><![CDATA[
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+    to='hag66@shakespeare.example/UUID-c8y/1573'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     <identity
@@ -695,7 +696,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <section2 topic='Discovering the Channels on a Service' anchor='disco-channel-list'>
     <p>The list of channels supported by a MIX service is obtained by a disco#items command.   The MIX service MUST only return channel that exist and that the user making the query has rights to subscribe to.  </p>
     <example caption='Client Queries for Channels on MIX Service'><![CDATA[
-<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+<iq from='hag66@shakespeare.example/UUID-c8y/1573'
     id='kl2fax27'
     to='mix.shakespeare.lit'
     type='get'>
@@ -705,7 +706,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <example caption='MIX Service Returns Disco Items Result'><![CDATA[
 <iq from='mix.shakespeare.lit'
     id='kl2fax27'
-    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+    to='hag66@shakespeare.example/UUID-c8y/1573'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#items'>
     <item jid='coven@mix.shakespeare.example' />
@@ -718,7 +719,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <section2 topic='Discovering Channel Information' anchor='disco-channel-info'>
     <p>In order to find out more information about a given channel, a user can send a disco#info query to the channel. </p>
     <example caption='Entity Queries for Information about a Specific Channel'><![CDATA[
-<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+<iq from='hag66@shakespeare.example/UUID-c8y/1573'
     id='ik3vs715'
     to='coven@mix.shakespeare.lit'
     type='get'>
@@ -729,7 +730,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <example caption='Channel Returns Disco Info Result'><![CDATA[
 <iq from='coven@mix.shakespeare.lit'
     id='ik3vs715'
-    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+    to='hag66@shakespeare.example/UUID-c8y/1573'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info' node='mix'>
     <identity
@@ -745,7 +746,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <section2 topic='Discovering Nodes at a Channel' anchor='disco-channel-nodes'>
     <p>Use disco#items to find the nodes associated with a channel.   Discovering nodes in MIX MUST use the node='mix' attribute.  The MIX service MUST only return nodes that exist and that the user making the query has rights to subscribe to. </p>
     <example caption='Entity Queries for Nodes at a Channel'><![CDATA[
-<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+<iq from='hag66@shakespeare.example/UUID-c8y/1573'
     id='kl2fax27'
     to='coven@mix.shakespeare.lit'
     type='get'>
@@ -755,7 +756,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <example caption='Channel Returns Disco Items Result'><![CDATA[
 <iq from='coven@mix.shakespeare.lit'
     id='kl2fax27'
-    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+    to='hag66@shakespeare.example/UUID-c8y/1573'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#items' node='mix'>
     <item jid='coven@mix.shakespeare.example'
@@ -773,7 +774,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <section2 topic="Determining Information about a Channel" anchor="find-channel-info">
     <p>The Information Node contains various information about the channel that can be useful to the user, that the client can access using PubSub, as shown below.</p>
     <example caption='Client Requests Channel Information'><![CDATA[
-<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+<iq from='hag66@shakespeare.example/UUID-c8y/1573'
     id='kl2fax27'
     to='coven@mix.shakespeare.lit'
     type='get'>
@@ -785,7 +786,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <example caption='MIX Service Returns Channel Information'><![CDATA[
 <iq from='coven@mix.shakespeare.lit'
     id='kl2fax27'
-    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+    to='hag66@shakespeare.example/UUID-c8y/1573'
     type='result'>
   <pubsub xlns='http://jabber.org.protocol.pubsub'>
       <items node='urn:xmpp:nodes:info>>
@@ -816,7 +817,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <p>
       Online clients in the channel are determined from the presence node using PubSub.   Participants in the channel are determined from the Participants Node which will give proxy JID and nick. The jidmap node is used to map to real JIDs.    For JID Hidden channels, only the nicks are returned.  For JID Visible channels, nicks and real JIDs are returned. This query MUST be made directly by a client.</p>
     <example caption='User&apos;s Server Requests Participant List'><![CDATA[
-<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+<iq from='hag66@shakespeare.example/UUID-c8y/1573'
     id='kl2fax27'
     to='coven@mix.shakespeare.lit'
     type='get'>
@@ -828,7 +829,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <example caption='MIX Service Returns Participant List for JID Visible Room'><![CDATA[
 <iq from='coven@mix.shakespeare.lit'
     id='kl2fax27'
-    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+    to='hag66@shakespeare.example/UUID-c8y/1573'
     type='result'>
      <pubsub xlns='http://jabber.org.protocol.pubsub'>
           <items node='urn:xmpp:nodes:participants'>
@@ -845,17 +846,17 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       Where a client supports MIX, it MUST advertise this capability in response to a Disco request.    This will enable other entities to determine if a client supports MIX, and in particular it facilitates the client's server to determine client support.  This can be optimized by use of CAPS.    The following example shows a Disco request to and response from a client that supports both MIX and MUC.
     </p>
     <example caption='Disco Query for MIX support'><![CDATA[
- <iq  from='juliet@capulet.lit/46be1261-200b-4eea-8f82-e4fae46eec56/d6a85bb6-669f-471b-b55b-9a3930f5512e'
+ <iq  from='juliet@capulet.lit/UUID-e3r/9264'
     id='d1rt87mr4w'
-    to='romeo@montague.lit/14e8cb74-9082-4782-9275-8918ee5d8fcd/6983052d-3fdc-4e32-8221-79571a5210fe'
+    to='romeo@montague.lit/UUID-m2t/3945'
     type='get'>
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>
 
 
-<iq from='romeo@montague.lit/14e8cb74-9082-4782-9275-8918ee5d8fcd/6983052d-3fdc-4e32-8221-79571a5210fe'
+<iq from='romeo@montague.lit/UUID-m2t/3945'
     id='d1rt87mr4w'
-    to='juliet@capulet.lit/46be1261-200b-4eea-8f82-e4fae46eec56/d6a85bb6-669f-471b-b55b-9a3930f5512e'
+    to='juliet@capulet.lit/UUID-e3r/9264'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     <feature var='http://jabber.org/protocol/caps'/>
@@ -885,7 +886,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
         <example caption="Client sends request to Local Server to Join a Channel"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    from='hag66@shakespeare.example/UUID-a1j/7533'
     to='hag66@shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <join xmlns='urn:xmpp:mix:0'
@@ -936,7 +937,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <example caption="User's Server sends response to Client"><![CDATA[
 <iq type='result'
     from='coven@mix.shakespeare.example'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <join xmlns='urn:xmpp:mix:0' jid='coven+123456@mix.shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
@@ -985,7 +986,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </p>
       <example caption="User Modifies Subscription Request"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    from='hag66@shakespeare.example/UUID-a1j/7533'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <update-subscription xmlns='urn:xmpp:mix:0'>
@@ -995,7 +996,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq type='result'
      from='coven@mix.shakespeare.example'
-     to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+     to='hag66@shakespeare.example/UUID-a1j/7533'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <update-subscription xmlns='urn:xmpp:mix:0' jid='hag66@shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
@@ -1091,7 +1092,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
      <p>The client MAY also query the channel in order to find out which user preferences are supported and the options available.  This will allow users to set options not specified in the standard, by providing a form template in the result.   This query is direct from the client to the MIX channel.</p>
      <example caption="User Requests and Recieves Preferences Template Form"><![CDATA[
 <iq type='get'
-    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    from='hag66@shakespeare.example/UUID-a1j/7533'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
     <user-preference xmlns='urn:xmpp:mix:0'/>
@@ -1099,7 +1100,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq type='result'
     from='coven@mix.shakespeare.example'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
     <user-preference xmlns='urn:xmpp:mix:0'>
     <x xmlns='jabber:x:data' type='form'>
@@ -1128,7 +1129,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
      </p>
      <example caption="User Updates Preferences"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    from='hag66@shakespeare.example/UUID-a1j/7533'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
     <user-preference xmlns='urn:xmpp:mix:0'/>
@@ -1150,7 +1151,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq type='result'
     from='coven@mix.shakespeare.example'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
     <user-preference xmlns='urn:xmpp:mix:0'>
     <x xmlns='jabber:x:data' type='result'>
@@ -1178,7 +1179,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
       <example caption="Client Requests to Leave a Channel"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    from='hag66@shakespeare.example/UUID-a1j/7533'
     to='hag66@shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <leave xmlns='urn:xmpp:mix:0'
@@ -1219,7 +1220,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <example caption="User's Server Confirms Leave to Client"><![CDATA[
 <iq type='result'
     from='coven@mix.shakespeare.example'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <leave xmlns='urn:xmpp:mix:0'/>
 </iq>
@@ -1267,7 +1268,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     </p>
     <example caption="User sets Nick on Channel"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    from='hag66@shakespeare.example/UUID-a1j/7533'
     to='coven@mix.shakespeare.example'
     id='7nve413p'>
   <query xmlns='urn:xmpp:mix:0'>
@@ -1283,7 +1284,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <example caption="Channel informs user of Nick"><![CDATA[
 <iq type='result'
     from='coven@mix.shakespeare.example'
-    to'hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to'hag66@shakespeare.example/UUID-a1j/7533'
     id='7nve413p'>
   <query xmlns='urn:xmpp:mix:0'>
     <nick>thirdwitch</nick>
@@ -1300,14 +1301,14 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </p>
       <example caption="User Determines features of the MIX service"><![CDATA[
 <iq type='get'
-    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    from='hag66@shakespeare.example/UUID-a1j/7533'
     to='mix.shakespeare.example'
     id='7nve413p'>
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>
 
 <iq type='result'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     from='mix.shakespeare.example'
     id='7nve413p'>
     <query xmlns='http://jabber.org/protocol/disco#info'/>
@@ -1323,7 +1324,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
  a &lt;register/&gt; command to the service. </p>
       <example caption="User Registers with Service"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    from='hag66@shakespeare.example/UUID-a1j/7533'
     to='mix.shakespeare.example'
     id='7nve413p'>
   <register xmlns='urn:xmpp:mix:0'>
@@ -1335,7 +1336,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <example caption="Service Returns User of Nick"><![CDATA[
 <iq type='result'
     to='mix.shakespeare.example'
-    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    from='hag66@shakespeare.example/UUID-a1j/7533'
     id='7nve413p'>
   <register xmlns='urn:xmpp:mix:0'>
     <nick>thirdwitch</nick>
@@ -1346,7 +1347,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <example caption="Nick is Taken">
 <![CDATA[<iq type='error'
     to='mix.shakespeare.example'
-    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    from='hag66@shakespeare.example/UUID-a1j/7533'
     id='7nve413p'>
   <error type='cancel'>
     <conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
@@ -1377,7 +1378,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <p>
         A user setting status is now used as an example.   Unlike in &xep0045; where coming online is a special action, coming online in MIX is implicit when presence status is set.  Going offline is a achieved by setting presence status to unavailable, which removes the client full JID entry from the presence node.  When a user sets a presence status, the user's server sends updated presence to the MIX channel, and the MIX service then publishes the user's  availability to the "urn:xmpp:mix:nodes:presence" node. If there is not an item named by the full JID of the client with updated presence status, this item is created.</p>
       <example caption="User Setting Presence Status">
-<![CDATA[<presence xmlns='jabber:client' from=‘hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0’
+<![CDATA[<presence xmlns='jabber:client' from=‘hag66@shakespeare.example/UUID-a1j/7533’
               to='coven@mix.shakespeare.example'>
   <show>dnd</show>
   <status>Making a Brew</status>
@@ -1446,7 +1447,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <p>When a client goes offline, this presence update is sent by the client's server to the MIX channel.   From the client perspective, this is the same as any other presence change.   Handling by the MIX channel is slightly different.</p>
       <example caption="Client Goes Offline in the Channel"><![CDATA[
 <presence type='unavailable'
-          from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+          from='hag66@shakespeare.example/UUID-a1j/7533'
           to='coven@mix.shakespeare.example'/>
 ]]></example>
       <p>The MIX channel will retract (remove) the item in the presence node of the MIX channel identified by the client's full JID.  The MIX channel will notify subscribers to the presence node of the user going offline by sending a presence stanza to the full proxy JID of each client.</p>
@@ -1469,7 +1470,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <section3 topic='Sending a Message' anchor='usecase-user-message'>
       <p>A client sends a message directly to a MIX channel as a standard groupchat message, in exactly the same way as for &xep0045;. Messages are sent directly to the MIX channel from the user's client. The message id is selected by the client.</p>
       <example caption="User Sends Message to Channel"><![CDATA[
-<message from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+<message from='hag66@shakespeare.example/UUID-a1j/7533'
          to='coven@mix.shakespeare.example'
          id='92vax143g'
          type='groupchat'>
@@ -1510,7 +1511,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         A MIX channel MAY support message retraction, where the sender of a messages or an authorized administrator deletes a message.   If this is done the original message MAY be replaced by a tombstone.  The protocol to request retraction does this by a message with a &lt;retract&gt; element as shown in the following example.
       </p>
       <example caption="User Retracts a Message"><![CDATA[
-<message from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+<message from='hag66@shakespeare.example/UUID-a1j/7533'
          to='coven@mix.shakespeare.example'
          id='92vax143g'>
   <retract id='28482-98726-73623' xmlns='urn:xmpp:mix:0'/>
@@ -1530,7 +1531,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         With this approach, the original message &lt;body&gt; is removed and replaced with a tombstone using the &lt;retracted&gt; element that shows the JID of user performing the retraction and the time of the retraction.
       </p>
       <example caption="Retracted message tombstone in a MAM result"><![CDATA[
-<message id='aeb213' to='juliet@capulet.lit/46be1261-200b-4eea-8f82-e4fae46eec56/d6a85bb6-669f-471b-b55b-9a3930f5512e'>
+<message id='aeb213' to='juliet@capulet.lit/UUID-e3r/9264'>
   <result xmlns='urn:xmpp:mam:1' queryid='f27' id='28482-98726-73623'>
     <forwarded xmlns='urn:xmpp:forward:0'>
       <delay xmlns='urn:xmpp:delay' stamp='2010-07-10T23:08:25Z'/>
@@ -1567,7 +1568,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         The first step is for the inviter to request an invitation from the channel.   The invitation contains inviter, invitee and a token.  The channel will evaluate if the inviter has rights to issue the invitation.   This will be because the inviter is a channel administrator or if the inviter is a channel participant and the channel has 'Participation Addition by Invitation from Participant' mode enabled.  If the inviter has rights to make the invitation, the channel will return a token.  The token is a string that the channel can subsequently use to validate an invitation.   The format of the token is not specified in this standard.   The encoded token MAY reflect a validity time.
       </p>
       <example caption='Inviter Requests and Receives Invitation'><![CDATA[
-<iq from='hag66@shakespeare.lit/d1781be2-2b2d-4cd8-8886-bdc0e1087873/2183ee64-9c97-4eeb-bdc0-c35138b9c2b1'
+<iq from='hag66@shakespeare.lit/UUID-h5z/0253'
     id='kl2fax27'
     to='coven@mix.shakespeare.lit'
     type='get'>
@@ -1579,7 +1580,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq from='coven@mix.shakespeare.lit'
     id='kl2fax27'
-    to='hag66@shakespeare.lit/d1781be2-2b2d-4cd8-8886-bdc0e1087873/2183ee64-9c97-4eeb-bdc0-c35138b9c2b1'
+    to='hag66@shakespeare.lit/UUID-h5z/0253'
     type='result'>
   <invite xmlns='urn:xmpp:mix:0'>
         <invitation>
@@ -1595,7 +1596,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         The inviter can now send the invitee a message containing the invitation, as shown in the following example.
       </p>
       <example caption='Inviter sends Invitation to Invitee'><![CDATA[
-<message from='hag66@shakespeare.lit/d1781be2-2b2d-4cd8-8886-bdc0e1087873/2183ee64-9c97-4eeb-bdc0-c35138b9c2b1'
+<message from='hag66@shakespeare.lit/UUID-h5z/0253'
     id='f5pp2toz'
     to='cat@shakespeare.lit'>
     <body>Would you like to join the coven?<body>
@@ -1631,9 +1632,9 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         <li>'Acknowledged': The invitation is acknowledged, without information on action taken or planned.</li>
       </ul>
       <example caption='Invitee sends Acknowledgement to Inviter'><![CDATA[
-<message from='cat@shakespeare.lit/066923ad-9f06-474d-8cc9-085d14af0554/4974bd01-d991-4bf8-ac4e-18b10160ba46'
+<message from='cat@shakespeare.lit/UUID-l1w/8813'
     id='b6p9llze'
-    to='hag66@shakespeare.lit/d1781be2-2b2d-4cd8-8886-bdc0e1087873/2183ee64-9c97-4eeb-bdc0-c35138b9c2b1'>
+    to='hag66@shakespeare.lit/UUID-h5z/0253'>
     <body>No Thanks - too busy chasing mice....<body>
     <invitation-ack xmlns='urn:xmpp:mix:0'>
         <value>Declined</value>
@@ -1672,7 +1673,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <section3 topic="Requesting vCard" anchor="usecase-vcard">
       <p>A user MAY request the vCard of a channel participant by sending a request through the channel.  The request MAY be sent directly by the client or MAY be sent by the user's server on behalf of the user.  The MIX channel MAY pass this request on or MAY block it.  vCard requests MAY use &xep0054; (vcard-temp) or &xep0292; (vCard4 over XMPP).  Where a MIX service supports one or both of these protocols, the protocol MUST be advertised as a feature of the MIX service.   In the following example, using vcard-temp, the requesting client sends a message to the anonymized bare JID of the channel participant for which the vCard is desired.</p>
       <example caption="Client directly requests vCard through channel" ><![CDATA[
-<iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+<iq from='hag66@shakespeare.example/UUID-c8y/1573'
     id='lx09df27'
     to='coven+989898@mix.shakespeare.example'
     type='get'>
@@ -1715,7 +1716,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <example caption="MIX Channel sends vCard responst to Client" ><![CDATA[
 <iq from='coven+989898@mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+    to='hag66@shakespeare.example/UUID-c8y/1573'
     type='result'>
  <vCard xmlns='vcard-temp'>
     <FN>Peter Saint-Andre</FN>
@@ -1796,7 +1797,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         MIX does not standardize an access control model for creating and deleting MIX channels.    The choice is left to the MIX implementer, and could be a very simple or complex approach.  A client can determine if it has permission to create a channel on a MIX service, which MAY be used to control options presented to the user.   This is achieved by a disco command on the MIX service.   If the 'create-channel' feature is returned, the user is able to create a channel.
       </p>
         <example caption="Client determines Capability to Create a Channel" ><![CDATA[
- <iq from='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+ <iq from='hag66@shakespeare.example/UUID-c8y/1573'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='get'>
@@ -1805,7 +1806,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+    to='hag66@shakespeare.example/UUID-c8y/1573'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     <identity
@@ -1823,7 +1824,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         A client creates a channel by sending a simple request to the MIX service.   A channel MAY be created with default parameters, as shown in the following example.   The result MUST include the name of the channel which MUST match the channel name in the request (if present).  Creating and destroying a channel is done direct from a client.
       </p>
         <example caption="Creating a Channel with Default Parameters" ><![CDATA[
-<iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+<iq from='hag66@shakespeare.example/UUID-a1j/7533'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -1832,7 +1833,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     type='result'>
   <create channel='coven' xmlns='urn:xmpp:mix:0'/>
 </iq>
@@ -1841,7 +1842,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         The client MAY also include parameters in &xep0004; format as part of channel creation.    If the client wishes to inspect configuration, channel administration procedures SHOULD be used.
       </p>
       <example caption="Creating a Channel with Client Specified Parameters" ><![CDATA[
-<iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+<iq from='hag66@shakespeare.example/UUID-a1j/7533'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -1871,7 +1872,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     type='result'>
   <create channel='coven' xmlns='urn:xmpp:mix:0'/>
 </iq>
@@ -1885,7 +1886,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         Channels MAY be created for ad hoc use between a set of users.  Channels of this nature will have channel name created by the server and will not be addressable or discoverable.  Here a channel is created without specifying the channel name.   Parameters for the channel MAY also be specified.
       </p>
       <example caption="Creating a Channel for Ad Hoc Use" ><![CDATA[
-<iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+<iq from='hag66@shakespeare.example/UUID-a1j/7533'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -1894,7 +1895,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     type='result'>
   <create channel='A1B2C345' xmlns='urn:xmpp:mix:0'/>
 </iq>
@@ -1909,7 +1910,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
        This will generally be done by the user creating the channel before the other user is invited, but MAY be sent by either the user creating the channel or the 1:1 chat partner at any time subsequently.
      </p>
      <example caption="Forwarding a message to create History" ><![CDATA[
-<message from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+<message from='hag66@shakespeare.example/UUID-a1j/7533'
          to='A1B2C345@mix.shakespeare.example'
          id='92vax143g'
          type='groupchat'>
@@ -1917,7 +1918,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
           <delay xmlns='urn:xmpp:delay' stamp='2010-07-10T23:08:25Z'/>
           <message from='hag67@shakespeare.example/pda'
                    id='0202197'
-                   to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+                   to='hag66@shakespeare.example/UUID-a1j/7533'
                    type='chat'
                    xmlns='jabber:client'>
               <body>Harpier cries: 'tis time, 'tis time.</body>
@@ -1935,7 +1936,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         A client destroys a channel using a simple set operation, as shown in the following example.
       </p>
       <example caption="Client Destroys a Channel" ><![CDATA[
- <iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+ <iq from='hag66@shakespeare.example/UUID-a1j/7533'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -1944,7 +1945,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     type='result'>
 </iq>
 ]]></example>
@@ -1958,7 +1959,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <section3 topic='Modifying Channel Information' anchor='usecase-admin-information'>
       <p>Authorized users, typically owners and sometimes administrators, MAY modify the channel information.   The client MAY issue a pubsub get command to obtain a form that will facilitate update of the information node.   The values in the form show current values, which be defaults or MAY have been explicitly set.  In the following example, the channel name was previously set, but other values were not. </p>
       <example caption="Getting Information Form" ><![CDATA[
- <iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+ <iq from='hag66@shakespeare.example/UUID-a1j/7533'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='get'>
@@ -1969,7 +1970,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/'>
      <items node='urn:xmpp:mix:nodes:info'>
@@ -1996,7 +1997,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
       <p>  Updating the information node is done using a pubsub set command.  The MIX channel MUST update the fields with values provided, leaving other fields unchanged.  The result returns the id used in the information node item, which is the date/time of the modification. </p>
       <example caption="Modifying Channel Information" ><![CDATA[
- <iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+ <iq from='hag66@shakespeare.example/UUID-a1j/7533'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -2023,7 +2024,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'>
       <publish node='urn:xmpp:mix:nodes:info'>
@@ -2037,7 +2038,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <p>Channel owners are allowed to modify the channel configuration.    The client MAY issue a pubsub get command to obtain a form that will facilitate update of the configuration node.  Other clients MAY be authorized to use this command to see the channel configuration, but only owners MAY update the configuration.   The values in the form show current values, which MAY be defaults or MAY have been explicitly set.  The following example shows a short form returned to illustrate the syntax.   A typical configuration form will be much larger with many fields.  Modifying channel configuration is done directly by a client.
       </p>
       <example caption="Getting Configuration Form" ><![CDATA[
- <iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+ <iq from='hag66@shakespeare.example/UUID-a1j/7533'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='get'>
@@ -2048,7 +2049,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     type='result'>
      <pubsub xmlns='http://jabber.org/protocol/pubsub'>
       <items xmlns='urn:xmpp:mix:0'  node='urn:xmpp:mix:nodes:config'>
@@ -2067,7 +2068,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
       <p>  Updating the information node is done using a pubsub set command.  The MIX channel MUST update the fields with values provided, leaving other fields unchanged.  The result returns the id used in the configuration node item, which is the date/time of the modification. </p>
       <example caption="Modifying Channel Configuration" ><![CDATA[
- <iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+ <iq from='hag66@shakespeare.example/UUID-a1j/7533'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -2099,7 +2100,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'>
       <publish node='urn:xmpp:mix:nodes:config'>
@@ -2115,7 +2116,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
        Allowed and Banned lists MAY be read by PubSub get of the Banned and Allowed Nodes.  This operation MAY be used by users as controlled by 'Allowed Node Subscription' and 'Banned Node Subscription' configuration node options (default Administrators).
       </p>
       <example caption="Client Reads Allowed Node" ><![CDATA[
-<iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+<iq from='hag66@shakespeare.example/UUID-a1j/7533'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='get'>
@@ -2126,7 +2127,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'>
          <items node='urn:xmpp:mix:nodes:allowed'>
@@ -2140,7 +2141,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         JIDs can be added to the  Allowed and Banned nodes  by a pubsub set command.  This is used to add one item to a node.
       </p>
  <example caption="Client Adds a JID to the Allowed Node" ><![CDATA[
-<iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+<iq from='hag66@shakespeare.example/UUID-a1j/7533'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -2153,7 +2154,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'/>
 </iq>
@@ -2162,7 +2163,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         JIDs can be removed from the Allowed and Banned nodes by pubsub retract command.
       </p>
     <example caption="Client Removes a JID to the Banned Node" ><![CDATA[
-<iq from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+<iq from='hag66@shakespeare.example/UUID-a1j/7533'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
@@ -2175,7 +2176,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    to='hag66@shakespeare.example/UUID-a1j/7533'
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'/>
 </iq>
@@ -2227,7 +2228,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
     <example caption="Participant's Server Sends Modified Message to two Clients"><![CDATA[
 <message from='coven@mix.shakespeare.example'
-         to='hecate@shakespeare.example/473c6613-fc5b-40f1-9984-a27887d406c9/7afcdb49-b08a-4617-a372-f3b4cff75c6a'
+         to='hecate@shakespeare.example/UUID-x4r/2491'
          id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
          type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
@@ -2236,7 +2237,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 </message>
 
 <message from='coven@mix.shakespeare.example'
-         to='hecate@shakespeare.example/111c6613-fc5b-40f1-9984-a27887d406c9/222cdb49-b08a-4617-a372-f3b4cff75c6a'
+         to='hecate@shakespeare.example/UUID-b5b/0114'
          id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
          type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
@@ -2270,7 +2271,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
   <example caption="Client sends request to local server to Join a MIX Channel"><![CDATA[
 <iq type='set'
-    from='hag66@shakespeare.example/d104f6a7-97e9-477f-8947-e4a37691d7ee/7533375f-2cd1-4455-a311-494bab21f9f0'
+    from='hag66@shakespeare.example/UUID-a1j/7533'
     to='hag66@shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <join xmlns='urn:xmpp:mix:0'
@@ -2361,7 +2362,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <example caption="Service responds with Disco Info result showing MIX and MUC support" ><![CDATA[
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+    to='hag66@shakespeare.example/UUID-c8y/1573'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     <identity
@@ -2384,7 +2385,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <example caption="MIX Service responds with Disco Info result sharing MUC service location" ><![CDATA[
 <iq from='mix.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+    to='hag66@shakespeare.example/UUID-c8y/1573'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     <identity
@@ -2410,7 +2411,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <example caption="MUC Service responds with Disco Info result sharing MIX service location" ><![CDATA[
 <iq from='chat.shakespeare.example'
     id='lx09df27'
-    to='hag66@shakespeare.example/e0def5dc-3282-4d00-840a-0292622ba804/ba70bd0f-96fe-442d-872a-96ef3b168613'
+    to='hag66@shakespeare.example/UUID-c8y/1573'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     <identity

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -37,6 +37,14 @@
   &skille;
   &stpeter;
   <revision>
+    <version>0.8.2</version>
+    <date>2017-03-xx</date>
+    <initials>sek</initials>
+    <remark><p>
+     Make example ids pseudo-random;
+    </p></remark>
+  </revision>
+  <revision>
     <version>0.8.1</version>
     <date>2017-02-20</date>
     <initials>sek</initials>
@@ -838,7 +846,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     </p>
     <example caption='Disco Query for MIX support'><![CDATA[
  <iq  from='juliet@capulet.lit/46be1261-200b-4eea-8f82-e4fae46eec56/d6a85bb6-669f-471b-b55b-9a3930f5512e'
-    id='disco1'
+    id='d1rt87mr4w'
     to='romeo@montague.lit/14e8cb74-9082-4782-9275-8918ee5d8fcd/6983052d-3fdc-4e32-8221-79571a5210fe'
     type='get'>
   <query xmlns='http://jabber.org/protocol/disco#info'/>
@@ -846,7 +854,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 
 <iq from='romeo@montague.lit/14e8cb74-9082-4782-9275-8918ee5d8fcd/6983052d-3fdc-4e32-8221-79571a5210fe'
-    id='disco1'
+    id='d1rt87mr4w'
     to='juliet@capulet.lit/46be1261-200b-4eea-8f82-e4fae46eec56/d6a85bb6-669f-471b-b55b-9a3930f5512e'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
@@ -1223,7 +1231,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         </p>
       <example caption="Reporting when User Leaves a Channel"><![CDATA[
 <message from='coven@mix.shakespeare.example'
-                to='hecate@shakespeare.example' id='foo'>
+                to='hecate@shakespeare.example' id='f5pp2toz'>
   <event xmlns='http://jabber.org/protocol/pubsub#event'>
     <items node='urn:xmpp:mix:nodes:participants'>
       <retract id='coven+123456@mix.shakespeare.example'/>
@@ -1588,7 +1596,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </p>
       <example caption='Inviter sends Invitation to Invitee'><![CDATA[
 <message from='hag66@shakespeare.lit/d1781be2-2b2d-4cd8-8886-bdc0e1087873/2183ee64-9c97-4eeb-bdc0-c35138b9c2b1'
-    id='foo'
+    id='f5pp2toz'
     to='cat@shakespeare.lit'>
     <body>Would you like to join the coven?<body>
     <invitation xmlns='urn:xmpp:mix:0'>
@@ -1624,7 +1632,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </ul>
       <example caption='Invitee sends Acknowledgement to Inviter'><![CDATA[
 <message from='cat@shakespeare.lit/066923ad-9f06-474d-8cc9-085d14af0554/4974bd01-d991-4bf8-ac4e-18b10160ba46'
-    id='bar'
+    id='b6p9llze'
     to='hag66@shakespeare.lit/d1781be2-2b2d-4cd8-8886-bdc0e1087873/2183ee64-9c97-4eeb-bdc0-c35138b9c2b1'>
     <body>No Thanks - too busy chasing mice....<body>
     <invitation-ack xmlns='urn:xmpp:mix:0'>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -44,6 +44,7 @@
      Make example ids pseudo-random;
      Shorten the example BIND2 resources;
      Fix Disco features to not use second namespace;
+     Correct encoding of jid-multi;
     </p></remark>
   </revision>
   <revision>
@@ -1854,8 +1855,6 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         </field>
         <field var='Owner'>
             <value>hecate@shakespeare.lit</value>
-        </field>
-        <field var='Owner'>
             <value>greymalkin@shakespeare.lit</value>
         </field>
         <field var='Message Node Subscription'>
@@ -2081,8 +2080,6 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         </field>
         <field var='Owner'>
             <value>hecate@shakespeare.lit</value>
-        </field>
-        <field var='Owner'>
             <value>greymalkin@shakespeare.lit</value>
         </field>
         <field var='Message Node Subscription'>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -43,6 +43,7 @@
     <remark><p>
      Make example ids pseudo-random;
      Shorten the example BIND2 resources;
+     Fix Disco features to not use second namespace;
     </p></remark>
   </revision>
   <revision>
@@ -679,7 +680,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         name='Shakespearean Chat Service'
         type='text'/>
     <feature var='urn:xmpp:mix:0'/>
-    <feature var='searchable' xmlns='urn:xmpp:mix:0'>
+    <feature var='urn:xmpp:mix:0#searchable'>
   </query>
 </iq>
 ]]></example>
@@ -688,8 +689,8 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
      </p>
     <ul>
       <li>'urn:xmpp:mix:0': This indicates support of MIX, and is returned by all MIX services.</li>
-      <li>'searchable': This is shown in the above example and indicates that a the MIX Service MAY be searched for channels.   This presence of this feature can be used by a client to guide the user to search for channels in a MIX service.</li>
-      <li>'create-channel': This is described in <link url='#usecase-admin-check-create'> Checking for Permission to Create a Channel</link> in support of channel administration.   When an end user client  needs to create channels, perhaps for short term usage, this feature helps the client to identify an MIX service to use.  It enables a configuration where permanent (searchable) channels are placed in one MIX service and clients will be able to create channels in another MIX service which is not searchable.</li>
+      <li>'urn:xmpp:mix:0#searchable': This is shown in the above example and indicates that a the MIX Service MAY be searched for channels.   This presence of this feature can be used by a client to guide the user to search for channels in a MIX service.</li>
+      <li>'urn:xmpp:mix:0#create-channel': This is described in <link url='#usecase-admin-check-create'> Checking for Permission to Create a Channel</link> in support of channel administration.   When an end user client  needs to create channels, perhaps for short term usage, this feature helps the client to identify an MIX service to use.  It enables a configuration where permanent (searchable) channels are placed in one MIX service and clients will be able to create channels in another MIX service which is not searchable.</li>
     </ul>
     <p>A MIX service MUST NOT advertise support for &xep0313;, as MAM is supported by the channels and not by the service.   A  MIX service MUST NOT advertise support for generic &xep0060;, as although MIX makes use of PubSub it is not a generic PubSub service.</p>
   </section2>
@@ -1312,12 +1313,12 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='mix.shakespeare.example'
     id='7nve413p'>
     <query xmlns='http://jabber.org/protocol/disco#info'/>
-        <feature xmlns='urn:xmpp:mix:0' var='mix_nick_register'/>
+        <feature var='urn:xmpp:mix:0#mix_nick_register'/>
     </query>
 </iq>
 ]]></example>
       <p>
-        The response will be a list of features of the MIX channel.  If Nick Registration is supported, then the result set will include &lt;feature var="mix_nick_register"/&gt;.
+        The response will be a list of features of the MIX channel.  If Nick Registration is supported, then the result set will include &lt;feature var="urn:xmpp:mix:0#mix_nick_register"/&gt;.
       </p>
       <p>
         To register a nick with the MIX service the user sends
@@ -1794,7 +1795,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
     <section3 topic='Checking For Permission To Create a Channel' anchor='usecase-admin-check-create'>
       <p>
-        MIX does not standardize an access control model for creating and deleting MIX channels.    The choice is left to the MIX implementer, and could be a very simple or complex approach.  A client can determine if it has permission to create a channel on a MIX service, which MAY be used to control options presented to the user.   This is achieved by a disco command on the MIX service.   If the 'create-channel' feature is returned, the user is able to create a channel.
+        MIX does not standardize an access control model for creating and deleting MIX channels.    The choice is left to the MIX implementer, and could be a very simple or complex approach.  A client can determine if it has permission to create a channel on a MIX service, which MAY be used to control options presented to the user.   This is achieved by a disco command on the MIX service.   If the 'urn:xmpp:mix:0#create-channel' feature is returned, the user is able to create a channel.
       </p>
         <example caption="Client determines Capability to Create a Channel" ><![CDATA[
  <iq from='hag66@shakespeare.example/UUID-c8y/1573'
@@ -1814,7 +1815,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         name='Shakespearean Chat Service'
         type='text'/>
     <feature var='urn:xmpp:mix:0'/>
-    <feature var='create-channel' xmlns='urn:xmpp:mix:0'>
+    <feature var='urn:xmpp:mix:0#create-channel'>
   </query>
 </iq>
 ]]></example>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -45,6 +45,7 @@
      Shorten the example BIND2 resources;
      Fix Disco features to not use second namespace;
      Correct encoding of jid-multi;
+     MAM intro clarification;
     </p></remark>
   </revision>
   <revision>
@@ -312,7 +313,7 @@
 </p>
   </section2>
   <section2 topic="MIX and MAM" anchor="concepts-mam">
-    <p> Historical data (such as the messages sent to the channel) is stored in an archive supporting  Message Archive Management (MAM) so that clients can subsequently access this data with MAM. Each node can be archived separately (e.g., the presence node or the configuration node). MIX clients can retrieve archived information with MAM in order to quickly resync messages with regard to a channel, and can do so without providing presence information.</p>
+    <p> Historical data (such as the messages sent to the channel) is stored in an archive supporting  Message Archive Management (MAM) so that clients can subsequently access this data with MAM. Each node can be archived separately (e.g., the presence node or the configuration node).  MIX messages are archived by both the MIX channel and the user's server, so that clients can generally use their local MAM archiver.  MIX clients can retrieve archived information with MAM in order to quickly resync messages with regard to a channel, and can do so without providing presence information.</p>
   </section2>
   <section2 topic="Behaviour of MIX Participant's Server" anchor="concepts-mix-participant-server">
     <p>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -46,6 +46,7 @@
      Fix Disco features to not use second namespace;
      Correct encoding of jid-multi;
      MAM intro clarification;
+     Always add to roster, with direction of roster controlled by share preference;
     </p></remark>
   </revision>
   <revision>
@@ -1009,11 +1010,17 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     </section3>
     <section3 topic="Roster Management" anchor="usecase-roster-management">
       <p>
-        As part of the channel joining process, the user's server MAY add the MIX channel to the user's roster using standard XMPP to update the roster.  This is done to share the user's presence status with the channel and so the MIX channel will get presence information from the user.  This roster entry will lead to the user's server correctly sending user's presence from all clients to the MIX channel. The roster subscription is configured with one way presence, as presence is sent to the MIX channel but no presence information is sent about the MIX channel to the user. The user's server MUST remove this roster entry after the user leaves the channel.
+        As part of the channel joining process, the user's server MUST add the MIX channel to the user's roster.  This is done to share the user's presence status with the channel and channel participants subscribing to presence, when the user wishes this presence to be shared.  These roster entries also enables the user's client to quickly determine which channels the user has joined.
+        This roster entry will lead to the user's server correctly sending user's presence from all the user's MIX clients to the MIX channel.  Where the user wishes to share presence, the roster subscription is configured with one way presence, as presence is sent to the MIX channel but no presence information is sent about the MIX channel to the user. 
       </p>
       <p>
-           If the user does not wish to publish presence information to the channel, the user will not add the roster entry.  A channel MAY require presence to be provided by all channel participants, which is controlled by the 'Participants Must Provide Presence' option.   The channel MAY check that channel participants have done this and MAY remove participants that do not do this.
+        If the user does not wish to publish presence information to the channel, the user's server will  add the roster entry with mode subscription=none.  The roster entry will be present to record that the user has joined the channel, but it will not send presence information to the channel.    The user's server MUST do this when the user has chosen Presence preference of 'Not Share' as described below.   If the user changes the value of the preference, the server MUST modify subscription mode to reflect this.
+
       </p>
+      <p>
+        The user's server MUST remove this roster entry when the user leaves the channel.
+      </p>
+      
       <p>
        A channel MAY publish an Avatar following &xep0084;.  A client MAY make use of this information to associate an Avatar with the roster entry for a channel.
       </p>


### PR DESCRIPTION
MIX (XEP-0369) update to 0.8.2

    Make example ids pseudo-random;
     Shorten the example BIND2 resources;
     Fix Disco features to not use second namespace;
     Correct encoding of jid-multi;
     MAM intro clarification;
     Always add to roster, with direction of roster controlled by share preference;