### PR TITLE
XEP-0363: fixed typo in example 5

### DIFF
--- a/xep-0363.xml
+++ b/xep-0363.xml
@@ -29,6 +29,12 @@
     <jid>daniel@gultsch.de</jid>
   </author>
   <revision>
+    <version>0.3.1</version>
+    <date>2017-04-21</date>
+    <initials>dg</initials>
+    <remark><p>Fixed example</p></remark>
+  </revision>
+  <revision>
     <version>0.3.0</version>
     <date>2017-02-01</date>
     <initials>dg</initials>
@@ -167,7 +173,6 @@
     filename='my-juliet.jpg'
     size='23456'
     content-type='image/jpeg' />
-  </request>
 </iq>]]></example>
   <p>The upload service responds with both a PUT and a GET URL wrapped by a &lt;slot&gt; element. The service SHOULD keep the file name and especially the file ending intact. Using the same hostname for PUT and GET is OPTIONAL. The host MUST provide Transport Layer Security (&rfc5246;).</p>
   <p>The &lt;put&gt; element MAY also contain an unlimited number of &lt;header&gt; elements which correspond to HTTP header fields. Each &lt;header&gt; element MUST have a name-attribute and a content with the value of the header.</p>


### PR DESCRIPTION
example had a </request> closing tag that didn't belong there