### PR TITLE
XEP-0369: Correct XML syntax.

### DIFF
--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -1532,7 +1532,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
           <items node='urn:xmpp:mix:nodes:jidmap'>
              <item id='123456#coven@mix.shakespeare.example'>
                  <participant xmlns='urn:xmpp:mix:0'>
-                      <jid>hecate@mix.shakespeare.example<jid/>
+                      <jid>hecate@mix.shakespeare.example</jid>
                  </participant>
              </item>
            </items>
@@ -1574,7 +1574,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
                        <items node='urn:xmpp:mix:nodes:jidmap'>
                            <item id='123456#coven@mix.shakespeare.example'>
                                   <participant xmlns='urn:xmpp:mix:0'>
-                                      <jid>hecate@mix.shakespeare.example<jid/>
+                                      <jid>hecate@mix.shakespeare.example</jid>
                                   </participant>
                            </item>
                        </items>


### PR DESCRIPTION
Example 46 and 47 incorrectly uses `<jid/>`.