### PR TITLE
XEP-0065: Remove duplicate example

### DIFF
--- a/xep-0065.xml
+++ b/xep-0065.xml
@@ -315,18 +315,6 @@
 ]]></example>
   <p>If the Proxy is unable to act as a StreamHost, the Proxy MUST return an error to the Requester, which SHOULD be &notallowed;.</p>
     <example caption='Proxy is Unable to Act as a StreamHost'><![CDATA[
-<iq from='streamer.example.com'
-    id='uj2c15z9'
-    to='requester@example.com/foo'
-    type='error'>
-  <error type='auth'>
-    <forbidden
-        xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
-  </error>
-</iq>
-]]></example>
-  <p>If the Proxy is unable to act as a StreamHost, the Proxy MUST return an error to the Requester, which SHOULD be &notallowed;.</p>
-    <example caption='Proxy is Unable to Act as a StreamHost'><![CDATA[
 <iq from='requester@example.com/foo'
     id='uj2c15z9'
     to='streamer.example.com'


### PR DESCRIPTION
Example 10 was a duplicate (the stanza was a copy of ex. 9, the description a copy of example 11) so I removed it.