### PR TITLE
README: Remove invalid step from advancing section

### DIFF
--- a/xep-README.xml
+++ b/xep-README.xml
@@ -23,6 +23,12 @@
   <shortname>N/A</shortname>
   &stpeter;
   <revision>
+    <version>0.15</version>
+    <date>2017-03-09</date>
+    <initials>ssw</initials>
+    <remark><p>Remove invalid step from advancing an XEP section</p></remark>
+  </revision>
+  <revision>
     <version>0.14</version>
     <date>2017-01-28</date>
     <initials>ssw</initials>
@@ -249,7 +255,6 @@ $ ./announce.py 0353
   <li>Check your changes into source control.</li>
   <li>Log into the webserver, change directories to /home/xsf/xmpp-hg/extensions, run the "archive.sh" script to copy the previous XEP version to the "attic" (just in case the last editor team member forgot), type 'hg pull' and 'hg update', and run the "gen.py" script to generate HTML and PDF files.</li>
   <li>Run the "announce.py" script on the webserver (see note about <link url='#lists'>List Administration</link>).</li>
-  <li>Update the protocol pages at <link url='http://xmpp.org/protocols/'>http://xmpp.org/protocols/</link> to reflect advancement of the XEP.</li>
 </ol>
 </section2>
 


### PR DESCRIPTION
The http://xmpp.org/protocols/ page doesn't appear to exist anymore; I'm assuming it's similar to https://xmpp.org/extensions/index.html which is auto updated.