### PR TITLE
Add Dockerfile serving HTML extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:8
+MAINTAINER XSF Editors <editor@xmpp.org>
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get -y dist-upgrade
+RUN apt-get install -y xsltproc libxml2-utils libxml2 texlive fonts-inconsolata make nginx
+
+RUN mkdir /src
+COPY *.xml xep.* *.css *.xsl /src/
+COPY Makefile *.js  /src/
+WORKDIR /src
+RUN mkdir /var/www/html/extensions
+RUN OUTDIR=/var/www/html/extensions/ make html
+
+EXPOSE 80
+
+CMD /usr/sbin/nginx -g 'daemon off;'

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,15 @@ RUN apt-get update && apt-get -y dist-upgrade
 RUN apt-get install -y xsltproc libxml2-utils libxml2 texlive fonts-inconsolata make nginx
 
 RUN mkdir /src
-COPY *.xml xep.* *.css *.xsl /src/
-COPY Makefile *.js  /src/
+COPY *.xml xep.* *.css *.xsl *.js *.xsl Makefile /src/
+RUN mkdir /src/resources
+COPY resources/*.pdf /src/resources/
 WORKDIR /src
+RUN apt-get install -y curl python python-pip texlive-xetex 
+RUN curl https://pilotfiber.dl.sourceforge.net/project/getfo/texml/texml-2.0.2/texml-2.0.2.tar.gz -o texml-2.0.2.tar.gz && tar -xf texml-2.0.2.tar.gz && pip install texml-2.0.2/ && rm -rf texml-2.0.2
+RUN apt-get install -y texlive-fonts-recommended texlive-fonts-extra
 RUN mkdir /var/www/html/extensions
-RUN OUTDIR=/var/www/html/extensions/ make html
+RUN OUTDIR=/var/www/html/extensions/ make html pdf
 
 EXPOSE 80
 

--- a/Makefile
+++ b/Makefile
@@ -107,3 +107,15 @@ preview:
 			xsltproc --path $(CURDIR) xep.xsl "$${dir}/$${file}" > "$(OUTDIR)/$${file%.*}.html" && echo "Built $${file%.*}.html $${event}"; \
 		fi \
 	done
+
+.PHONY: docker
+docker:
+	docker build -t xmpp-org/extensions .
+
+.PHONY: testdocker
+testdocker:
+	docker run -d --name tmpxeps -p 3080:80 xmpp-org/extensions
+
+.PHONY: stopdocker
+stopdocker:
+	docker stop tmpxeps; docker rm -v tmpxeps

--- a/README.md
+++ b/README.md
@@ -44,3 +44,8 @@ To change the output directory, set the variable `OUTDIR`, eg.
     OUTDIR=/tmp/xeps make all
 
 For more information try `make help`.
+
+Using Docker
+------------
+
+A full set of HTML and PDFs can be generated inside a docker container, with no dependencies on the host other than Docker itself, and served by nginx in the container. To build the template `make docker`, to run it `make testdocker` (serves on http://localhost:3080), and to stop/delete it afterwards `make stopdocker`


### PR DESCRIPTION
Test-Information:
Runs, http://localhost:3080/extensions/xep-0001.html serves styled
content.