### PR TITLE
XEP-0234: Fix xml of error examples

### DIFF
--- a/xep-0234.xml
+++ b/xep-0234.xml
@@ -880,7 +880,7 @@ a=file-range:1024-*]]></code>
   <jingle xmlns='urn:xmpp:jingle:1'
           action='content-reject'
           sid='uj3b2'>
-    <content creator='initiator' name='requesting-file' senders='initiator'>
+    <content creator='initiator' name='requesting-file' senders='initiator'/>
     <reason>
       <failed-application />
       <file-not-available xmlns='urn:xmpp:jingle:apps:file-transfer:errors:0' />
@@ -904,7 +904,7 @@ a=file-range:1024-*]]></code>
   <jingle xmlns='urn:xmpp:jingle:1'
           action='content-remove'
           sid='uj3b2'>
-    <content creator='initiator' name='big-file' senders='initiator'>
+    <content creator='initiator' name='big-file' senders='initiator'/>
     <reason>
       <media-error />
       <file-too-large xmlns='urn:xmpp:jingle:apps:file-transfer:errors:0' />


### PR DESCRIPTION
There were some xml errors in XEP-0234 (Jingle FIle Transfer).
The content element of Examples 17 and 18 is empty and opened, but not closed.