### PR TITLE
XEP-0369: MIX - Update to 0.9.3

### DIFF
--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -45,6 +45,7 @@
       Add mix element in message to hold MIX additional information;
       Roster Update Clarifications;
       Clarify when messages are delivered to clients;
+      Extend Roster Get to select format;
     </p></remark>
   </revision>
   <revision>
@@ -2523,13 +2524,23 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </section2>
 
   <section2 topic="MIX Roster Item Capability Sharing" anchor="mix-roster-capability-sharing">
-    <p>It is useful for a MIX client to know which roster members are MIX channels, as this will facilitate convenient presentation of subscribed MIX channels to the user. A standard roster item is encoded as follows.</p>
+    <p>It is useful for a MIX client to know which roster members are MIX channels, as this will facilitate convenient presentation of subscribed MIX channels to the user.  A MIX client MAY request that the server return this additional information. The server MUST return the additional information. The request is made by adding to the standard roster get request and element &lt;mix-info-request/&gt; qualified by the ‘urn:xmpp:mix:0' namespace.</p>
+    <example caption="Roster Get Requesting MIX Information"><![CDATA[
+<iq from='juliet@example.com/balcony'
+          id='bv1bs71f'
+          type='get'>
+       <query xmlns='jabber:iq:roster'/>
+       <mix-info-request xmlns=‘urn:xmpp:mix:0'/>
+     </iq>
+]]></example>  
+    
+    <p>A standard roster item is encoded as follows.</p>
     <example caption="Standard Roster Item Encoding"><![CDATA[
 <item jid='romeo@example.net'/>
 ]]></example>
 
     <p>
-      MIX channels in the roster have an element 'channel' included in the roster item.
+      MIX channels in the roster information returned in response to a request for this additional MIX information MUST have an element &lt;channel/&gt; qualified by the ‘urn:xmpp:mix:0' namespace  included in the roster item, as shown inf the following example.
     </p>
 
     <example caption="Roster Item Encoding of a MIX Channel"><![CDATA[
@@ -2538,18 +2549,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </item>
 ]]></example>
 
-    <p>
-      A server following the MIX specification MUST determine whether or not a client supports MIX.     If the server does not have this information it MUST use service discovery to determine it before providing roster information.
-      When sending roster information to a client that advertises MIX capability, the server MUST return all MIX channels and MUST use this encoding.  Presence  of MIX roster items MUST be set to offline (unavailable).
-    </p>
-
-    <p>
-      Where a client does not advertise MIX capability, the server MAY choose to not return MIX channels as roster items.   If this is done care needs to be taken, in particular around support of roster versioning  &xep0237;.
-    </p>
-
-    <p>
-      When a client adds MIX capability, additional information needs to be provided by the server.   To support this, a server MUST maintain information about client MIX support status.   When a server detects this change it needs to update the roster which it MAY do incrementally or by sending all of the roster.  
-    </p>
+   
   </section2>
 
   <section2 topic="MAM Archive Support" anchor="proxy-mam">

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -961,7 +961,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 <section1 topic='Use Cases' anchor='usecases'>
   <section2 topic='Common User Use Cases' anchor='usecases-user'>
     <section3 topic='Joining a Channel' anchor='usecase-user-join'>
-      <p>A user joins a channel by sending a MIX "join" command. There is no default set of nodes, so the user MUST specify the set of nodes to be subscribed to. To achieve the equivalent service to MUC, a user would subscribe to messages, and presence. The &lt;join/&gt; is a child element of &lt;iq/&gt; element.  The &lt;join/&gt; element is qualified by the 'urn:xmpp:mix:1' namespace.  The channel is specified by a 'channel' attribute in the &lt;join/&gt; element.  The requested nodes are encoded as &lt;subscribe/&gt; child elements of the &lt;join/&gt; element.
+      <p>A user joins a channel by sending a MIX "join" command. There is no default set of nodes, so the user MUST specify the set of nodes to be subscribed to. To achieve the equivalent service to MUC, a user would subscribe to both messages and presence nodes.  A user will typically subscribe to at least the message and/or presence nodes but MAY join and not subscribe to any nodes. The &lt;join/&gt; is a child element of &lt;iq/&gt; element.     The &lt;join/&gt; element is qualified by the 'urn:xmpp:mix:1' namespace.  The channel is specified by a 'channel' attribute in the &lt;join/&gt; element.  The requested nodes are encoded as &lt;subscribe/&gt; child elements of the &lt;join/&gt; element.
          The join leads to the server subscribing the user to each of the requested nodes associated with the channel. The MIX service will also add the user to the participant list by injecting a new item into the "urn:xmpp:mix:nodes:participants" node automatically.
 
       </p>
@@ -1036,7 +1036,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 </iq>
 ]]></example>
       <p>
-        If a user cannot be subscribed to one or more of the requested nodes (e.g., because the node does not exist), but can be subscribed to some the response simply lists the nodes successfully subscribed.    If none of the nodes requested are successfully subscribed to, an error response is sent indicating the reason that the first node requested was not subscribed to.   This error response will also include other nodes requested where subscription failed for the same reason. </p>
+        If a user cannot be subscribed to one or more of the requested nodes (e.g., because the node does not exist), but can be subscribed to some the response simply lists the nodes successfully subscribed.    If at least one node is requested and none of the nodes requested are successfully subscribed to, an error response is sent indicating the reason that the first node requested was not subscribed to.   This error response will also include other nodes requested where subscription failed for the same reason. </p>
 
       <p>
         The following response example shows a successful response to the initial request example where

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -44,6 +44,7 @@
       Remove Legacy MIX Namespace;
       Add mix element in message to hold MIX additional information;
       Roster Update Clarifications;
+      Clarify when messages are delivered to clients;
     </p></remark>
   </revision>
   <revision>
@@ -2422,6 +2423,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
 
   <p>
+    The server receiving the message will then deliver the messages to all online clients with status available and a non-negative resource priority.
     The following example shows how the participant's server modifies the inbound message to replace the bare JID in the 'to' with a full JID for each of two active MIX clients.
   </p>
 

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -38,7 +38,7 @@
   &stpeter;
   <revision>
     <version>0.9.3</version>
-    <date>2017-06-16</date>
+    <date>2017-06-20</date>
     <initials>sek</initials>
     <remark><p>
       Remove Legacy MIX Namespace;
@@ -50,7 +50,7 @@
       Change mix_nick_register to nick-register;
       Separate namespace for roster information;
       rename jidmap2 to jidmap-visible;
-      version bump to urn:xmpp:mix:1;
+      Namespace bump to mix:1;
     </p></remark>
   </revision>
   <revision>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -52,6 +52,7 @@
       rename jidmap2 to jidmap-visible;
       Namespace bump to mix:1;
       Correct from in response of join/leave IQs;
+      Add capability for MIX in client's server;
     </p></remark>
   </revision>
   <revision>
@@ -2487,6 +2488,29 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </section2>
 
 
+  <section2 topic="Client Determines MIX Capability of Local Server" anchor="user-server-client-capability">
+    <p>
+      Servers supporting the capabilities necessary to enable MIX clients MUST advertise this.   A client wishing to use MIX MUST check for this capability in the server before using MIX.  The capability is represented by the 'urn:xmpp:mix:account:0' feature.
+    </p>
+    <example caption="Client Determines MIX Capability of Local Server"><![CDATA[
+<iq from='hag66@shakespeare.example/UUID-c8y/1573'
+    id='lx09df27'
+    type='get'>
+  <query xmlns='http://jabber.org/protocol/disco#info'/>
+</iq>
+
+<iq from='shakespeare.example'
+    id='lx09df27'
+    to='hag66@shakespeare.example/UUID-c8y/1573'
+    type='result'>
+  <query xmlns='http://jabber.org/protocol/disco#info'>
+    <feature var='urn:xmpp:mix:account:0'/>
+  </query>
+</iq>
+]]></example>
+    
+  </section2>
+#
   <section2 topic="MIX Management and Discovery" anchor="user-server-disco">
     <p>
       Most interaction between  a MIX client and a MIX channel is directly between the client and the channel. The participant's server relays the message but does not modify the messages.   In particular configuration management and discovery is direct.   Interaction will be direct, unless explicitly stated otherwise.

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -2530,7 +2530,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </section2>
 
   <section2 topic="MIX Roster Item Capability Sharing" anchor="mix-roster-capability-sharing">
-    <p>It is useful for a MIX client to know which roster members are MIX channels, as this will facilitate convenient presentation of subscribed MIX channels to the user.  A MIX client MAY request that the server return this additional information that annotates roster elements with MIX capability. The server MUST return the additional information. The request is made by extending the standard roster get request by adding a child element &lt;annotate/&gt; to the &lt;query/&gt; element.  The &lt;mix-info-request/&gt; is qualified by the ‘urn:xmpp:mix:roster:0' namespace.</p>
+    <p>It is useful for a MIX client to know which roster members are MIX channels, as this will facilitate convenient presentation of subscribed MIX channels to the user.  A MIX client MAY request that the server return this additional information that annotates roster elements with MIX capability. The server MUST return the additional information. The request is made by extending the standard roster get request by adding a child element &lt;annotate/&gt; to the &lt;query/&gt; element.  The &lt;annotate/&gt; element is qualified by the ‘urn:xmpp:mix:roster:0' namespace.</p>
     <example caption="Roster Get Requesting MIX Information"><![CDATA[
 <iq from='juliet@example.com/balcony'
           id='bv1bs71f'

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -43,6 +43,7 @@
     <remark><p>
       Remove Legacy MIX Namespace;
       Add mix element in message to hold MIX additional information;
+      Roster Update Clarifications;
     </p></remark>
   </revision>
   <revision>
@@ -2519,22 +2520,23 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </section2>
 
   <section2 topic="MIX Roster Item Capability Sharing" anchor="mix-roster-capability-sharing">
-    <p>It will be useful for a MIX client to know which roster members are MIX channels, as this will facilitate convenient presentation of subscribed MIX channels to the user. A standard roster item is encoded as follows.</p>
+    <p>It is useful for a MIX client to know which roster members are MIX channels, as this will facilitate convenient presentation of subscribed MIX channels to the user. A standard roster item is encoded as follows.</p>
     <example caption="Standard Roster Item Encoding"><![CDATA[
 <item jid='romeo@example.net'/>
 ]]></example>
 
     <p>
-      MIX channels in the roster have an attribute 'channel' set to true.
+      MIX channels in the roster have an empty element 'channel' included in the roster item.
     </p>
 
     <example caption="Roster Item Encoding of a MIX Channel"><![CDATA[
-  <item jid='romeo@example.net'>
+  <item jid='balcony@example.net'>
       <channel xmlns=‘urn:xmpp:mix:0'/>
   </item>
 ]]></example>
 
     <p>
+      A server following the MIX specification MUST determine whether or not a client supports MIX.   The server will often have this information prior to the roster request, due to &xep0115; Entity Capabilities.   If the server does not have this information it MUST use service discovery to determine it before providing roster information.
       When sending roster information to a client that advertises MIX capability, the server MUST return all MIX channels and MUST use this encoding.  Presence  of MIX roster items MUST be set to offline (unavailable).
     </p>
 
@@ -2542,6 +2544,9 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       Where a client does not advertise MIX capability, the server MAY choose to not return MIX channels as roster items.   If this is done care needs to be taken, in particular around support of roster versioning  &xep0237;.
     </p>
 
+    <p>
+      When a server determines that a client has added or removed MIX capability, the entire roster MUST be sent and roster version reset.   This is not a particularly efficient approach, but this is expected to be a rare event and so a simple approach is preferred.
+    </p>
   </section2>
 
   <section2 topic="MAM Archive Support" anchor="proxy-mam">

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -42,6 +42,7 @@
     <initials>sek</initials>
     <remark><p>
       Remove Legacy MIX Namespace;
+      Add mix element in message to hold MIX additional information;
     </p></remark>
   </revision>
   <revision>
@@ -1652,8 +1653,15 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <body>Harpier cries: 'tis time, 'tis time.</body>
 </message>
 ]]></example>
+      <p>
+        The MIX channel then adds information to the message using a &lt;mix&gt; element.   This element contains two elements:
+      </p>
+      <ol>
+        <li>A &lt;nick&gt; element that contains the Nick of the message sender, taken from the Participants Node.</li>
+        <li>A &lt;jid&gt; element containing the full proxy JID of the sender.</li>
+      </ol>
       <p>The MIX channel then puts a copy of the message into the MAM archive for the channel and sends a copy of  the message to each participant in
-        standard groupchat format.    These messages sent by the channel are addressed to the bare JID of each participant and this will be handled by the participant's local server.  The message from value is the JID of the channel.  To enable sender identification, the Nick and bare proxy JID of the sender are included in the message as MIX parameters.   The id of the message is the ID from the MAM archive and NOT the id used by the sender. The message placed in the MAM archive is the reflected message without a 'to' element.</p>
+        standard groupchat format.    These messages sent by the channel are addressed to the bare JID of each participant and this will be handled by the participant's local server.  The message from value is the JID of the channel.   The id of the message is the ID from the MAM archive and NOT the id used by the sender. The message placed in the MAM archive is the reflected message without a 'to' element.</p>
       
       
       <example caption="Channel Puts Message in MAM Archive"><![CDATA[
@@ -1661,8 +1669,10 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
          id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
          type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
-  <nick xmlns='urn:xmpp:mix:0'>thirdwitch</nick>
-  <jid xmlns='urn:xmpp:mix:0'>123456#coven@mix.shakespeare.example</jid>
+  <mix xmlns='urn:xmpp:mix:0'>
+        <nick>thirdwitch</nick>
+        <jid>123456#coven@mix.shakespeare.example</jid>
+  </mix>
 </message>
 ]]></example>
 
@@ -1672,12 +1682,14 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
          id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
          type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
-  <nick xmlns='urn:xmpp:mix:0'>thirdwitch</nick>
-  <jid xmlns='urn:xmpp:mix:0'>123456#coven@mix.shakespeare.example</jid>
+  <mix xmlns='urn:xmpp:mix:0'>
+        <nick>thirdwitch</nick>
+        <jid>123456#coven@mix.shakespeare.example</jid>
+  </mix>
 </message>
 ]]></example>
       <p>
-        The messages sent to participants have a different message id to the originally submitted message.  This does not impact most recipients, but it does not allow the message originator to correlate the message with the submitted message.   To address this the MIX channel MUST include an additional element of the message copy going back to the originator's bare JID that includes the original id.  This enables the originator to correlate the received message with the message submitted.
+        The messages sent to participants have a different message id to the originally submitted message.  This does not impact most recipients, but it does not allow the message originator to correlate the message with the submitted message.   To address this the MIX channel MUST include an additional &lt;submission-id&gt; element in the &lt;mix&gt; element of the message copy going back to the originator's bare JID.  The &lt;submission-id&gt; element holds the original id provided by the sender.  This enables the originator to correlate the received message with the message submitted.
       </p>
       <example caption="Channel Reflects Message back to Originator"><![CDATA[
 <message from='coven@mix.shakespeare.example'
@@ -1685,9 +1697,11 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
          id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
          type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
-  <nick xmlns='urn:xmpp:mix:0'>thirdwitch</nick>
-  <jid xmlns='urn:xmpp:mix:0'>123456#coven@mix.shakespeare.example</jid>
-  <submission-id xmlns='urn:xmpp:mix:0'>92vax143g</submission-id>
+ <mix xmlns='urn:xmpp:mix:0'>
+        <nick>thirdwitch</nick>
+        <jid>123456#coven@mix.shakespeare.example</jid>
+        <submission-id>92vax143g</submission-id>
+  </mix>
 </message>
 ]]></example>
     </section3>
@@ -2399,8 +2413,10 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
          id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
          type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
-  <nick xmlns='urn:xmpp:mix:0'>thirdwitch</nick>
-  <jid xmlns='urn:xmpp:mix:0'>123456#coven@mix.shakespeare.example</jid>
+  <mix xmlns='urn:xmpp:mix:0'>
+        <nick>thirdwitch</nick>
+        <jid>123456#coven@mix.shakespeare.example</jid>
+  </mix>
 </message>
 ]]></example>
 
@@ -2414,8 +2430,10 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
          id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
          type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
-  <nick xmlns='urn:xmpp:mix:0'>thirdwitch</nick>
-  <jid xmlns='urn:xmpp:mix:0'>123456#coven@mix.shakespeare.example</jid>
+  <mix xmlns='urn:xmpp:mix:0'>
+        <nick>thirdwitch</nick>
+        <jid>123456#coven@mix.shakespeare.example</jid>
+  </mix>
 </message>
 
 <message from='coven@mix.shakespeare.example'
@@ -2423,8 +2441,10 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
          id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
          type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
-  <nick xmlns='urn:xmpp:mix:0'>thirdwitch</nick>
-  <jid xmlns='urn:xmpp:mix:0'>123456#coven@mix.shakespeare.example</jid>
+   <mix xmlns='urn:xmpp:mix:0'>
+        <nick>thirdwitch</nick>
+        <jid>123456#coven@mix.shakespeare.example</jid>
+  </mix>
 </message>
 
 ]]></example>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -500,7 +500,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     </section3>
 
     <section3 topic="Participants Node" anchor="participants-node">
-      <p>Each channel participant is represented as an item of the 'urn:xmpp:mix:nodes:participants' channel node.  Each item is named by the bare proxy JID of the participant. For example '123456#coven@mix.shakespeare.example' might name the node item associated with participant 'hag66@shakespeare.example'.  Information is stored in a &lt;participant/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.   The nick associated with the user is mandatory and is stored in a &lt;nick/&gt; sub-element of the &lt;participant/&gt; element.   The nick for each channel participant MUST be different to the nick of other participants.
+      <p>Each channel participant is represented as an item of the 'urn:xmpp:mix:nodes:participants' channel node.  Each item is named by the bare proxy JID of the participant. For example '123456#coven@mix.shakespeare.example' might name the node item associated with participant 'hag66@shakespeare.example'.  Information is stored in a &lt;participant/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.   The nick associated with the user is mandatory and is stored in a &lt;nick/&gt; child element of the &lt;participant/&gt; element.   The nick for each channel participant MUST be different to the nick of other participants.
       </p>
       <p>
         When a user joins a channel, the user's bare JID is added to the participants node by the MIX service.   When a user leaves a channel, they are removed from the participants node.  The participants node MUST NOT be directly modified using pubsub.
@@ -523,7 +523,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
       <p>The JID Map node is used to associate a proxy bare JID to its corresponding real bare JID.  The JID Map node MUST have one entry for each entry in the Participants node.  This value is added when a user joins the channel and is removed when the user leaves the channel.
        Each item is identified by proxy bare JID, mapping to the real bare JID.  This node is used to give administrator access to real JIDs and participant access to real JIDs in jid-visible channels.  This node MUST NOT be modified directly using pubsub.
-       In JID Visible channels, all participants MAY subscribe to this node.  In JID Hidden and JID Maybe Visible channels, only administrators can subscribe.   The JID Map node is a permanent node with one item per participant. Information is stored in a &lt;participant/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.  The real JID is stored in a &lt;jid/&gt; sub-element of the &lt;participant/&gt; element.  </p>
+       In JID Visible channels, all participants MAY subscribe to this node.  In JID Hidden and JID Maybe Visible channels, only administrators can subscribe.   The JID Map node is a permanent node with one item per participant. Information is stored in a &lt;participant/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.  The real JID is stored in a &lt;jid/&gt; child element of the &lt;participant/&gt; element.  </p>
       <example caption="Value of JID Map Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:jidmap'>
   <item id='123456#coven@mix.shakespeare.example'>
@@ -956,7 +956,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 <section1 topic='Use Cases' anchor='usecases'>
   <section2 topic='Common User Use Cases' anchor='usecases-user'>
     <section3 topic='Joining a Channel' anchor='usecase-user-join'>
-      <p>A user joins a channel by sending a MIX "join" command. There is no default set of nodes, so the user MUST specify the set of nodes to be subscribed to. To achieve the equivalent service to MUC, a user would subscribe to messages, and presence. The &lt;join/&gt; is a sub-element of &lt;iq/&gt; qualified by the 'urn:xmpp:mix:0' namespace.  The channel is specified by a 'channel' attribute in the &lt;join/&gt; element.  The requested nodes are encoded as &lt;subscribe/&gt; sub-elements of the &lt;join/&gt; element.
+      <p>A user joins a channel by sending a MIX "join" command. There is no default set of nodes, so the user MUST specify the set of nodes to be subscribed to. To achieve the equivalent service to MUC, a user would subscribe to messages, and presence. The &lt;join/&gt; is a child element of &lt;iq/&gt; element.  The &lt;join/&gt; element is qualified by the 'urn:xmpp:mix:0' namespace.  The channel is specified by a 'channel' attribute in the &lt;join/&gt; element.  The requested nodes are encoded as &lt;subscribe/&gt; child elements of the &lt;join/&gt; element.
          The join leads to the server subscribing the user to each of the requested nodes associated with the channel. The MIX service will also add the user to the participant list by injecting a new item into the "urn:xmpp:mix:nodes:participants" node automatically.
 
       </p>
@@ -1068,7 +1068,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         At the same time the participant MUST be added to the JID Map node, to map from proxy JID to real JID.   For a JID Maybe Visible channel, the participant MUST be added to the JID Maybe Visible Map node.    The value in this node MUST reflect the user's visibility preference for the channel and MUST be updated to reflect any changes to this preference.
       </p>
       <p>
-        A user MAY subsequently modify subscription to nodes in a channel by sending a subscription modification request encoded as a &lt;update-subscription/$gt;  sub-element of &lt;iq/&gt; qualified by the 'urn:xmpp:mix:0' namespace.  The requested notes are encoded as &lt;subscribe/&gt; sub-elements of the &lt;update-subscription/$gt; element with the node name encoded as a 'node' attribute.  This modification goes directly from client to MIX channel, as this change does not impact the roster and so does not need any local action.  The following example shows subscription modification.
+        A user MAY subsequently modify subscription to nodes in a channel by sending a subscription modification request encoded as a &lt;update-subscription/$gt;  child element of &lt;iq/&gt; element. The &lt;update-subscription/$gt; element is qualified by the 'urn:xmpp:mix:0' namespace.  The requested notes are encoded as &lt;subscribe/&gt; child elements of the &lt;update-subscription/$gt; element with the node name encoded as a 'node' attribute.  This modification goes directly from client to MIX channel, as this change does not impact the roster and so does not need any local action.  The following example shows subscription modification.
       </p>
       <example caption="User Modifies Subscription Request"><![CDATA[
 <iq type='set'
@@ -1180,7 +1180,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </join>
 </iq>
 ]]></example>
-     <p>The client MAY also query the channel in order to find out which user preferences are supported and the options available.  This will allow users to set options not specified in the standard, by providing a form template in the result.  The request is encoded as a &lt;user-preference/&gt; sub-element of &lt;iq/&gt; qualified by the 'urn:xmpp:mix:0' namespace.  The result is encoded as a form sub-element in the &lt;user-preference/&gt; element.</p>
+     <p>The client MAY also query the channel in order to find out which user preferences are supported and the options available.  This will allow users to set options not specified in the standard, by providing a form template in the result.  The request is encoded as a &lt;user-preference/&gt; child element of &lt;iq/&gt;.  &lt;user-preference/&gt; is qualified by the 'urn:xmpp:mix:0' namespace.  The result is encoded as a form child element in the &lt;user-preference/&gt; element.</p>
      <example caption="User Requests and Recieves Preferences Template Form"><![CDATA[
 <iq type='get'
     from='hag66@shakespeare.example/UUID-a1j/7533'
@@ -1265,7 +1265,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
    </section3>
 
     <section3 topic='Leaving a Channel' anchor='usecase-user-leaving'>
-      <p>Users generally remain in a channel for an extended period of time.  In particular the user remains as a participant the channel when the user goes offline.  Note that this is different to  &xep0045;, where the client leaves a room when going offline. So, leaving a MIX channel is a permanent action for a user across all clients.  In order to  leave a channel, a user sends a MIX "leave" command to the channel.  The leave command is encoded as a &lt;leave/&gt; sub-element of &lt;iq/&gt; element qualified by the 'urn:xmpp:mix:0' namespace, with the channel specified as a 'channel" attribute.  When a user leaves the channel, the user's server will remove the channel from the user's roster.   Leave commands are sent indirectly through the user's server, to enable roster removal.   Leaving is initiated by a client request, as shown in the following example.</p>
+      <p>Users generally remain in a channel for an extended period of time.  In particular the user remains as a participant the channel when the user goes offline.  Note that this is different to  &xep0045;, where the client leaves a room when going offline. So, leaving a MIX channel is a permanent action for a user across all clients.  In order to  leave a channel, a user sends a MIX "leave" command to the channel.  The leave command is encoded as a &lt;leave/&gt; child element of &lt;iq/&gt; element.  The &lt;leave/&gt; element is qualified by the 'urn:xmpp:mix:0' namespace, with the channel specified as a 'channel" attribute.  When a user leaves the channel, the user's server will remove the channel from the user's roster.   Leave commands are sent indirectly through the user's server, to enable roster removal.   Leaving is initiated by a client request, as shown in the following example.</p>
 
 
       <example caption="Client Requests to Leave a Channel"><![CDATA[
@@ -1355,7 +1355,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <li>The MIX service generates the nick.  In this case it is RECOMMENDED that the assigned nick is a UUID following &rfc4122;.</li>
     </ol>
     <p>
-      A user will typically set a nick when joining a channel and MAY update this nick from time to time.   The user does this by sending a command to the channel to set the nick.  This command is a &lt;setnick/&gt; sub-element of &lt;iq/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.   The nick is encoded as a &lt;nick/&gt; sub-element of the &lt;setnick/&gt; element. If the user wishes the channel to assign a nick (or knows that the channel will assign a nick) the nick field can be left blank, so that the user can see what is assigned in the result.
+      A user will typically set a nick when joining a channel and MAY update this nick from time to time.   The user does this by sending a command to the channel to set the nick.  This command is a &lt;setnick/&gt; child element of &lt;iq/&gt; element. The &lt;setnick/&gt; element is qualified by the 'urn:xmpp:mix:0' namespace.   The nick is encoded as a &lt;nick/&gt; child element of the &lt;setnick/&gt; element. If the user wishes the channel to assign a nick (or knows that the channel will assign a nick) the nick field can be left blank, so that the user can see what is assigned in the result.
     </p>
     <example caption="User sets Nick on Channel"><![CDATA[
 <iq type='set'
@@ -1412,7 +1412,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </p>
       <p>
         To register a nick with the MIX service the user sends
-        a register command to the service. This is encoded as a &lt;register/&gt; sub-element of an &lt;iq/&gt; element qualified by the urn:xmpp:mix:0' namespace.  The nick is encoded in a &lt;nick/&gt; sub-element of the &lt;register/&gt; element. </p>
+        a register command to the service. This is encoded as a &lt;register/&gt; child element of an &lt;iq/&gt; element. The &lt;register/&gt; element is  qualified by the urn:xmpp:mix:0' namespace.  The nick is encoded in a &lt;nick/&gt; child element of the &lt;register/&gt; element. </p>
       <example caption="User Registers with Service"><![CDATA[
 <iq type='set'
     from='hag66@shakespeare.example/UUID-a1j/7533'
@@ -1658,7 +1658,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 </message>
 ]]></example>
       <p>
-        The MIX channel then adds information to the message using a &lt;mix&gt; element qualified by the 'urn:xmpp:mix:0' namespace.   This element contains two sub-elements:
+        The MIX channel then adds information to the message using a &lt;mix&gt; element qualified by the 'urn:xmpp:mix:0' namespace.   This element contains two child elements:
       </p>
       <ol>
         <li>A &lt;nick&gt; element that contains the Nick of the message sender, taken from the Participants Node.</li>
@@ -1769,7 +1769,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         <li>The invitee MAY send a response to the inviter, indicating if the invitation was accepted or declined.</li>
       </ol>
       <p>
-        The first step is for the inviter to request an invitation from the channel.   The invitation contains inviter, invitee and a token.  The channel will evaluate if the inviter has rights to issue the invitation.   This will be because the inviter is a channel administrator or if the inviter is a channel participant and the channel allows invitation by participants.  If the inviter has rights to make the invitation, the channel will return a token.  The token is a string that the channel can subsequently use to validate an invitation.   The format of the token is not specified in this standard.   The encoded token MAY reflect a validity time.  The invitation request is encoded as an &lt;invite/&gt; sub-element of an &lt;iq/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.  &lt;invite/&gt; contains an &lt;invitation/&gt; sub-element, which contain &lt;inviter/&gt;, &lt;invitee/&gt;, &lt;channel/&gt; and &lt;token/&gt; sub-elements.
+        The first step is for the inviter to request an invitation from the channel.   The invitation contains inviter, invitee and a token.  The channel will evaluate if the inviter has rights to issue the invitation.   This will be because the inviter is a channel administrator or if the inviter is a channel participant and the channel allows invitation by participants.  If the inviter has rights to make the invitation, the channel will return a token.  The token is a string that the channel can subsequently use to validate an invitation.   The format of the token is not specified in this standard.   The encoded token MAY reflect a validity time.  The invitation request is encoded as an &lt;invite/&gt; child element of an &lt;iq/&gt; element. The &lt;invite/&gt; element is qualified by the 'urn:xmpp:mix:0' namespace.  &lt;invite/&gt; contains an &lt;invitation/&gt; child element, which contain &lt;inviter/&gt;, &lt;invitee/&gt;, &lt;channel/&gt; and &lt;token/&gt; child elements.
       </p>
       <example caption='Inviter Requests and Receives Invitation'><![CDATA[
 <iq from='hag66@shakespeare.lit/UUID-h5z/0253'
@@ -1812,7 +1812,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
    </invitation>
 </iq>
 ]]></example>
-  <p>The invitation can now be used by the invitee to join a channel. The &lt;invitation/&gt; sub-element is simply added to the standard channel &lt;join/&gt; element, so that the channel can validate the invitation using the token. If the allowed node is present and the invitee is not matched against any item, the channel MUST add the invitee to the allowed node as part of the join.</p>
+  <p>The invitation can now be used by the invitee to join a channel. The &lt;invitation/&gt; child element is simply added to the standard channel &lt;join/&gt; element, so that the channel can validate the invitation using the token. If the allowed node is present and the invitee is not matched against any item, the channel MUST add the invitee to the allowed node as part of the join.</p>
       <example caption="User Joins a Channel with an Invitation"><![CDATA[
 <iq type='set'
     from='cat@shakespeare.example'
@@ -1830,7 +1830,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 </iq>
 ]]></example>
       <p>The invitee MAY send an acknowledgement back to the inviter, noting the status of the invitation. 
-        This is encoded as an &lt;invitation-ack/&gt; sub-element of &lt;message/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.   The &lt;invitation-ack/&gt; has an &lt;invitation/&gt; sub-element that encodes the invitation being acknowledged and a &lt;value/&gt; sub-element to encode the acknowledgement value.
+        This is encoded as an &lt;invitation-ack/&gt; child element of &lt;message/&gt; element.  The &lt;invitation-ack/&gt; element is qualified by the 'urn:xmpp:mix:0' namespace.   The &lt;invitation-ack/&gt; has an &lt;invitation/&gt; child element that encodes the invitation being acknowledged and a &lt;value/&gt; child element to encode the acknowledgement value.
         &lt;value/&gt; has the following values:</p>
       <ul>
         <li>'Joined': The invitee has joined the channel.</li>
@@ -1949,7 +1949,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       It is important that messages are all transferred from the MIX channel to the server associated with the each channel participant.   Transfer between servers will typically happen quickly and &xep0198; will deal with short connection failures between servers.   Longer connection failures could lead to message loss.  This would lead to online users (who remain connected to their servers) missing messages, and to messages being missed out of the user archive.  This section describes how MIX addresses this.
     </p>
     <p>
-      When there is a long term connection failure, the MIX channel will receive an error from the XMPP server indicating that a message failed to transfer to a recipient.   When this happens, the MIX channel MUST take responsibility to ensure that the message is retransmitted and delivered.   When the MIX channel detects a failure it will make use of an IQ Marker message to determine when the connection to the peer server is working again.  Once the channel has received a response to the marker IQ it will retransmit the pending messages.  The marker is encoded as a &lt;marker/&gt; sub-element of an &lt;iq/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.
+      When there is a long term connection failure, the MIX channel will receive an error from the XMPP server indicating that a message failed to transfer to a recipient.   When this happens, the MIX channel MUST take responsibility to ensure that the message is retransmitted and delivered.   When the MIX channel detects a failure it will make use of an IQ Marker message to determine when the connection to the peer server is working again.  Once the channel has received a response to the marker IQ it will retransmit the pending messages.  The marker is encoded as a &lt;marker/&gt; child element of an &lt;iq/&gt; element. The &lt;marker/&gt; element is qualified by the 'urn:xmpp:mix:0' namespace.
     </p>
     <example caption="Channel Sends Marker Message" ><![CDATA[
  <iq from='coven@mix.shakespeare.example'
@@ -2027,7 +2027,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     </section3>
     <section3 topic='Creating a Channel' anchor='usecase-admin-create'>
       <p>
-        A client creates a channel by sending a simple request to the MIX service.   A channel MAY be created with default parameters, as shown in the following example.   The result MUST include the name of the channel which MUST match the channel name in the request (if present).  The create is encoded as a &lt;create/&gt; sub-element of &lt;iq/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.   The &lt;create/&gt; element MUST have a 'channel' attribute to specify the channel name.
+        A client creates a channel by sending a simple request to the MIX service.   A channel MAY be created with default parameters, as shown in the following example.   The result MUST include the name of the channel which MUST match the channel name in the request (if present).  The create is encoded as a &lt;create/&gt; child element of &lt;iq/&gt; element.   The &lt;create/&gt; is qualified by the 'urn:xmpp:mix:0' namespace.   The &lt;create/&gt; element MUST have a 'channel' attribute to specify the channel name.
       </p>
         <example caption="Creating a Channel with Default Parameters" ><![CDATA[
 <iq from='hag66@shakespeare.example/UUID-a1j/7533'
@@ -2137,7 +2137,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         MIX channels are always explicitly destroyed by an owner of the channel or by a server operator. There is no concept of temporary channel, equivalent to &xep0045; temporary room which is automatically destroyed by the server when the users leave.   However, channels MAY be configured with an explicit lifetime, after which the channel MUST be removed by the MIX service.   Where a channel is created for ad hoc use, it MAY be desirable to keep the channel for history reference or for re-use by the same set of users.  Note that the owner of the channel does not need to have presence registered in the channel in order to destroy it.
      </p>
       <p>
-        The destroy operation is encoded as a &lt;destroy/&gt; sub-element of an &lt;iq/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.  The &lt;destroy/&gt; element MUST have a 'channel' attribute to specify the channel to be destroyed.
+        The destroy operation is encoded as a &lt;destroy/&gt; child element of an &lt;iq/&gt; element.  The &lt;destroy/&gt; element is qualified by the 'urn:xmpp:mix:0' namespace.  The &lt;destroy/&gt; element MUST have a 'channel' attribute to specify the channel to be destroyed.
         A client destroys a channel using a simple set operation, as shown in the following example.
       </p>
       <example caption="Client Destroys a Channel" ><![CDATA[
@@ -2528,7 +2528,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </section2>
 
   <section2 topic="MIX Roster Item Capability Sharing" anchor="mix-roster-capability-sharing">
-    <p>It is useful for a MIX client to know which roster members are MIX channels, as this will facilitate convenient presentation of subscribed MIX channels to the user.  A MIX client MAY request that the server return this additional information. The server MUST return the additional information. The request is made by extending the standard roster get request by adding a sub-element &lt;mix-info-request/&gt; to the &lt;query/&gt; element qualified by the ‘urn:xmpp:mix:0' namespace.</p>
+    <p>It is useful for a MIX client to know which roster members are MIX channels, as this will facilitate convenient presentation of subscribed MIX channels to the user.  A MIX client MAY request that the server return this additional information. The server MUST return the additional information. The request is made by extending the standard roster get request by adding a child element &lt;mix-info-request/&gt; to the &lt;query/&gt; element.  The &lt;mix-info-request/&gt; is qualified by the ‘urn:xmpp:mix:0' namespace.</p>
     <example caption="Roster Get Requesting MIX Information"><![CDATA[
 <iq from='juliet@example.com/balcony'
           id='bv1bs71f'

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -1477,18 +1477,27 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       Presence status and availability is set in a MIX channel by standard presence stanzas sent to the MIX channel by the user's server.   Users wishing to receive presence updates will subscribe to the MIX channel presence node.   Presence updates are sent out to subscribing participants using standard presence stanzas.
       </p>
       <p>
-        A user setting status is now used as an example.   Unlike in &xep0045; where coming online is a special action, coming online in MIX is implicit when presence status is set.  Going offline is a achieved by setting presence status to unavailable, which removes the client full JID entry from the presence node.  When a user sets a presence status, the user's server sends updated presence to the MIX channel, and the MIX service then publishes the user's  availability to the "urn:xmpp:mix:nodes:presence" node. If there is not an item named by the full JID of the client with updated presence status, this item is created.</p>
-      <example caption="User Setting Presence Status">
-<![CDATA[<presence xmlns='jabber:client' from=‘hag66@shakespeare.example/UUID-a1j/7533’
+        A user setting status is now used as an example.   Unlike in &xep0045; where coming online is a special action, coming online in MIX is implicit when presence status is set.  Going offline is a achieved by setting presence status to unavailable, which removes the client full JID entry from the presence node.  When a user sets a presence status, the user's server sends updated presence to the MIX channel, and the MIX service then publishes the user's  availability to the "urn:xmpp:mix:nodes:presence" node. If there is not an item named by the full JID of the client with updated presence status, this item is created.   The sequence is shown in the following examples, starting with a client setting presences status on the connected server.</p>
+      <example caption="Client Sets Presence Status on Server">
+        <![CDATA[<presence xmlns='jabber:client' from=‘hag66@shakespeare.example/UUID-a1j/7533’>
+  <show>dnd</show>
+  <status>Making a Brew</status>
+</presence>]]></example>
+      
+      <p>
+        The server then sends the presence information to roster entries.  The following example then shows the presence message from the client's server to the MIX channel.
+      </p>
+      <example caption="Server sends Presence Status to MIX Channel">
+<![CDATA[<presence  from=‘hag66@shakespeare.example/UUID-a1j/7533’
               to='coven@mix.shakespeare.example'>
   <show>dnd</show>
   <status>Making a Brew</status>
 </presence>]]></example>
-      <p>The user's presence information is then published by the service to the "urn:xmpp:mix:nodes:presence" node, with the 'publisher' attribute set to the user's participant identifier (the proxy JID). The MIX channel then broadcasts the presence change to all users who are subscribed to the "urn:xmpp:mix:nodes:presence" node.  The presence stanza is sent from the full proxy JID of the user.
-      Note that presence is associated with a client and so will have a full JID as it comes directly from the client and not from the user's server.</p>
+      <p>The user's presence information is then published by the service to the "urn:xmpp:mix:nodes:presence" node, with the 'publisher' attribute set to the user's participant identifier (the proxy JID). The MIX channel then broadcasts the presence change to all users who are subscribed to the "urn:xmpp:mix:nodes:presence" node.  The presence stanza is sent from the full proxy JID of the client updating status.
+      Note that presence is associated with a client and so will have a full JID.  The following example shows a presence message as distributed by the server to a presences subscriber.</p>
       <example caption="Channel Distributes Presence">
         <![CDATA[<presence from='123435#coven@mix.shakespeare.example/678'
-          to='coven@mix.shakespeare.example'
+          to='hag99@shakespeare.example'
           id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'>
   <nick xmlns='http://jabber.org/protocol/nick'>thirdwitch</nick>
   <show>dnd</show>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -38,7 +38,7 @@
   &stpeter;
   <revision>
     <version>0.9.3</version>
-    <date>2017-06-13</date>
+    <date>2017-06-15</date>
     <initials>sek</initials>
     <remark><p>
       Remove Legacy MIX Namespace;
@@ -2423,7 +2423,8 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
 
   <p>
-    The server receiving the message will then deliver the messages to all online clients with status available and a non-negative resource priority.
+    The server receiving the message will then deliver the messages to all online clients.   Messages are delivered to all available online resources irrespective of 
+    status  and resource priority.
     The following example shows how the participant's server modifies the inbound message to replace the bare JID in the 'to' with a full JID for each of two active MIX clients.
   </p>
 

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -38,7 +38,7 @@
   &stpeter;
   <revision>
     <version>0.9.3</version>
-    <date>2017-06-15</date>
+    <date>2017-06-16</date>
     <initials>sek</initials>
     <remark><p>
       Remove Legacy MIX Namespace;
@@ -47,6 +47,7 @@
       Clarify when messages are delivered to clients;
       Extend Roster Get to select format;
       Ensure that text defining attributes and elements reference the namespace;
+      Change mix_nick_register to nick-register;
     </p></remark>
   </revision>
   <revision>
@@ -1403,12 +1404,12 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='mix.shakespeare.example'
     id='7nve413p'>
     <query xmlns='http://jabber.org/protocol/disco#info'/>
-        <feature var='urn:xmpp:mix:0#mix_nick_register'/>
+        <feature var='urn:xmpp:mix:0#nick-register'/>
     </query>
 </iq>
 ]]></example>
       <p>
-        The response will be a list of features of the MIX channel.  If Nick Registration is supported, then the result set will include &lt;feature var="urn:xmpp:mix:0#mix_nick_register"/&gt;.
+        The response will be a list of features of the MIX channel.  If Nick Registration is supported, then the result set will include &lt;feature var="urn:xmpp:mix:0#nick-register"/&gt;.
       </p>
       <p>
         To register a nick with the MIX service the user sends

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -1665,7 +1665,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         <li>A &lt;jid&gt; element containing the full proxy JID of the sender.</li>
       </ol>
       <p>The MIX channel then puts a copy of the message into the MAM archive for the channel and sends a copy of  the message to each participant in
-        standard groupchat format.    These messages sent by the channel are addressed to the bare JID of each participant and this will be handled by the participant's local server.  The message from value is the JID of the channel.   The id of the message is the ID from the MAM archive and NOT the id used by the sender. The message placed in the MAM archive is the reflected message without a 'to' element.</p>
+        standard groupchat format.    These messages sent by the channel are addressed to the bare JID of each participant and this will be handled by the participant's local server.  The message 'from' attribute is the JID of the channel.   The id of the message is the ID from the MAM archive and NOT the id used by the sender. The message placed in the MAM archive is the reflected message without a 'to' attribute.</p>
       
       
       <example caption="Channel Puts Message in MAM Archive"><![CDATA[

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -51,6 +51,7 @@
       Separate namespace for roster information;
       rename jidmap2 to jidmap-visible;
       Namespace bump to mix:1;
+      Correct from in response of join/leave IQs;
     </p></remark>
   </revision>
   <revision>
@@ -1023,7 +1024,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
       <example caption="User's Server sends response to Client"><![CDATA[
 <iq type='result'
-    from='coven@mix.shakespeare.example'
+    from='hag66@shakespeare.example'
     to='hag66@shakespeare.example/UUID-a1j/7533'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <join xmlns='urn:xmpp:mix:1' jid='123456#coven@mix.shakespeare.example'>
@@ -1314,7 +1315,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
       <example caption="User's Server Confirms Leave to Client"><![CDATA[
 <iq type='result'
-    from='coven@mix.shakespeare.example'
+    from='hag66@shakespeare.example'
     to='hag66@shakespeare.example/UUID-a1j/7533'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <leave xmlns='urn:xmpp:mix:1'/>
@@ -2713,7 +2714,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 </section1>
 
 <section1 topic='Acknowledgements' anchor='ack'>
-  <p>Thanks to the following who have made contributions: Dave Cridland, Philipp Hancke, Waqas Hussain, Timothée Jaussoin, Evgeny Khramtsov, Georg Lukas, Tobias Markmann, Ralph Meijer, Edwin Mons, Emmanuel Gil Peyrot, Florian Schmaus, Lance Stout, Sam Whited, Jonas Wielicki, Matthew Wild and one anonymous reviewer.</p>
+  <p>Thanks to the following who have made contributions: Dave Cridland, Tarun Gupta, Philipp Hancke, Waqas Hussain, Timothée Jaussoin, Evgeny Khramtsov, Georg Lukas, Tobias Markmann, Ralph Meijer, Edwin Mons, Emmanuel Gil Peyrot, Florian Schmaus, Lance Stout, Sam Whited, Jonas Wielicki, Matthew Wild and one anonymous reviewer.</p>
 </section1>
 
 </xep>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -38,7 +38,7 @@
   &stpeter;
   <revision>
     <version>0.9.3</version>
-    <date>2017-06-20</date>
+    <date>2017-07-18</date>
     <initials>sek</initials>
     <remark><p>
       Remove Legacy MIX Namespace;
@@ -701,7 +701,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
 <section1 topic="Error Handling" anchor="error-handling">
   <p>
-    The MIX specification is built on layered services that have defined errors.  This enables the core MIX specification to reflect primarily the successful use case, as in almost all cases the error reporting of the layer service provides what is needed.   A message sender MUST be prepared to handle any valid error from the layer services.   When a message receiver encounters an error situation, it MUST use the most appropriate layer server error to report this issue back to the sender.   For example a message receiver might use the "not authorized" IQ error in response to a MIX disco that is not authorized.   Errors for the following layer services need to be handled for MIX:
+    The MIX specification is built on layered services that have defined errors.  This enables the core MIX specification to reflect primarily the successful use case, as in almost all cases the error reporting of the layer service provides what is needed.   A message sender MUST be prepared to handle any valid error from the layer services.   When a message receiver encounters an error situation, it MUST use the most appropriate layer server error to report this issue back to the sender.   For example a  receiving entity might use the "not authorized"  error in response to a  disco query that is not authorized.   Errors for the following layer services need to be handled for MIX:
   </p>
   <ol>
     <li>IQ.  All of the IQ errors of &rfc6120; MUST be supported.</li>
@@ -1374,7 +1374,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
 
     <p>
-      The channel will return the nick that is to be used, noting that this MAY be different to the requested nick. MIX services SHOULD apply the "nickname" profile of the PRECIS OpaqueString class, as defined in &rfc7700;.
+      On successful nick assignment, the channel will return the nick that is to be used, noting that this MAY be different to the requested nick. MIX services SHOULD apply the "nickname" profile of the PRECIS OpaqueString class, as defined in &rfc7700;.  The channel MAY return a conflict error or other appropriate error.
     </p>
 
     <example caption="Channel informs user of Nick"><![CDATA[
@@ -1444,7 +1444,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </register>
 </iq>
 ]]></example>
-      <p>If the requested nick is already taken, the MIX service returns a &lt;conflict/&gt; error:</p>
+      <p>If the requested nick is already taken and the MIX service does not assign an alternate nick, the MIX service MUST return a &lt;conflict/&gt; error:</p>
       <example caption="Nick is Taken">
 <![CDATA[<iq type='error'
     to='mix.shakespeare.example'
@@ -1455,7 +1455,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </error>
 </iq>
 ]]></example>
-      <p>If the register request does not contain a &lt;nick/&gt; element, then the MIX service assigns one.  It is RECOMMENDED that the assigned nick is a UUID following &rfc4122;.
+      <p>If the register request does not contain a &lt;nick/&gt; element, then the MIX service MUST assign one.  It is RECOMMENDED that the assigned nick is a UUID following &rfc4122;.
 </p>
 
 
@@ -1717,13 +1717,20 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
     <section3 topic="Retracting a Message" anchor="usecase-retract">
       <p>
-        A MIX channel MAY support message retraction, where the sender of a messages or an authorized administrator deletes a message.   If this is done the original message MAY be replaced by a tombstone.  The protocol to request retraction does this by adding to the  message  a &lt;retract&gt; element qualified by the 'urn:xmpp:mix:1' namespace as shown in the following example.
+        A MIX channel MAY support message retraction, where the sender of a messages or an authorized administrator deletes a message.   If this is done the original message MAY be replaced by a tombstone.  The protocol to request retraction does this by adding to the  message  a &lt;retract&gt; element qualified by the 'urn:xmpp:mix:1' namespace.   The &lt;retract&gt; element MUST include an &lt;id&gt; attribute that holds the id of the original  message.  A message and it's retraction shown in the following example.
       </p>
       <example caption="User Retracts a Message"><![CDATA[
+        
+<message from='hag66@shakespeare.example/UUID-a1j/7533'
+         to='coven@mix.shakespeare.example'
+         id='abcde'>
+  <body> A Message I did not mean to send </body>
+</message>
+
 <message from='hag66@shakespeare.example/UUID-a1j/7533'
          to='coven@mix.shakespeare.example'
          id='92vax143g'>
-  <retract id='28482-98726-73623' xmlns='urn:xmpp:mix:1'/>
+  <retract id='abcde' xmlns='urn:xmpp:mix:1'/>
 </message>
 ]]></example>
       <p>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -2528,7 +2528,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
 
     <p>
-      MIX channels in the roster have an empty element 'channel' included in the roster item.
+      MIX channels in the roster have an element 'channel' included in the roster item.
     </p>
 
     <example caption="Roster Item Encoding of a MIX Channel"><![CDATA[
@@ -2538,7 +2538,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
 
     <p>
-      A server following the MIX specification MUST determine whether or not a client supports MIX.   The server will often have this information prior to the roster request, due to &xep0115; Entity Capabilities.   If the server does not have this information it MUST use service discovery to determine it before providing roster information.
+      A server following the MIX specification MUST determine whether or not a client supports MIX.     If the server does not have this information it MUST use service discovery to determine it before providing roster information.
       When sending roster information to a client that advertises MIX capability, the server MUST return all MIX channels and MUST use this encoding.  Presence  of MIX roster items MUST be set to offline (unavailable).
     </p>
 
@@ -2547,7 +2547,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     </p>
 
     <p>
-      When a server determines that a client has added or removed MIX capability, the entire roster MUST be sent and roster version reset.   This is not a particularly efficient approach, but this is expected to be a rare event and so a simple approach is preferred.
+      When a client adds MIX capability, additional information needs to be provided by the server.   To support this, a server MUST maintain information about client MIX support status.   When a server detects this change it needs to update the roster which it MAY do incrementally or by sending all of the roster.  
     </p>
   </section2>
 

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -50,6 +50,7 @@
       Change mix_nick_register to nick-register;
       Separate namespace for roster information;
       rename jidmap2 to jidmap-visible;
+      version bump to urn:xmpp:mix:1;
     </p></remark>
   </revision>
   <revision>
@@ -503,7 +504,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     </section3>
 
     <section3 topic="Participants Node" anchor="participants-node">
-      <p>Each channel participant is represented as an item of the 'urn:xmpp:mix:nodes:participants' channel node.  Each item is named by the bare proxy JID of the participant. For example '123456#coven@mix.shakespeare.example' might name the node item associated with participant 'hag66@shakespeare.example'.  Information is stored in a &lt;participant/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.   The nick associated with the user is mandatory and is stored in a &lt;nick/&gt; child element of the &lt;participant/&gt; element.   The nick for each channel participant MUST be different to the nick of other participants.
+      <p>Each channel participant is represented as an item of the 'urn:xmpp:mix:nodes:participants' channel node.  Each item is named by the bare proxy JID of the participant. For example '123456#coven@mix.shakespeare.example' might name the node item associated with participant 'hag66@shakespeare.example'.  Information is stored in a &lt;participant/&gt; element qualified by the 'urn:xmpp:mix:1' namespace.   The nick associated with the user is mandatory and is stored in a &lt;nick/&gt; child element of the &lt;participant/&gt; element.   The nick for each channel participant MUST be different to the nick of other participants.
       </p>
       <p>
         When a user joins a channel, the user's bare JID is added to the participants node by the MIX service.   When a user leaves a channel, they are removed from the participants node.  The participants node MUST NOT be directly modified using pubsub.
@@ -515,7 +516,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <example caption="Value of Participants Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:participants'>
   <item id='123456#coven@mix.shakespeare.example'>
-      <participant xmlns='urn:xmpp:mix:0'>
+      <participant xmlns='urn:xmpp:mix:1'>
          <nick>thirdwitch</nick>
       </participant>
   </item>
@@ -526,11 +527,11 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
       <p>The JID Map node is used to associate a proxy bare JID to its corresponding real bare JID.   It is a PubSub node with the 'node' attribute set to 'urn:xmpp:mix:nodes:jidmap'. The JID Map node MUST have one entry for each entry in the Participants node.  This value is added when a user joins the channel and is removed when the user leaves the channel.
        Each item is identified by proxy bare JID, mapping to the real bare JID.  This node is used to give administrator access to real JIDs and participant access to real JIDs in jid-visible channels.  This node MUST NOT be modified directly using pubsub.
-       In JID Visible channels, all participants MAY subscribe to this node.  In JID Hidden and JID Maybe Visible channels, only administrators can subscribe.   The JID Map node is a permanent node with one item per participant. Information is stored in a &lt;participant/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.  The real JID is stored in a &lt;jid/&gt; child element of the &lt;participant/&gt; element.  </p>
+       In JID Visible channels, all participants MAY subscribe to this node.  In JID Hidden and JID Maybe Visible channels, only administrators can subscribe.   The JID Map node is a permanent node with one item per participant. Information is stored in a &lt;participant/&gt; element qualified by the 'urn:xmpp:mix:1' namespace.  The real JID is stored in a &lt;jid/&gt; child element of the &lt;participant/&gt; element.  </p>
       <example caption="Value of JID Map Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:jidmap'>
   <item id='123456#coven@mix.shakespeare.example'>
-      <participant xmlns='urn:xmpp:mix:0'>
+      <participant xmlns='urn:xmpp:mix:1'>
          <jid>hecate@mix.shakespeare.example</jid>
       </participant>
   </item>
@@ -590,7 +591,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <item id='2016-05-30T09:00:00'>
       <x xmlns='jabber:x:data' type='result'>
         <field var='FORM_TYPE' type='hidden'>
-             <value>urn:xmpp:mix:0</value>
+             <value>urn:xmpp:mix:1</value>
         </field>
         <field var='Name'>
             <value>Witches Coven</value>
@@ -670,7 +671,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <item id='2016-05-30T09:00:00'>
       <x xmlns='jabber:x:data' type='result'>
         <field var='FORM_TYPE' type='hidden'>
-             <value>urn:xmpp:mix:0</value>
+             <value>urn:xmpp:mix:1</value>
         </field>
         <field var='Owner'>
             <value>hecate@shakespeare.lit</value>
@@ -742,7 +743,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>
 ]]></example>
-    <p>The MIX service then MUST return its identity and the features it supports, which MUST include the 'urn:xmpp:mix:0' feature, and the identity MUST have a category of 'conference' and a type of 'text', as shown in the following example: </p>
+    <p>The MIX service then MUST return its identity and the features it supports, which MUST include the 'urn:xmpp:mix:1' feature, and the identity MUST have a category of 'conference' and a type of 'text', as shown in the following example: </p>
     <example caption="Service responds with Disco Info result" ><![CDATA[
 <iq from='mix.shakespeare.example'
     id='lx09df27'
@@ -753,18 +754,18 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         category='conference'
         name='Shakespearean Chat Service'
         type='text'/>
-    <feature var='urn:xmpp:mix:0'/>
-    <feature var='urn:xmpp:mix:0#searchable'>
+    <feature var='urn:xmpp:mix:1'/>
+    <feature var='urn:xmpp:mix:1#searchable'>
   </query>
 </iq>
 ]]></example>
     <p>
-      A MIX service MUST return the 'urn:xmpp:mix:0' feature  and MAY return the other features listed here:
+      A MIX service MUST return the 'urn:xmpp:mix:1' feature  and MAY return the other features listed here:
      </p>
     <ul>
-      <li>'urn:xmpp:mix:0': This indicates support of MIX, and is returned by all MIX services.</li>
-      <li>'urn:xmpp:mix:0#searchable': This is shown in the above example and indicates that a the MIX Service MAY be searched for channels.   This presence of this feature can be used by a client to guide the user to search for channels in a MIX service.</li>
-      <li>'urn:xmpp:mix:0#create-channel': This is described in <link url='#usecase-admin-check-create'> Checking for Permission to Create a Channel</link> in support of channel administration.   When an end user client  needs to create channels, perhaps for short term usage, this feature helps the client to identify an MIX service to use.  It enables a configuration where permanent (searchable) channels are placed in one MIX service and clients will be able to create channels in another MIX service which is not searchable.</li>
+      <li>'urn:xmpp:mix:1': This indicates support of MIX, and is returned by all MIX services.</li>
+      <li>'urn:xmpp:mix:1#searchable': This is shown in the above example and indicates that a the MIX Service MAY be searched for channels.   This presence of this feature can be used by a client to guide the user to search for channels in a MIX service.</li>
+      <li>'urn:xmpp:mix:1#create-channel': This is described in <link url='#usecase-admin-check-create'> Checking for Permission to Create a Channel</link> in support of channel administration.   When an end user client  needs to create channels, perhaps for short term usage, this feature helps the client to identify an MIX service to use.  It enables a configuration where permanent (searchable) channels are placed in one MIX service and clients will be able to create channels in another MIX service which is not searchable.</li>
     </ul>
     <p>A MIX service MUST NOT advertise support for &xep0313;, as MAM is supported by the channels and not by the service.   A  MIX service MUST NOT advertise support for generic &xep0060;, as although MIX makes use of PubSub it is not a generic PubSub service.</p>
   </section2>
@@ -812,7 +813,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         category='conference'
         name='A Dark Cave'
         type='mix'/>
-    <feature var='urn:xmpp:mix:0'/>
+    <feature var='urn:xmpp:mix:1'/>
     <feature var='urn:xmpp:mam:1'/>
   </query>
 </iq>
@@ -866,10 +867,10 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <pubsub xlns='http://jabber.org/protocol/pubsub'>
       <items node='urn:xmpp:mix:nodes:info>>
          <item>
-           <item id='2016-05-30T09:00:00' xmlns='urn:xmpp:mix:0'>
+           <item id='2016-05-30T09:00:00' xmlns='urn:xmpp:mix:1'>
               <x xmlns='jabber:x:data' type='result'>
                  <field var='FORM_TYPE' type='hidden'>
-                     <value>urn:xmpp:mix:0</value>
+                     <value>urn:xmpp:mix:1</value>
                  </field>
                  <field var='Name'>
                      <value>Witches Coven</value>
@@ -909,12 +910,12 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
      <pubsub xlns='http://jabber.org/protocol/pubsub'>
           <items node='urn:xmpp:mix:nodes:participants'>
              <item id='123456#coven@mix.shakespeare.example'>
-                 <participant xmlns='urn:xmpp:mix:0'>
+                 <participant xmlns='urn:xmpp:mix:1'>
                       <nick>thirdwitch</nick>
                   </participant>
              </item>
               <item id='87123#coven@mix.shakespeare.example'>
-                 <participant xmlns='urn:xmpp:mix:0'>
+                 <participant xmlns='urn:xmpp:mix:1'>
                       <nick>top witch</nick>
                   </participant>
              </item>           
@@ -949,7 +950,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <feature var='http://jabber.org/protocol/disco#info'/>
     <feature var='http://jabber.org/protocol/disco#items'/>
     <feature var='http://jabber.org/protocol/muc'/>
-    <feature var='urn:xmpp:mix:0'/>
+    <feature var='urn:xmpp:mix:1'/>
   </query>
 </iq>
 ]]></example>
@@ -959,7 +960,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 <section1 topic='Use Cases' anchor='usecases'>
   <section2 topic='Common User Use Cases' anchor='usecases-user'>
     <section3 topic='Joining a Channel' anchor='usecase-user-join'>
-      <p>A user joins a channel by sending a MIX "join" command. There is no default set of nodes, so the user MUST specify the set of nodes to be subscribed to. To achieve the equivalent service to MUC, a user would subscribe to messages, and presence. The &lt;join/&gt; is a child element of &lt;iq/&gt; element.  The &lt;join/&gt; element is qualified by the 'urn:xmpp:mix:0' namespace.  The channel is specified by a 'channel' attribute in the &lt;join/&gt; element.  The requested nodes are encoded as &lt;subscribe/&gt; child elements of the &lt;join/&gt; element.
+      <p>A user joins a channel by sending a MIX "join" command. There is no default set of nodes, so the user MUST specify the set of nodes to be subscribed to. To achieve the equivalent service to MUC, a user would subscribe to messages, and presence. The &lt;join/&gt; is a child element of &lt;iq/&gt; element.  The &lt;join/&gt; element is qualified by the 'urn:xmpp:mix:1' namespace.  The channel is specified by a 'channel' attribute in the &lt;join/&gt; element.  The requested nodes are encoded as &lt;subscribe/&gt; child elements of the &lt;join/&gt; element.
          The join leads to the server subscribing the user to each of the requested nodes associated with the channel. The MIX service will also add the user to the participant list by injecting a new item into the "urn:xmpp:mix:nodes:participants" node automatically.
 
       </p>
@@ -975,7 +976,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='hag66@shakespeare.example/UUID-a1j/7533'
     to='hag66@shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <join xmlns='urn:xmpp:mix:0'
+  <join xmlns='urn:xmpp:mix:1'
          channel='coven@mix.shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
@@ -993,7 +994,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='hag66@shakespeare.example'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <join xmlns='urn:xmpp:mix:0'>
+  <join xmlns='urn:xmpp:mix:1'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
     <subscribe node='urn:xmpp:mix:nodes:participants'/>
@@ -1007,7 +1008,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='coven@mix.shakespeare.example'
     to='hag66@shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <join xmlns='urn:xmpp:mix:0' jid='123456#coven@mix.shakespeare.example'>
+  <join xmlns='urn:xmpp:mix:1' jid='123456#coven@mix.shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
     <subscribe node='urn:xmpp:mix:nodes:participants'/>
@@ -1025,7 +1026,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='coven@mix.shakespeare.example'
     to='hag66@shakespeare.example/UUID-a1j/7533'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <join xmlns='urn:xmpp:mix:0' jid='123456#coven@mix.shakespeare.example'>
+  <join xmlns='urn:xmpp:mix:1' jid='123456#coven@mix.shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
     <subscribe node='urn:xmpp:mix:nodes:participants'/>
@@ -1045,7 +1046,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='hag66@shakespeare.example'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <join xmlns='urn:xmpp:mix:0' jid='123456#coven@mix.shakespeare.example'>
+  <join xmlns='urn:xmpp:mix:1' jid='123456#coven@mix.shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:participants'/>
     <subscribe node='urn:xmpp:mix:nodes:info'/>
@@ -1060,7 +1061,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   <event xmlns='http://jabber.org/protocol/pubsub#event'>
     <items node='urn:xmpp:mix:nodes:participants'>
       <item id='123456#coven@mix.shakespeare.example'>
-        <participant xmlns='urn:xmpp:mix:0'/>
+        <participant xmlns='urn:xmpp:mix:1'/>
       </item>
     </items>
   </event>
@@ -1071,14 +1072,14 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         At the same time the participant MUST be added to the JID Map node, to map from proxy JID to real JID.   For a JID Maybe Visible channel, the participant MUST be added to the JID Maybe Visible Map node.    The value in this node MUST reflect the user's visibility preference for the channel and MUST be updated to reflect any changes to this preference.
       </p>
       <p>
-        A user MAY subsequently modify subscription to nodes in a channel by sending a subscription modification request encoded as a &lt;update-subscription/$gt;  child element of &lt;iq/&gt; element. The &lt;update-subscription/$gt; element is qualified by the 'urn:xmpp:mix:0' namespace.  The requested notes are encoded as &lt;subscribe/&gt; child elements of the &lt;update-subscription/$gt; element with the node name encoded as a 'node' attribute.  This modification goes directly from client to MIX channel, as this change does not impact the roster and so does not need any local action.  The following example shows subscription modification.
+        A user MAY subsequently modify subscription to nodes in a channel by sending a subscription modification request encoded as a &lt;update-subscription/$gt;  child element of &lt;iq/&gt; element. The &lt;update-subscription/$gt; element is qualified by the 'urn:xmpp:mix:1' namespace.  The requested notes are encoded as &lt;subscribe/&gt; child elements of the &lt;update-subscription/$gt; element with the node name encoded as a 'node' attribute.  This modification goes directly from client to MIX channel, as this change does not impact the roster and so does not need any local action.  The following example shows subscription modification.
       </p>
       <example caption="User Modifies Subscription Request"><![CDATA[
 <iq type='set'
     from='hag66@shakespeare.example/UUID-a1j/7533'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <update-subscription xmlns='urn:xmpp:mix:0'>
+  <update-subscription xmlns='urn:xmpp:mix:1'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
   </update-subscription>
 </iq>
@@ -1087,7 +1088,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
      from='coven@mix.shakespeare.example'
      to='hag66@shakespeare.example/UUID-a1j/7533'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <update-subscription xmlns='urn:xmpp:mix:0' jid='hag66@shakespeare.example'>
+  <update-subscription xmlns='urn:xmpp:mix:1' jid='hag66@shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
   </update-subscription>
 </iq>
@@ -1143,12 +1144,12 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='hag66@shakespeare.example'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-    <join xmlns='urn:xmpp:mix:0'>
+    <join xmlns='urn:xmpp:mix:1'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
     <x xmlns='jabber:x:data' type='submit'>
         <field var='FORM_TYPE' type='hidden'>
-             <value>urn:xmpp:mix:0</value>
+             <value>urn:xmpp:mix:1</value>
         </field>
         <field var='JID Visibility'>
             <value>never</value>
@@ -1163,12 +1164,12 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='coven@mix.shakespeare.example'
     to='hag66@shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <join xmlns='urn:xmpp:mix:0' jid='hag66@shakespeare.example'>
+  <join xmlns='urn:xmpp:mix:1' jid='hag66@shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
     <x xmlns='jabber:x:data' type='result'>
         <field var='FORM_TYPE' type='hidden'>
-             <value>urn:xmpp:mix:0</value>
+             <value>urn:xmpp:mix:1</value>
         </field>
         <field var='JID Visibility'>
             <value>never</value>
@@ -1183,23 +1184,23 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </join>
 </iq>
 ]]></example>
-     <p>The client MAY also query the channel in order to find out which user preferences are supported and the options available.  This will allow users to set options not specified in the standard, by providing a form template in the result.  The request is encoded as a &lt;user-preference/&gt; child element of &lt;iq/&gt;.  &lt;user-preference/&gt; is qualified by the 'urn:xmpp:mix:0' namespace.  The result is encoded as a form child element in the &lt;user-preference/&gt; element.</p>
+     <p>The client MAY also query the channel in order to find out which user preferences are supported and the options available.  This will allow users to set options not specified in the standard, by providing a form template in the result.  The request is encoded as a &lt;user-preference/&gt; child element of &lt;iq/&gt;.  &lt;user-preference/&gt; is qualified by the 'urn:xmpp:mix:1' namespace.  The result is encoded as a form child element in the &lt;user-preference/&gt; element.</p>
      <example caption="User Requests and Recieves Preferences Template Form"><![CDATA[
 <iq type='get'
     from='hag66@shakespeare.example/UUID-a1j/7533'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-    <user-preference xmlns='urn:xmpp:mix:0'/>
+    <user-preference xmlns='urn:xmpp:mix:1'/>
 </iq>
 
 <iq type='result'
     from='coven@mix.shakespeare.example'
     to='hag66@shakespeare.example/UUID-a1j/7533'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-    <user-preference xmlns='urn:xmpp:mix:0'>
+    <user-preference xmlns='urn:xmpp:mix:1'>
     <x xmlns='jabber:x:data' type='form'>
         <field var='FORM_TYPE' type='hidden'>
-             <value>urn:xmpp:mix:0</value>
+             <value>urn:xmpp:mix:1</value>
         </field>
         <field type='list-single' label='Preference for JID Visibility'
                    var='JID Visibility'>
@@ -1226,10 +1227,10 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='hag66@shakespeare.example/UUID-a1j/7533'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-    <user-preference xmlns='urn:xmpp:mix:0'/>
+    <user-preference xmlns='urn:xmpp:mix:1'/>
      <x xmlns='jabber:x:data' type='submit'>
         <field var='FORM_TYPE' type='hidden'>
-             <value>urn:xmpp:mix:0</value>
+             <value>urn:xmpp:mix:1</value>
         </field>
         <field var='JID Visibility'>
             <value>never</value>
@@ -1247,10 +1248,10 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='coven@mix.shakespeare.example'
     to='hag66@shakespeare.example/UUID-a1j/7533'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-    <user-preference xmlns='urn:xmpp:mix:0'>
+    <user-preference xmlns='urn:xmpp:mix:1'>
     <x xmlns='jabber:x:data' type='result'>
         <field var='FORM_TYPE' type='hidden'>
-             <value>urn:xmpp:mix:0</value>
+             <value>urn:xmpp:mix:1</value>
         </field>
         <field var='JID Visibility'>
             <value>never</value>
@@ -1268,7 +1269,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
    </section3>
 
     <section3 topic='Leaving a Channel' anchor='usecase-user-leaving'>
-      <p>Users generally remain in a channel for an extended period of time.  In particular the user remains as a participant the channel when the user goes offline.  Note that this is different to  &xep0045;, where the client leaves a room when going offline. So, leaving a MIX channel is a permanent action for a user across all clients.  In order to  leave a channel, a user sends a MIX "leave" command to the channel.  The leave command is encoded as a &lt;leave/&gt; child element of &lt;iq/&gt; element.  The &lt;leave/&gt; element is qualified by the 'urn:xmpp:mix:0' namespace, with the channel specified as a 'channel" attribute.  When a user leaves the channel, the user's server will remove the channel from the user's roster.   Leave commands are sent indirectly through the user's server, to enable roster removal.   Leaving is initiated by a client request, as shown in the following example.</p>
+      <p>Users generally remain in a channel for an extended period of time.  In particular the user remains as a participant the channel when the user goes offline.  Note that this is different to  &xep0045;, where the client leaves a room when going offline. So, leaving a MIX channel is a permanent action for a user across all clients.  In order to  leave a channel, a user sends a MIX "leave" command to the channel.  The leave command is encoded as a &lt;leave/&gt; child element of &lt;iq/&gt; element.  The &lt;leave/&gt; element is qualified by the 'urn:xmpp:mix:1' namespace, with the channel specified as a 'channel" attribute.  When a user leaves the channel, the user's server will remove the channel from the user's roster.   Leave commands are sent indirectly through the user's server, to enable roster removal.   Leaving is initiated by a client request, as shown in the following example.</p>
 
 
       <example caption="Client Requests to Leave a Channel"><![CDATA[
@@ -1276,7 +1277,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='hag66@shakespeare.example/UUID-a1j/7533'
     to='hag66@shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <leave xmlns='urn:xmpp:mix:0'
+  <leave xmlns='urn:xmpp:mix:1'
           channel=`coven@mix.shakespeare.example`/>
 </iq>
 ]]></example>
@@ -1290,7 +1291,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='hag66@shakespeare.example'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <leave xmlns='urn:xmpp:mix:0'/>
+  <leave xmlns='urn:xmpp:mix:1'/>
 </iq>
 ]]></example>
 
@@ -1302,7 +1303,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='coven@mix.shakespeare.example'
     to='hag66@shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <leave xmlns='urn:xmpp:mix:0'/>
+  <leave xmlns='urn:xmpp:mix:1'/>
 </iq>
 ]]></example>
 
@@ -1316,7 +1317,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='coven@mix.shakespeare.example'
     to='hag66@shakespeare.example/UUID-a1j/7533'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <leave xmlns='urn:xmpp:mix:0'/>
+  <leave xmlns='urn:xmpp:mix:1'/>
 </iq>
 ]]></example>
       <p>When the user leaves the channel, the MIX service is responsible for unsubscribing the user from all nodes in the channel and for removing the user from the participants and presence list.  If the user has online presence when the user leaves the channel, the change of presence status caused by removing the user's entry or entries from the presence node will ensure that subscribers to the presence node are correctly updated on presence status.
@@ -1358,14 +1359,14 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <li>The MIX service generates the nick.  In this case it is RECOMMENDED that the assigned nick is a UUID following &rfc4122;.</li>
     </ol>
     <p>
-      A user will typically set a nick when joining a channel and MAY update this nick from time to time.   The user does this by sending a command to the channel to set the nick.  This command is a &lt;setnick/&gt; child element of &lt;iq/&gt; element. The &lt;setnick/&gt; element is qualified by the 'urn:xmpp:mix:0' namespace.   The nick is encoded as a &lt;nick/&gt; child element of the &lt;setnick/&gt; element. If the user wishes the channel to assign a nick (or knows that the channel will assign a nick) the nick field can be left blank, so that the user can see what is assigned in the result.
+      A user will typically set a nick when joining a channel and MAY update this nick from time to time.   The user does this by sending a command to the channel to set the nick.  This command is a &lt;setnick/&gt; child element of &lt;iq/&gt; element. The &lt;setnick/&gt; element is qualified by the 'urn:xmpp:mix:1' namespace.   The nick is encoded as a &lt;nick/&gt; child element of the &lt;setnick/&gt; element. If the user wishes the channel to assign a nick (or knows that the channel will assign a nick) the nick field can be left blank, so that the user can see what is assigned in the result.
     </p>
     <example caption="User sets Nick on Channel"><![CDATA[
 <iq type='set'
     from='hag66@shakespeare.example/UUID-a1j/7533'
     to='coven@mix.shakespeare.example'
     id='7nve413p'>
-  <setnick xmlns='urn:xmpp:mix:0'>
+  <setnick xmlns='urn:xmpp:mix:1'>
     <nick>thirdwitch</nick>
   </setnick>
 </iq>
@@ -1380,7 +1381,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='coven@mix.shakespeare.example'
     to'hag66@shakespeare.example/UUID-a1j/7533'
     id='7nve413p'>
-  <setnick xmlns='urn:xmpp:mix:0'>
+  <setnick xmlns='urn:xmpp:mix:1'>
     <nick>thirdwitch</nick>
   </setnick>
 </iq>
@@ -1406,22 +1407,22 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='mix.shakespeare.example'
     id='7nve413p'>
     <query xmlns='http://jabber.org/protocol/disco#info'/>
-        <feature var='urn:xmpp:mix:0#nick-register'/>
+        <feature var='urn:xmpp:mix:1#nick-register'/>
     </query>
 </iq>
 ]]></example>
       <p>
-        The response will be a list of features of the MIX channel.  If Nick Registration is supported, then the result set will include &lt;feature var="urn:xmpp:mix:0#nick-register"/&gt;.
+        The response will be a list of features of the MIX channel.  If Nick Registration is supported, then the result set will include &lt;feature var="urn:xmpp:mix:1#nick-register"/&gt;.
       </p>
       <p>
         To register a nick with the MIX service the user sends
-        a register command to the service. This is encoded as a &lt;register/&gt; child element of an &lt;iq/&gt; element. The &lt;register/&gt; element is  qualified by the urn:xmpp:mix:0' namespace.  The nick is encoded in a &lt;nick/&gt; child element of the &lt;register/&gt; element. </p>
+        a register command to the service. This is encoded as a &lt;register/&gt; child element of an &lt;iq/&gt; element. The &lt;register/&gt; element is  qualified by the urn:xmpp:mix:1' namespace.  The nick is encoded in a &lt;nick/&gt; child element of the &lt;register/&gt; element. </p>
       <example caption="User Registers with Service"><![CDATA[
 <iq type='set'
     from='hag66@shakespeare.example/UUID-a1j/7533'
     to='mix.shakespeare.example'
     id='7nve413p'>
-  <register xmlns='urn:xmpp:mix:0'>
+  <register xmlns='urn:xmpp:mix:1'>
     <nick>thirdwitch</nick>
   </register>
 </iq>
@@ -1437,7 +1438,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     to='mix.shakespeare.example'
     from='hag66@shakespeare.example/UUID-a1j/7533'
     id='7nve413p'>
-  <register xmlns='urn:xmpp:mix:0'>
+  <register xmlns='urn:xmpp:mix:1'>
     <nick>thirdwitch</nick>
   </register>
 </iq>
@@ -1547,7 +1548,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
      <pubsub xlns='http://jabber.org/protocol/pubsub'>
           <items node='urn:xmpp:mix:nodes:jidmap'>
              <item id='123456#coven@mix.shakespeare.example'>
-                 <participant xmlns='urn:xmpp:mix:0'>
+                 <participant xmlns='urn:xmpp:mix:1'>
                       <jid>hecate@mix.shakespeare.example<jid/>
                  </participant>
              </item>
@@ -1589,7 +1590,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
                   <event xmlns='http://jabber.org/protocol/pubsub#event'>
                        <items node='urn:xmpp:mix:nodes:jidmap'>
                            <item id='123456#coven@mix.shakespeare.example'>
-                                  <participant xmlns='urn:xmpp:mix:0'>
+                                  <participant xmlns='urn:xmpp:mix:1'>
                                       <jid>hecate@mix.shakespeare.example<jid/>
                                   </participant>
                            </item>
@@ -1661,7 +1662,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 </message>
 ]]></example>
       <p>
-        The MIX channel then adds information to the message using a &lt;mix&gt; element qualified by the 'urn:xmpp:mix:0' namespace.   This element contains two child elements:
+        The MIX channel then adds information to the message using a &lt;mix&gt; element qualified by the 'urn:xmpp:mix:1' namespace.   This element contains two child elements:
       </p>
       <ol>
         <li>A &lt;nick&gt; element that contains the Nick of the message sender, taken from the Participants Node.</li>
@@ -1676,7 +1677,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
          id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
          type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
-  <mix xmlns='urn:xmpp:mix:0'>
+  <mix xmlns='urn:xmpp:mix:1'>
         <nick>thirdwitch</nick>
         <jid>123456#coven@mix.shakespeare.example</jid>
   </mix>
@@ -1689,7 +1690,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
          id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
          type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
-  <mix xmlns='urn:xmpp:mix:0'>
+  <mix xmlns='urn:xmpp:mix:1'>
         <nick>thirdwitch</nick>
         <jid>123456#coven@mix.shakespeare.example</jid>
   </mix>
@@ -1704,7 +1705,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
          id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
          type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
- <mix xmlns='urn:xmpp:mix:0'>
+ <mix xmlns='urn:xmpp:mix:1'>
         <nick>thirdwitch</nick>
         <jid>123456#coven@mix.shakespeare.example</jid>
         <submission-id>92vax143g</submission-id>
@@ -1715,13 +1716,13 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
     <section3 topic="Retracting a Message" anchor="usecase-retract">
       <p>
-        A MIX channel MAY support message retraction, where the sender of a messages or an authorized administrator deletes a message.   If this is done the original message MAY be replaced by a tombstone.  The protocol to request retraction does this by adding to the  message  a &lt;retract&gt; element qualified by the 'urn:xmpp:mix:0' namespace as shown in the following example.
+        A MIX channel MAY support message retraction, where the sender of a messages or an authorized administrator deletes a message.   If this is done the original message MAY be replaced by a tombstone.  The protocol to request retraction does this by adding to the  message  a &lt;retract&gt; element qualified by the 'urn:xmpp:mix:1' namespace as shown in the following example.
       </p>
       <example caption="User Retracts a Message"><![CDATA[
 <message from='hag66@shakespeare.example/UUID-a1j/7533'
          to='coven@mix.shakespeare.example'
          id='92vax143g'>
-  <retract id='28482-98726-73623' xmlns='urn:xmpp:mix:0'/>
+  <retract id='28482-98726-73623' xmlns='urn:xmpp:mix:1'/>
 </message>
 ]]></example>
       <p>
@@ -1735,7 +1736,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </p>
       <p>
         The second approach is to leave a tombstone, which if taken MUST be done in the following manner.   This is appropriate where it is desired to leave a record of the message that was redacted.
-        With this approach, the original message &lt;body&gt; is removed and replaced with a tombstone using the &lt;retracted&gt; element qualified by the 'urn:xmpp:mix:0' namespace that shows the JID of user performing the retraction and the time of the retraction.
+        With this approach, the original message &lt;body&gt; is removed and replaced with a tombstone using the &lt;retracted&gt; element qualified by the 'urn:xmpp:mix:1' namespace that shows the JID of user performing the retraction and the time of the retraction.
       </p>
       <example caption="Retracted message tombstone in a MAM result"><![CDATA[
 <message id='aeb213' to='juliet@capulet.lit/UUID-e3r/9264'>
@@ -1744,7 +1745,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <delay xmlns='urn:xmpp:delay' stamp='2010-07-10T23:08:25Z'/>
       <message xmlns='jabber:client' from="hag66@shakespeare.example"
                  to="macbeth@shakespeare.lit">
-        <retracted xmlns='urn:xmpp:mix:0' by='hag66@shakespeare.example'
+        <retracted xmlns='urn:xmpp:mix:1' by='hag66@shakespeare.example'
                  time='2010-07-10T23:08:25Z'/>
       </message>
     </forwarded>
@@ -1772,14 +1773,14 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         <li>The invitee MAY send a response to the inviter, indicating if the invitation was accepted or declined.</li>
       </ol>
       <p>
-        The first step is for the inviter to request an invitation from the channel.   The invitation contains inviter, invitee and a token.  The channel will evaluate if the inviter has rights to issue the invitation.   This will be because the inviter is a channel administrator or if the inviter is a channel participant and the channel allows invitation by participants.  If the inviter has rights to make the invitation, the channel will return a token.  The token is a string that the channel can subsequently use to validate an invitation.   The format of the token is not specified in this standard.   The encoded token MAY reflect a validity time.  The invitation request is encoded as an &lt;invite/&gt; child element of an &lt;iq/&gt; element. The &lt;invite/&gt; element is qualified by the 'urn:xmpp:mix:0' namespace.  &lt;invite/&gt; contains an &lt;invitation/&gt; child element, which contain &lt;inviter/&gt;, &lt;invitee/&gt;, &lt;channel/&gt; and &lt;token/&gt; child elements.
+        The first step is for the inviter to request an invitation from the channel.   The invitation contains inviter, invitee and a token.  The channel will evaluate if the inviter has rights to issue the invitation.   This will be because the inviter is a channel administrator or if the inviter is a channel participant and the channel allows invitation by participants.  If the inviter has rights to make the invitation, the channel will return a token.  The token is a string that the channel can subsequently use to validate an invitation.   The format of the token is not specified in this standard.   The encoded token MAY reflect a validity time.  The invitation request is encoded as an &lt;invite/&gt; child element of an &lt;iq/&gt; element. The &lt;invite/&gt; element is qualified by the 'urn:xmpp:mix:1' namespace.  &lt;invite/&gt; contains an &lt;invitation/&gt; child element, which contain &lt;inviter/&gt;, &lt;invitee/&gt;, &lt;channel/&gt; and &lt;token/&gt; child elements.
       </p>
       <example caption='Inviter Requests and Receives Invitation'><![CDATA[
 <iq from='hag66@shakespeare.lit/UUID-h5z/0253'
     id='kl2fax27'
     to='coven@mix.shakespeare.lit'
     type='get'>
-  <invite xmlns='urn:xmpp:mix:0'>
+  <invite xmlns='urn:xmpp:mix:1'>
       <invitee>cat@shakespeare.lit</invitee>
   </invite>
 </iq>
@@ -1789,7 +1790,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     id='kl2fax27'
     to='hag66@shakespeare.lit/UUID-h5z/0253'
     type='result'>
-  <invite xmlns='urn:xmpp:mix:0'>
+  <invite xmlns='urn:xmpp:mix:1'>
         <invitation>
            <inviter>hag66@shakespeare.lit</inviter>
            <invitee>cat@shakespeare.lit</invitee>
@@ -1807,7 +1808,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     id='f5pp2toz'
     to='cat@shakespeare.lit'>
     <body>Would you like to join the coven?<body>
-    <invitation xmlns='urn:xmpp:mix:0'>
+    <invitation xmlns='urn:xmpp:mix:1'>
         <inviter>hag66@shakespeare.lit</inviter>
         <invitee>cat@shakespeare.lit</invitee>
         <channel>coven@mix.shakespeare.lit</channel>
@@ -1821,7 +1822,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='cat@shakespeare.example'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <join xmlns='urn:xmpp:mix:0'>
+  <join xmlns='urn:xmpp:mix:1'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <invitation>
         <inviter>hag66@shakespeare.lit</inviter>
@@ -1833,7 +1834,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 </iq>
 ]]></example>
       <p>The invitee MAY send an acknowledgement back to the inviter, noting the status of the invitation. 
-        This is encoded as an &lt;invitation-ack/&gt; child element of &lt;message/&gt; element.  The &lt;invitation-ack/&gt; element is qualified by the 'urn:xmpp:mix:0' namespace.   The &lt;invitation-ack/&gt; has an &lt;invitation/&gt; child element that encodes the invitation being acknowledged and a &lt;value/&gt; child element to encode the acknowledgement value.
+        This is encoded as an &lt;invitation-ack/&gt; child element of &lt;message/&gt; element.  The &lt;invitation-ack/&gt; element is qualified by the 'urn:xmpp:mix:1' namespace.   The &lt;invitation-ack/&gt; has an &lt;invitation/&gt; child element that encodes the invitation being acknowledged and a &lt;value/&gt; child element to encode the acknowledgement value.
         &lt;value/&gt; has the following values:</p>
       <ul>
         <li>'Joined': The invitee has joined the channel.</li>
@@ -1845,7 +1846,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     id='b6p9llze'
     to='hag66@shakespeare.lit/UUID-h5z/0253'>
     <body>No Thanks - too busy chasing mice....<body>
-    <invitation-ack xmlns='urn:xmpp:mix:0'>
+    <invitation-ack xmlns='urn:xmpp:mix:1'>
         <value>Declined</value>
         <invitation>
              <inviter>hag66@shakespeare.lit</inviter>
@@ -1952,14 +1953,14 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       It is important that messages are all transferred from the MIX channel to the server associated with the each channel participant.   Transfer between servers will typically happen quickly and &xep0198; will deal with short connection failures between servers.   Longer connection failures could lead to message loss.  This would lead to online users (who remain connected to their servers) missing messages, and to messages being missed out of the user archive.  This section describes how MIX addresses this.
     </p>
     <p>
-      When there is a long term connection failure, the MIX channel will receive an error from the XMPP server indicating that a message failed to transfer to a recipient.   When this happens, the MIX channel MUST take responsibility to ensure that the message is retransmitted and delivered.   When the MIX channel detects a failure it will make use of an IQ Marker message to determine when the connection to the peer server is working again.  Once the channel has received a response to the marker IQ it will retransmit the pending messages.  The marker is encoded as a &lt;marker/&gt; child element of an &lt;iq/&gt; element. The &lt;marker/&gt; element is qualified by the 'urn:xmpp:mix:0' namespace.
+      When there is a long term connection failure, the MIX channel will receive an error from the XMPP server indicating that a message failed to transfer to a recipient.   When this happens, the MIX channel MUST take responsibility to ensure that the message is retransmitted and delivered.   When the MIX channel detects a failure it will make use of an IQ Marker message to determine when the connection to the peer server is working again.  Once the channel has received a response to the marker IQ it will retransmit the pending messages.  The marker is encoded as a &lt;marker/&gt; child element of an &lt;iq/&gt; element. The &lt;marker/&gt; element is qualified by the 'urn:xmpp:mix:1' namespace.
     </p>
     <example caption="Channel Sends Marker Message" ><![CDATA[
  <iq from='coven@mix.shakespeare.example'
     id='lx09df27'
     to='hag66@shakespeare.example'
     type='get'>
-  <marker xmlns='urn:xmpp:mix:0'/>
+  <marker xmlns='urn:xmpp:mix:1'/>
 </iq>
 
 
@@ -1967,7 +1968,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     id='lx09df27'
     to='coven@mix.shakespeare.example'
     type='result'>
- <marker xmlns='urn:xmpp:mix:0'/>
+ <marker xmlns='urn:xmpp:mix:1'/>
 </iq>
 ]]></example>
   </section2>
@@ -2003,7 +2004,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
     <section3 topic='Checking For Permission To Create a Channel' anchor='usecase-admin-check-create'>
       <p>
-        MIX does not standardize an access control model for creating and deleting MIX channels.    The choice is left to the MIX implementer, and could be a very simple or complex approach.  A client can determine if it has permission to create a channel on a MIX service, which MAY be used to control options presented to the user.   This is achieved by a disco command on the MIX service.   If the 'urn:xmpp:mix:0#create-channel' feature is returned, the user is able to create a channel.
+        MIX does not standardize an access control model for creating and deleting MIX channels.    The choice is left to the MIX implementer, and could be a very simple or complex approach.  A client can determine if it has permission to create a channel on a MIX service, which MAY be used to control options presented to the user.   This is achieved by a disco command on the MIX service.   If the 'urn:xmpp:mix:1#create-channel' feature is returned, the user is able to create a channel.
       </p>
         <example caption="Client determines Capability to Create a Channel" ><![CDATA[
  <iq from='hag66@shakespeare.example/UUID-c8y/1573'
@@ -2022,29 +2023,29 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         category='conference'
         name='Shakespearean Chat Service'
         type='text'/>
-    <feature var='urn:xmpp:mix:0'/>
-    <feature var='urn:xmpp:mix:0#create-channel'>
+    <feature var='urn:xmpp:mix:1'/>
+    <feature var='urn:xmpp:mix:1#create-channel'>
   </query>
 </iq>
 ]]></example>
     </section3>
     <section3 topic='Creating a Channel' anchor='usecase-admin-create'>
       <p>
-        A client creates a channel by sending a simple request to the MIX service.   A channel MAY be created with default parameters, as shown in the following example.   The result MUST include the name of the channel which MUST match the channel name in the request (if present).  The create is encoded as a &lt;create/&gt; child element of &lt;iq/&gt; element.   The &lt;create/&gt; is qualified by the 'urn:xmpp:mix:0' namespace.   The &lt;create/&gt; element MUST have a 'channel' attribute to specify the channel name.
+        A client creates a channel by sending a simple request to the MIX service.   A channel MAY be created with default parameters, as shown in the following example.   The result MUST include the name of the channel which MUST match the channel name in the request (if present).  The create is encoded as a &lt;create/&gt; child element of &lt;iq/&gt; element.   The &lt;create/&gt; is qualified by the 'urn:xmpp:mix:1' namespace.   The &lt;create/&gt; element MUST have a 'channel' attribute to specify the channel name.
       </p>
         <example caption="Creating a Channel with Default Parameters" ><![CDATA[
 <iq from='hag66@shakespeare.example/UUID-a1j/7533'
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
-  <create channel='coven' xmlns='urn:xmpp:mix:0'/>
+  <create channel='coven' xmlns='urn:xmpp:mix:1'/>
 </iq>
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
     to='hag66@shakespeare.example/UUID-a1j/7533'
     type='result'>
-  <create channel='coven' xmlns='urn:xmpp:mix:0'/>
+  <create channel='coven' xmlns='urn:xmpp:mix:1'/>
 </iq>
 ]]></example>
       <p>
@@ -2055,10 +2056,10 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
-  <create channel='coven' xmlns='urn:xmpp:mix:0'>
+  <create channel='coven' xmlns='urn:xmpp:mix:1'>
      <x xmlns='jabber:x:data' type='submit'>
         <field var='FORM_TYPE' type='hidden'>
-             <value>urn:xmpp:mix:0</value>
+             <value>urn:xmpp:mix:1</value>
         </field>
         <field var='Owner'>
             <value>hecate@shakespeare.lit</value>
@@ -2081,7 +2082,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     id='lx09df27'
     to='hag66@shakespeare.example/UUID-a1j/7533'
     type='result'>
-  <create channel='coven' xmlns='urn:xmpp:mix:0'/>
+  <create channel='coven' xmlns='urn:xmpp:mix:1'/>
 </iq>
 ]]></example>
 
@@ -2097,14 +2098,14 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
-  <create xmlns='urn:xmpp:mix:0'/>
+  <create xmlns='urn:xmpp:mix:1'/>
 </iq>
 
 <iq from='mix.shakespeare.example'
     id='lx09df27'
     to='hag66@shakespeare.example/UUID-a1j/7533'
     type='result'>
-  <create channel='A1B2C345' xmlns='urn:xmpp:mix:0'/>
+  <create channel='A1B2C345' xmlns='urn:xmpp:mix:1'/>
 </iq>
 ]]></example>
    </section3>
@@ -2140,7 +2141,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         MIX channels are always explicitly destroyed by an owner of the channel or by a server operator. There is no concept of temporary channel, equivalent to &xep0045; temporary room which is automatically destroyed by the server when the users leave.   However, channels MAY be configured with an explicit lifetime, after which the channel MUST be removed by the MIX service.   Where a channel is created for ad hoc use, it MAY be desirable to keep the channel for history reference or for re-use by the same set of users.  Note that the owner of the channel does not need to have presence registered in the channel in order to destroy it.
      </p>
       <p>
-        The destroy operation is encoded as a &lt;destroy/&gt; child element of an &lt;iq/&gt; element.  The &lt;destroy/&gt; element is qualified by the 'urn:xmpp:mix:0' namespace.  The &lt;destroy/&gt; element MUST have a 'channel' attribute to specify the channel to be destroyed.
+        The destroy operation is encoded as a &lt;destroy/&gt; child element of an &lt;iq/&gt; element.  The &lt;destroy/&gt; element is qualified by the 'urn:xmpp:mix:1' namespace.  The &lt;destroy/&gt; element MUST have a 'channel' attribute to specify the channel to be destroyed.
         A client destroys a channel using a simple set operation, as shown in the following example.
       </p>
       <example caption="Client Destroys a Channel" ><![CDATA[
@@ -2148,7 +2149,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     id='lx09df27'
     to='mix.shakespeare.example'
     type='set'>
-  <destroy channel='coven' xmlns='urn:xmpp:mix:0'/>
+  <destroy channel='coven' xmlns='urn:xmpp:mix:1'/>
 </iq>
 
 <iq from='mix.shakespeare.example'
@@ -2184,7 +2185,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
      <items node='urn:xmpp:mix:nodes:info'>
        <x xmlns='jabber:x:data' type='form'>
         <field var='FORM_TYPE' type='hidden'>
-             <value>urn:xmpp:mix:0</value>
+             <value>urn:xmpp:mix:1</value>
         </field>
         <title>Information Node Modification</title>
         <field type='text-multi'
@@ -2213,7 +2214,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
      <publish node='urn:xmpp:mix:nodes:info'>
        <x xmlns='jabber:x:data' type='submit'>
         <field var='FORM_TYPE' type='hidden'>
-             <value>urn:xmpp:mix:0</value>
+             <value>urn:xmpp:mix:1</value>
         </field>
         <field var='Name'>
             <value>Witches Coven</value>
@@ -2236,7 +2237,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'>
       <publish node='urn:xmpp:mix:nodes:info'>
-        <item id='2016-05-30T09:00:00' xmlns='urn:xmpp:mix:0'/>
+        <item id='2016-05-30T09:00:00' xmlns='urn:xmpp:mix:1'/>
        </publish>
    </pubsub>
 </iq>
@@ -2260,10 +2261,10 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     to='hag66@shakespeare.example/UUID-a1j/7533'
     type='result'>
      <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-      <items xmlns='urn:xmpp:mix:0'  node='urn:xmpp:mix:nodes:config'>
+      <items xmlns='urn:xmpp:mix:1'  node='urn:xmpp:mix:nodes:config'>
        <x xmlns='jabber:x:data' type='form'>
         <field var='FORM_TYPE' type='hidden'>
-             <value>urn:xmpp:mix:0</value>
+             <value>urn:xmpp:mix:1</value>
         </field>
         <title>Configuration Node Modification</title>
          <field type=jid-multi'
@@ -2284,7 +2285,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <publish node='urn:xmpp:mix:nodes:config'>
       <x xmlns='jabber:x:data' type='submit'>
         <field var='FORM_TYPE' type='hidden'>
-             <value>urn:xmpp:mix:0</value>
+             <value>urn:xmpp:mix:1</value>
         </field>
         <field var='Owner'>
             <value>hecate@shakespeare.lit</value>
@@ -2310,7 +2311,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     type='result'>
     <pubsub xmlns='http://jabber.org/protocol/pubsub'>
       <publish node='urn:xmpp:mix:nodes:config'>
-        <item id='2016-05-30T09:00:00' xmlns='urn:xmpp:mix:0'/>
+        <item id='2016-05-30T09:00:00' xmlns='urn:xmpp:mix:1'/>
        </publish>
    </pubsub>
 </iq>
@@ -2423,7 +2424,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
          id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
          type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
-  <mix xmlns='urn:xmpp:mix:0'>
+  <mix xmlns='urn:xmpp:mix:1'>
         <nick>thirdwitch</nick>
         <jid>123456#coven@mix.shakespeare.example</jid>
   </mix>
@@ -2442,7 +2443,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
          id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
          type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
-  <mix xmlns='urn:xmpp:mix:0'>
+  <mix xmlns='urn:xmpp:mix:1'>
         <nick>thirdwitch</nick>
         <jid>123456#coven@mix.shakespeare.example</jid>
   </mix>
@@ -2453,7 +2454,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
          id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
          type='groupchat'>
   <body>Harpier cries: 'tis time, 'tis time.</body>
-   <mix xmlns='urn:xmpp:mix:0'>
+   <mix xmlns='urn:xmpp:mix:1'>
         <nick>thirdwitch</nick>
         <jid>123456#coven@mix.shakespeare.example</jid>
   </mix>
@@ -2488,7 +2489,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='hag66@shakespeare.example/UUID-a1j/7533'
     to='hag66@shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <join xmlns='urn:xmpp:mix:0'
+  <join xmlns='urn:xmpp:mix:1'
          channel='coven@mix.shakespeare.example'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
@@ -2505,7 +2506,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='hag66@shakespeare.example'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <join xmlns='urn:xmpp:mix:0'>
+  <join xmlns='urn:xmpp:mix:1'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
     <subscribe node='urn:xmpp:mix:nodes:participants'/>
@@ -2587,11 +2588,11 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         category='conference'
         name='Shakespearean Chat Service'
         type='text'/>
-    <feature var='urn:xmpp:mix:0'/>
+    <feature var='urn:xmpp:mix:1'/>
     <feature var='http://jabber.org/protocol/muc'/>
     <x xmlns='jabber:x:data' type='result'>
       <field var='FORM_TYPE' type='hidden'>
-        <value>urn:xmpp:mix:0#serviceinfo</value>
+        <value>urn:xmpp:mix:1#serviceinfo</value>
       </field>
     </x>
   </query>
@@ -2610,10 +2611,10 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         category='conference'
         name='Shakespearean Chat Service'
         type='text'/>
-    <feature var='urn:xmpp:mix:0'/>
+    <feature var='urn:xmpp:mix:1'/>
     <x xmlns='jabber:x:data' type='result'>
       <field var='FORM_TYPE' type='hidden'>
-        <value>urn:xmpp:mix:0#serviceinfo</value>
+        <value>urn:xmpp:mix:1#serviceinfo</value>
       </field>
       <field var='muc-mirror'
              type='jid-single'
@@ -2624,7 +2625,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </query>
 </iq>
 ]]></example>
-    <p>The result is returned in an extended disco results in a form whose type value is 'urn:xmpp:mix:0#serviceinfo'.  The  field with var='muc-mirror' is the value of which is the mirrored MUC domain's JID.  </p>
+    <p>The result is returned in an extended disco results in a form whose type value is 'urn:xmpp:mix:1#serviceinfo'.  The  field with var='muc-mirror' is the value of which is the mirrored MUC domain's JID.  </p>
     <p>Where a client supporting both MIX and MUC is given a reference to a MUC room, it is desirable that the client can determine the MIX channel and join using MIX.   This is achieved by an equivalent extension to MUC service discover.</p>
   <example caption="MUC Service responds with Disco Info result sharing MIX service location" ><![CDATA[
 <iq from='chat.shakespeare.example'
@@ -2639,7 +2640,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <feature var='http://jabber.org/protocol/muc'/>
     <x xmlns='jabber:x:data' type='result'>
       <field var='FORM_TYPE' type='hidden'>
-        <value>urn:xmpp:mix:0#serviceinfo</value>
+        <value>urn:xmpp:mix:1#serviceinfo</value>
       </field>
       <field var='mix-mirror'
              type='jid-single'
@@ -2650,7 +2651,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </query>
 </iq>
 ]]></example>
-  <p>The result is returned in an extended disco results in a form whose type value is 'urn:xmpp:mix:0#serviceinfo'.  The  field with var='mix-mirror' is the value of which is the mirrored MIX domain's JID.  </p>
+  <p>The result is returned in an extended disco results in a form whose type value is 'urn:xmpp:mix:1#serviceinfo'.  The  field with var='mix-mirror' is the value of which is the mirrored MIX domain's JID.  </p>
   <section2 topic="Choosing Which Invite to Send" anchor="mix-muc-invite-choice">
     <p>
       Where a client supports MUC and MIX and has determined that for a channel that the server also supports a MUC room, the client has a choice as to which type of invite to send.   This SHOULD be done by determining if the client support MIX using the mechanism specified in

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -48,6 +48,7 @@
       Extend Roster Get to select format;
       Ensure that text defining attributes and elements reference the namespace;
       Change mix_nick_register to nick-register;
+      Separate namespace for roster information;
     </p></remark>
   </revision>
   <revision>
@@ -2529,13 +2530,13 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </section2>
 
   <section2 topic="MIX Roster Item Capability Sharing" anchor="mix-roster-capability-sharing">
-    <p>It is useful for a MIX client to know which roster members are MIX channels, as this will facilitate convenient presentation of subscribed MIX channels to the user.  A MIX client MAY request that the server return this additional information. The server MUST return the additional information. The request is made by extending the standard roster get request by adding a child element &lt;mix-info-request/&gt; to the &lt;query/&gt; element.  The &lt;mix-info-request/&gt; is qualified by the ‘urn:xmpp:mix:0' namespace.</p>
+    <p>It is useful for a MIX client to know which roster members are MIX channels, as this will facilitate convenient presentation of subscribed MIX channels to the user.  A MIX client MAY request that the server return this additional information that annotates roster elements with MIX capability. The server MUST return the additional information. The request is made by extending the standard roster get request by adding a child element &lt;annotate/&gt; to the &lt;query/&gt; element.  The &lt;mix-info-request/&gt; is qualified by the ‘urn:xmpp:mix:roster:0' namespace.</p>
     <example caption="Roster Get Requesting MIX Information"><![CDATA[
 <iq from='juliet@example.com/balcony'
           id='bv1bs71f'
           type='get'>
        <query xmlns='jabber:iq:roster'>
-              <mix-info-request xmlns=‘urn:xmpp:mix:0'/>
+              <annotate xmlns=‘urn:xmpp:mix:roster:0'/>
        <query/>
      </iq>
 ]]></example>  
@@ -2546,12 +2547,12 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 ]]></example>
 
     <p>
-      MIX channels in the roster information returned in response to a request for this additional MIX information MUST have an element &lt;channel/&gt; qualified by the ‘urn:xmpp:mix:0' namespace  included in the roster item, as shown inf the following example.
+      MIX channels in the roster information returned in response to a request for this additional MIX information MUST have an element &lt;channel/&gt; qualified by the ‘urn:xmpp:mix:roster:0' namespace  included in the roster item, as shown inf the following example.
     </p>
 
     <example caption="Roster Item Encoding of a MIX Channel"><![CDATA[
   <item jid='balcony@example.net'>
-      <channel xmlns=‘urn:xmpp:mix:0'/>
+      <channel xmlns=‘urn:xmpp:mix:roster:0'/>
   </item>
 ]]></example>
 

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -46,6 +46,7 @@
       Roster Update Clarifications;
       Clarify when messages are delivered to clients;
       Extend Roster Get to select format;
+      Ensure that text defining attributes and elements reference the namespace;
     </p></remark>
   </revision>
   <revision>
@@ -499,7 +500,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     </section3>
 
     <section3 topic="Participants Node" anchor="participants-node">
-      <p>Each channel participant is represented as an item of the 'urn:xmpp:mix:nodes:participants' channel node.  Each item is named by the bare proxy JID of the participant. For example '123456#coven@mix.shakespeare.example' might name the node item associated with participant 'hag66@shakespeare.example'. The nick associated with the user is mandatory and is stored in the item.  The nick for each channel participant MUST be different to the nick of other participants.
+      <p>Each channel participant is represented as an item of the 'urn:xmpp:mix:nodes:participants' channel node.  Each item is named by the bare proxy JID of the participant. For example '123456#coven@mix.shakespeare.example' might name the node item associated with participant 'hag66@shakespeare.example'.  Information is stored in a &lt;participant/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.   The nick associated with the user is mandatory and is stored in a &lt;nick/&gt; sub-element of the &lt;participant/&gt; element.   The nick for each channel participant MUST be different to the nick of other participants.
       </p>
       <p>
         When a user joins a channel, the user's bare JID is added to the participants node by the MIX service.   When a user leaves a channel, they are removed from the participants node.  The participants node MUST NOT be directly modified using pubsub.
@@ -522,7 +523,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
       <p>The JID Map node is used to associate a proxy bare JID to its corresponding real bare JID.  The JID Map node MUST have one entry for each entry in the Participants node.  This value is added when a user joins the channel and is removed when the user leaves the channel.
        Each item is identified by proxy bare JID, mapping to the real bare JID.  This node is used to give administrator access to real JIDs and participant access to real JIDs in jid-visible channels.  This node MUST NOT be modified directly using pubsub.
-       In JID Visible channels, all participants MAY subscribe to this node.  In JID Hidden and JID Maybe Visible channels, only administrators can subscribe.   The JID Map node is a permanent node with one item per participant.</p>
+       In JID Visible channels, all participants MAY subscribe to this node.  In JID Hidden and JID Maybe Visible channels, only administrators can subscribe.   The JID Map node is a permanent node with one item per participant. Information is stored in a &lt;participant/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.  The real JID is stored in a &lt;jid/&gt; sub-element of the &lt;participant/&gt; element.  </p>
       <example caption="Value of JID Map Node"><![CDATA[
 <items node='urn:xmpp:mix:nodes:jidmap'>
   <item id='123456#coven@mix.shakespeare.example'>
@@ -543,7 +544,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     
     <section3 topic="Presence Node" anchor="presence-node">
       <p>
-        The presence node contains the presence value for clients belonging to participants that choose to publish presence to the channel. A MIX channel MAY require that all participants publish presence.  Each item in the presence node is identified by the full proxy JID, and contains the current presence value for that JID.  The presence is encoded in the same way as data that would be sent in a presence stanza. The full proxy JID is always used in this node. In MIX it is possible to have a 'presence-less channel' by not using this node. Access Control MAY be set to enforce that for each of the full JIDs in this list, the bare JID MUST be in the participants list.
+        The presence node contains the presence value for clients belonging to participants that choose to publish presence to the channel. A MIX channel MAY require that all participants publish presence.  Each item in the presence node is identified by the full proxy JID, and contains the current presence value for that JID.  The presence is encoded in the same way as data that would be sent in a presence stanza using a &lt;presence/&gt; element qualified by the 'jabber:client' namespace. The full proxy JID is always used in this node. In MIX it is possible to have a 'presence-less channel' by not using this node. Access Control MAY be set to enforce that for each of the full JIDs in this list, the bare JID MUST be in the participants list.
       </p>
 
       <p>
@@ -955,8 +956,8 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 <section1 topic='Use Cases' anchor='usecases'>
   <section2 topic='Common User Use Cases' anchor='usecases-user'>
     <section3 topic='Joining a Channel' anchor='usecase-user-join'>
-      <p>A user joins a channel by sending a MIX "join" command. There is no default set of nodes, so the user MUST specify the set of nodes to be subscribed to. To achieve the equivalent service to MUC, a user would subscribe to messages, and presence.
-         This will lead to the server subscribing the user to each of the requested nodes associated with the channel. The MIX service will also add the user to the participant list by injecting a new item into the "urn:xmpp:mix:nodes:participants" node automatically.
+      <p>A user joins a channel by sending a MIX "join" command. There is no default set of nodes, so the user MUST specify the set of nodes to be subscribed to. To achieve the equivalent service to MUC, a user would subscribe to messages, and presence. The &lt;join/&gt; is a sub-element of &lt;iq/&gt; qualified by the 'urn:xmpp:mix:0' namespace.  The channel is specified by a 'channel' attribute in the &lt;join/&gt; element.  The requested nodes are encoded as &lt;subscribe/&gt; sub-elements of the &lt;join/&gt; element.
+         The join leads to the server subscribing the user to each of the requested nodes associated with the channel. The MIX service will also add the user to the participant list by injecting a new item into the "urn:xmpp:mix:nodes:participants" node automatically.
 
       </p>
       <p>The default MIX model is that only channel participants are allowed to subscribe to nodes.    A MIX channel MAY allow non-participant subscription.   This will be handled by clients directly subscribing to the desired PubSub nodes.</p>
@@ -1067,7 +1068,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         At the same time the participant MUST be added to the JID Map node, to map from proxy JID to real JID.   For a JID Maybe Visible channel, the participant MUST be added to the JID Maybe Visible Map node.    The value in this node MUST reflect the user's visibility preference for the channel and MUST be updated to reflect any changes to this preference.
       </p>
       <p>
-        A user MAY subsequently modify subscription to nodes in a channel by sending a subscription modification request, as shown in the following example.  This modification goes directly from client to MIX channel, as this change does not impact the roster and so does not need any local action.
+        A user MAY subsequently modify subscription to nodes in a channel by sending a subscription modification request encoded as a &lt;update-subscription/$gt;  sub-element of &lt;iq/&gt; qualified by the 'urn:xmpp:mix:0' namespace.  The requested notes are encoded as &lt;subscribe/&gt; sub-elements of the &lt;update-subscription/$gt; element with the node name encoded as a 'node' attribute.  This modification goes directly from client to MIX channel, as this change does not impact the roster and so does not need any local action.  The following example shows subscription modification.
       </p>
       <example caption="User Modifies Subscription Request"><![CDATA[
 <iq type='set'
@@ -1179,7 +1180,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </join>
 </iq>
 ]]></example>
-     <p>The client MAY also query the channel in order to find out which user preferences are supported and the options available.  This will allow users to set options not specified in the standard, by providing a form template in the result.   This query is direct from the client to the MIX channel.</p>
+     <p>The client MAY also query the channel in order to find out which user preferences are supported and the options available.  This will allow users to set options not specified in the standard, by providing a form template in the result.  The request is encoded as a &lt;user-preference/&gt; sub-element of &lt;iq/&gt; qualified by the 'urn:xmpp:mix:0' namespace.  The result is encoded as a form sub-element in the &lt;user-preference/&gt; element.</p>
      <example caption="User Requests and Recieves Preferences Template Form"><![CDATA[
 <iq type='get'
     from='hag66@shakespeare.example/UUID-a1j/7533'
@@ -1264,7 +1265,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
    </section3>
 
     <section3 topic='Leaving a Channel' anchor='usecase-user-leaving'>
-      <p>Users generally remain in a channel for an extended period of time.  In particular the user remains as a participant the channel when the user goes offline.  Note that this is different to  &xep0045;, where the client leaves a room when going offline. So, leaving a MIX channel is a permanent action for a user across all clients.  In order to  leave a channel, a user sends a MIX "leave" command to the channel. When a user leaves the channel, the user's server will remove the channel from the user's roster.   Leave commands are sent indirectly through the user's server, to enable roster removal.   Leaving is initiated by a client request, as shown in the following example.</p>
+      <p>Users generally remain in a channel for an extended period of time.  In particular the user remains as a participant the channel when the user goes offline.  Note that this is different to  &xep0045;, where the client leaves a room when going offline. So, leaving a MIX channel is a permanent action for a user across all clients.  In order to  leave a channel, a user sends a MIX "leave" command to the channel.  The leave command is encoded as a &lt;leave/&gt; sub-element of &lt;iq/&gt; element qualified by the 'urn:xmpp:mix:0' namespace, with the channel specified as a 'channel" attribute.  When a user leaves the channel, the user's server will remove the channel from the user's roster.   Leave commands are sent indirectly through the user's server, to enable roster removal.   Leaving is initiated by a client request, as shown in the following example.</p>
 
 
       <example caption="Client Requests to Leave a Channel"><![CDATA[
@@ -1354,7 +1355,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <li>The MIX service generates the nick.  In this case it is RECOMMENDED that the assigned nick is a UUID following &rfc4122;.</li>
     </ol>
     <p>
-   A user will typically set a nick when joining a channel and MAY update this nick from time to time.   The user does this by sending a command to the channel to set the nick.  If the user wishes the channel to assign a nick (or knows that the channel will assign a nick) the nick field can be left blank, so that the user can see what is assigned in the result.
+      A user will typically set a nick when joining a channel and MAY update this nick from time to time.   The user does this by sending a command to the channel to set the nick.  This command is a &lt;setnick/&gt; sub-element of &lt;iq/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.   The nick is encoded as a &lt;nick/&gt; sub-element of the &lt;setnick/&gt; element. If the user wishes the channel to assign a nick (or knows that the channel will assign a nick) the nick field can be left blank, so that the user can see what is assigned in the result.
     </p>
     <example caption="User sets Nick on Channel"><![CDATA[
 <iq type='set'
@@ -1411,7 +1412,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </p>
       <p>
         To register a nick with the MIX service the user sends
- a &lt;register/&gt; command to the service. </p>
+        a register command to the service. This is encoded as a &lt;register/&gt; sub-element of an &lt;iq/&gt; element qualified by the urn:xmpp:mix:0' namespace.  The nick is encoded in a &lt;nick/&gt; sub-element of the &lt;register/&gt; element. </p>
       <example caption="User Registers with Service"><![CDATA[
 <iq type='set'
     from='hag66@shakespeare.example/UUID-a1j/7533'
@@ -1657,7 +1658,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 </message>
 ]]></example>
       <p>
-        The MIX channel then adds information to the message using a &lt;mix&gt; element.   This element contains two elements:
+        The MIX channel then adds information to the message using a &lt;mix&gt; element qualified by the 'urn:xmpp:mix:0' namespace.   This element contains two sub-elements:
       </p>
       <ol>
         <li>A &lt;nick&gt; element that contains the Nick of the message sender, taken from the Participants Node.</li>
@@ -1711,7 +1712,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 
     <section3 topic="Retracting a Message" anchor="usecase-retract">
       <p>
-        A MIX channel MAY support message retraction, where the sender of a messages or an authorized administrator deletes a message.   If this is done the original message MAY be replaced by a tombstone.  The protocol to request retraction does this by a message with a &lt;retract&gt; element as shown in the following example.
+        A MIX channel MAY support message retraction, where the sender of a messages or an authorized administrator deletes a message.   If this is done the original message MAY be replaced by a tombstone.  The protocol to request retraction does this by adding to the  message  a &lt;retract&gt; element qualified by the 'urn:xmpp:mix:0' namespace as shown in the following example.
       </p>
       <example caption="User Retracts a Message"><![CDATA[
 <message from='hag66@shakespeare.example/UUID-a1j/7533'
@@ -1731,7 +1732,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       </p>
       <p>
         The second approach is to leave a tombstone, which if taken MUST be done in the following manner.   This is appropriate where it is desired to leave a record of the message that was redacted.
-        With this approach, the original message &lt;body&gt; is removed and replaced with a tombstone using the &lt;retracted&gt; element that shows the JID of user performing the retraction and the time of the retraction.
+        With this approach, the original message &lt;body&gt; is removed and replaced with a tombstone using the &lt;retracted&gt; element qualified by the 'urn:xmpp:mix:0' namespace that shows the JID of user performing the retraction and the time of the retraction.
       </p>
       <example caption="Retracted message tombstone in a MAM result"><![CDATA[
 <message id='aeb213' to='juliet@capulet.lit/UUID-e3r/9264'>
@@ -1768,7 +1769,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         <li>The invitee MAY send a response to the inviter, indicating if the invitation was accepted or declined.</li>
       </ol>
       <p>
-        The first step is for the inviter to request an invitation from the channel.   The invitation contains inviter, invitee and a token.  The channel will evaluate if the inviter has rights to issue the invitation.   This will be because the inviter is a channel administrator or if the inviter is a channel participant and the channel allows invitation by participants.  If the inviter has rights to make the invitation, the channel will return a token.  The token is a string that the channel can subsequently use to validate an invitation.   The format of the token is not specified in this standard.   The encoded token MAY reflect a validity time.
+        The first step is for the inviter to request an invitation from the channel.   The invitation contains inviter, invitee and a token.  The channel will evaluate if the inviter has rights to issue the invitation.   This will be because the inviter is a channel administrator or if the inviter is a channel participant and the channel allows invitation by participants.  If the inviter has rights to make the invitation, the channel will return a token.  The token is a string that the channel can subsequently use to validate an invitation.   The format of the token is not specified in this standard.   The encoded token MAY reflect a validity time.  The invitation request is encoded as an &lt;invite/&gt; sub-element of an &lt;iq/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.  &lt;invite/&gt; contains an &lt;invitation/&gt; sub-element, which contain &lt;inviter/&gt;, &lt;invitee/&gt;, &lt;channel/&gt; and &lt;token/&gt; sub-elements.
       </p>
       <example caption='Inviter Requests and Receives Invitation'><![CDATA[
 <iq from='hag66@shakespeare.lit/UUID-h5z/0253'
@@ -1796,7 +1797,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 </iq>
 ]]></example>
       <p>
-        The inviter can now send the invitee a message containing the invitation, as shown in the following example.
+        The inviter can now send the invitee a message containing the invitation within the &lt;message/&gt; element, as shown in the following example.
       </p>
       <example caption='Inviter sends Invitation to Invitee'><![CDATA[
 <message from='hag66@shakespeare.lit/UUID-h5z/0253'
@@ -1811,7 +1812,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
    </invitation>
 </iq>
 ]]></example>
-  <p>The invitation can now be used by the invitee to join a channel. The invitation is simply added to the standard channel join, so that the channel can validate the invitation using the token. If the allowed node is present and the invitee is not matched against any item, the channel MUST add the invitee to the allowed node as part of the join.</p>
+  <p>The invitation can now be used by the invitee to join a channel. The &lt;invitation/&gt; sub-element is simply added to the standard channel &lt;join/&gt; element, so that the channel can validate the invitation using the token. If the allowed node is present and the invitee is not matched against any item, the channel MUST add the invitee to the allowed node as part of the join.</p>
       <example caption="User Joins a Channel with an Invitation"><![CDATA[
 <iq type='set'
     from='cat@shakespeare.example'
@@ -1828,7 +1829,9 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </join>
 </iq>
 ]]></example>
-      <p>The invitee MAY send an acknowledgement back to the inviter, noting the status of the invitation.  Values are:</p>
+      <p>The invitee MAY send an acknowledgement back to the inviter, noting the status of the invitation. 
+        This is encoded as an &lt;invitation-ack/&gt; sub-element of &lt;message/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.   The &lt;invitation-ack/&gt; has an &lt;invitation/&gt; sub-element that encodes the invitation being acknowledged and a &lt;value/&gt; sub-element to encode the acknowledgement value.
+        &lt;value/&gt; has the following values:</p>
       <ul>
         <li>'Joined': The invitee has joined the channel.</li>
         <li>'Declined': The invitee is not taking up the invitation.</li>
@@ -1946,7 +1949,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       It is important that messages are all transferred from the MIX channel to the server associated with the each channel participant.   Transfer between servers will typically happen quickly and &xep0198; will deal with short connection failures between servers.   Longer connection failures could lead to message loss.  This would lead to online users (who remain connected to their servers) missing messages, and to messages being missed out of the user archive.  This section describes how MIX addresses this.
     </p>
     <p>
-      When there is a long term connection failure, the MIX channel will receive an error from the XMPP server indicating that a message failed to transfer to a recipient.   When this happens, the MIX channel MUST take responsibility to ensure that the message is retransmitted and delivered.   When the MIX channel detects a failure it will make use of an IQ Marker message to determine when the connection to the peer server is working again.  Once the channel has received a response to the marker IQ it will retransmit the pending messages.
+      When there is a long term connection failure, the MIX channel will receive an error from the XMPP server indicating that a message failed to transfer to a recipient.   When this happens, the MIX channel MUST take responsibility to ensure that the message is retransmitted and delivered.   When the MIX channel detects a failure it will make use of an IQ Marker message to determine when the connection to the peer server is working again.  Once the channel has received a response to the marker IQ it will retransmit the pending messages.  The marker is encoded as a &lt;marker/&gt; sub-element of an &lt;iq/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.
     </p>
     <example caption="Channel Sends Marker Message" ><![CDATA[
  <iq from='coven@mix.shakespeare.example'
@@ -2024,7 +2027,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     </section3>
     <section3 topic='Creating a Channel' anchor='usecase-admin-create'>
       <p>
-        A client creates a channel by sending a simple request to the MIX service.   A channel MAY be created with default parameters, as shown in the following example.   The result MUST include the name of the channel which MUST match the channel name in the request (if present).  Creating and destroying a channel is done direct from a client.
+        A client creates a channel by sending a simple request to the MIX service.   A channel MAY be created with default parameters, as shown in the following example.   The result MUST include the name of the channel which MUST match the channel name in the request (if present).  The create is encoded as a &lt;create/&gt; sub-element of &lt;iq/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.   The &lt;create/&gt; element MUST have a 'channel' attribute to specify the channel name.
       </p>
         <example caption="Creating a Channel with Default Parameters" ><![CDATA[
 <iq from='hag66@shakespeare.example/UUID-a1j/7533'
@@ -2134,6 +2137,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         MIX channels are always explicitly destroyed by an owner of the channel or by a server operator. There is no concept of temporary channel, equivalent to &xep0045; temporary room which is automatically destroyed by the server when the users leave.   However, channels MAY be configured with an explicit lifetime, after which the channel MUST be removed by the MIX service.   Where a channel is created for ad hoc use, it MAY be desirable to keep the channel for history reference or for re-use by the same set of users.  Note that the owner of the channel does not need to have presence registered in the channel in order to destroy it.
      </p>
       <p>
+        The destroy operation is encoded as a &lt;destroy/&gt; sub-element of an &lt;iq/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.  The &lt;destroy/&gt; element MUST have a 'channel' attribute to specify the channel to be destroyed.
         A client destroys a channel using a simple set operation, as shown in the following example.
       </p>
       <example caption="Client Destroys a Channel" ><![CDATA[

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -49,6 +49,7 @@
       Ensure that text defining attributes and elements reference the namespace;
       Change mix_nick_register to nick-register;
       Separate namespace for roster information;
+      rename jidmap2 to jidmap-visible;
     </p></remark>
   </revision>
   <revision>
@@ -449,7 +450,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
       <tr><td>Messages</td><td>'urn:xmpp:mix:nodes:messages'</td><td>For distributing messages to the channel. Each item of this node will contain a message sent to the channel.</td><td>Message</td><td>Message</td></tr>
       <tr><td>Participants</td><td>'urn:xmpp:mix:nodes:participants'</td><td>For storing the list of participants and the associated nick.  Channel participants are added when they join the channel and removed when they leave </td><td>Join/Leave/Set Nick</td><td>PubSub</td></tr>
       <tr><td>JID Map</td><td>'urn:xmpp:mix:nodes:jidmap'</td><td>For storing a list of bare proxy JIDs from the participants node with a 1:1 mapping to the corresponding real JIDs.</td><td>Automatic</td><td>PubSub</td></tr>
-      <tr><td>JID Maybe Visible Map</td><td>'urn:xmpp:mix:nodes:jidmap2'</td><td>For storing a list of bare proxy JIDs from the participants node with a 1:1 mapping to the corresponding real JIDs for participants that choose to share real JIDs in a channel with JID Maybe Visible mode.</td><td>Automatic</td><td>PubSub</td></tr>
+      <tr><td>JID Maybe Visible Map</td><td>'urn:xmpp:mix:nodes:jidmap-visible'</td><td>For storing a list of bare proxy JIDs from the participants node with a 1:1 mapping to the corresponding real JIDs for participants that choose to share real JIDs in a channel with JID Maybe Visible mode.</td><td>Automatic</td><td>PubSub</td></tr>
       <tr><td>Presence</td><td>'urn:xmpp:mix:nodes:presence'</td><td>For storing information about the availability status of online participants, which MAY include multiple clients for a single participant.</td><td>Presence</td><td>Presence</td></tr>
       <tr><td>Information</td><td>'urn:xmpp:mix:nodes:info'</td><td>For storing general channel information, such as description. </td><td>PubSub</td><td>PubSub</td></tr>
       <tr><td>Allowed</td><td>'urn:xmpp:mix:nodes:allowed'</td><td>For storing JIDs that are allowed to be channel participants.</td><td>PubSub</td><td>PubSub</td></tr>
@@ -523,7 +524,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     </section3>
     <section3 topic="JID Map Node" anchor="jid-map-node">
 
-      <p>The JID Map node is used to associate a proxy bare JID to its corresponding real bare JID.  The JID Map node MUST have one entry for each entry in the Participants node.  This value is added when a user joins the channel and is removed when the user leaves the channel.
+      <p>The JID Map node is used to associate a proxy bare JID to its corresponding real bare JID.   It is a PubSub node with the 'node' attribute set to 'urn:xmpp:mix:nodes:jidmap'. The JID Map node MUST have one entry for each entry in the Participants node.  This value is added when a user joins the channel and is removed when the user leaves the channel.
        Each item is identified by proxy bare JID, mapping to the real bare JID.  This node is used to give administrator access to real JIDs and participant access to real JIDs in jid-visible channels.  This node MUST NOT be modified directly using pubsub.
        In JID Visible channels, all participants MAY subscribe to this node.  In JID Hidden and JID Maybe Visible channels, only administrators can subscribe.   The JID Map node is a permanent node with one item per participant. Information is stored in a &lt;participant/&gt; element qualified by the 'urn:xmpp:mix:0' namespace.  The real JID is stored in a &lt;jid/&gt; child element of the &lt;participant/&gt; element.  </p>
       <example caption="Value of JID Map Node"><![CDATA[
@@ -539,7 +540,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     
     <section3 topic="JID Maybe Visible Map Node" anchor="jid-map2-node">
       
-      <p>The JID Maybe Visible Map node is a similar node to the JID Map node that is used in addition to the JID Map Node in JID Maybe Visible channels.   All participants may subscribe to and access this node.    It uses the same encoding as JID Map node and all participant JIDs MUST be included.    Where a participant's preference is to not share the JID, the encoded participant value is the proxy JID.   This will enable a user looking up a JID to clearly determine that the user preference is to not share the JID and to clearly distinguish this case from an erroneous proxy JID.
+      <p>The JID Maybe Visible Map node is a similar node to the JID Map node that is used in addition to the JID Map Node in JID Maybe Visible channels.   It is a PubSub node with the 'node' attribute set to 'urn:xmpp:mix:nodes:jidmap-visible'. All participants may subscribe to and access this node.    It uses the same encoding as JID Map node and all participant JIDs MUST be included.    Where a participant's preference is to not share the JID, the encoded participant value is the proxy JID.   This will enable a user looking up a JID to clearly determine that the user preference is to not share the JID and to clearly distinguish this case from an erroneous proxy JID.
       </p>
       
     </section3>
@@ -642,7 +643,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         <tr><td>'Owner'</td><td>Bare JIDs with Owner rights as defined in ACL node.  When a channel is created, the JID creating the channel is configured as an owner, unless this attribute is explicitly configured to another value.</td><td>jid-multi</td><td>-</td><td>-</td></tr>
         <tr><td>'Administrator'</td><td>Bare JIDs with Administrator rights.</td><td>jid-multi</td><td>-</td><td>-</td></tr>
         <tr><td>'End of Life'</td><td>The date and time at which the channel will be automatically removed by the server.   If this is not set, the channel is permanent.</td><td>text-single</td><td>-</td><td>-</td></tr>
-        <tr><td>'Nodes Present'</td><td>Specifies which nodes are present. Presence of  config nodes is implicit.  Jidmap node MUST be present if participants node is present. 'avatar' means that both Avatar Data and Avatar Metadata nodes are present.</td><td>list-multi</td><td>'participants'; 'presence'; 'information'; 'allowed'; 'banned'; 'jidmap2'; 'avatar'</td><td>-</td></tr>
+        <tr><td>'Nodes Present'</td><td>Specifies which nodes are present. Presence of  config nodes is implicit.  Jidmap node MUST be present if participants node is present. 'avatar' means that both Avatar Data and Avatar Metadata nodes are present.</td><td>list-multi</td><td>'participants'; 'presence'; 'information'; 'allowed'; 'banned'; 'jidmap-visible'; 'avatar'</td><td>-</td></tr>
         <tr><td>'Messages Node Subscription'</td><td>Controls who can subscribe to messages node.</td><td>list-single</td><td>'participants'; 'allowed'; 'anyone'</td><td>'participants'</td></tr>
         <tr><td>'Presence Node Subscription'</td><td>Controls who can subscribe to presence node.</td><td>list-single</td><td>'participants'; 'allowed'; 'anyone'</td><td>'participants'</td></tr>
         <tr><td>'Participants Node Subscription'</td><td>Controls who can subscribe to participants node.</td><td>list-single</td><td>'participants'; 'allowed'; 'anyone'; 'nobody'; 'admins'; 'owners'</td><td>'participants'</td></tr>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -37,6 +37,14 @@
   &skille;
   &stpeter;
   <revision>
+    <version>0.9.3</version>
+    <date>2017-06-13</date>
+    <initials>sek</initials>
+    <remark><p>
+      Remove Legacy MIX Namespace;
+    </p></remark>
+  </revision>
+  <revision>
     <version>0.9.2</version>
     <date>2017-04-03</date>
     <initials>sek</initials>
@@ -933,7 +941,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     <feature var='http://jabber.org/protocol/disco#info'/>
     <feature var='http://jabber.org/protocol/disco#items'/>
     <feature var='http://jabber.org/protocol/muc'/>
-    <feature var='http://jabber.org/protocol/mix'/>
+    <feature var='urn:xmpp:mix:0'/>
   </query>
 </iq>
 ]]></example>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -2528,13 +2528,14 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
   </section2>
 
   <section2 topic="MIX Roster Item Capability Sharing" anchor="mix-roster-capability-sharing">
-    <p>It is useful for a MIX client to know which roster members are MIX channels, as this will facilitate convenient presentation of subscribed MIX channels to the user.  A MIX client MAY request that the server return this additional information. The server MUST return the additional information. The request is made by adding to the standard roster get request and element &lt;mix-info-request/&gt; qualified by the ‘urn:xmpp:mix:0' namespace.</p>
+    <p>It is useful for a MIX client to know which roster members are MIX channels, as this will facilitate convenient presentation of subscribed MIX channels to the user.  A MIX client MAY request that the server return this additional information. The server MUST return the additional information. The request is made by extending the standard roster get request by adding a sub-element &lt;mix-info-request/&gt; to the &lt;query/&gt; element qualified by the ‘urn:xmpp:mix:0' namespace.</p>
     <example caption="Roster Get Requesting MIX Information"><![CDATA[
 <iq from='juliet@example.com/balcony'
           id='bv1bs71f'
           type='get'>
-       <query xmlns='jabber:iq:roster'/>
-       <mix-info-request xmlns=‘urn:xmpp:mix:0'/>
+       <query xmlns='jabber:iq:roster'>
+              <mix-info-request xmlns=‘urn:xmpp:mix:0'/>
+       <query/>
      </iq>
 ]]></example>  
     


### PR DESCRIPTION
      Remove Legacy MIX Namespace;
      Add mix element in message to hold MIX additional information;
      Roster Update Clarifications;
      Clarify when messages are delivered to clients;
      Extend Roster Get to select format;
      Ensure that text defining attributes and elements reference the namespace;
      Change mix_nick_register to nick-register;
      Separate namespace for roster information;
      rename jidmap2 to jidmap-visible;
      Namespace bump to mix:1;