### PR TITLE
XEP-0060: Clarify behaviour of publish-options. Fields must be registered

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -50,6 +50,12 @@
   &ralphm;
 
   <revision>
+    <version>1.13.6</version>
+    <date>2017-06-22</date>
+    <initials>dg</initials>
+    <remark><p>Clarify behaviour of publish-options. Fields must be registered</p></remark>
+  </revision>
+  <revision>
     <version>1.13.5</version>
     <date>2016-12-21</date>
     <initials>psa (XEP Editor: ssw)</initials>
@@ -2940,11 +2946,11 @@ And by opposing end them?
   </pubsub>
 </iq>
 ]]></example>
-      <p>The &lt;publish-options/&gt; element SHOULD contain a data form (see <cite>XEP-0004</cite>), whose FORM_TYPE SHOULD be "http://jabber.org/protocol/pubsub#publish-options" (see <cite>XEP-0068</cite>).</p>
-      <p>How the fields are to be handled is up to the the pubsub service, which in the language of XEP-0004 functions as a form-processing entity.</p>
-      <p>For example, the service may treat the field as a precondition, in which case the service should proceed as follows:</p>
+      <p>The &lt;publish-options/&gt; element MUST contain a data form (see <cite>XEP-0004</cite>), whose FORM_TYPE MUST be "http://jabber.org/protocol/pubsub#publish-options" (see <cite>XEP-0068</cite>).</p>
+      <p>Fields and their behaviour MUST be registered with the XMPP Registrar. Each field MUST specify whether it defines METADATA to be attached to the item, a per-item OVERRIDE of the node configuration, or a PRECONDITION to be checked against the node configuration. A pubsub service advertising support for publishing options MUST reject publications with unknown fields.</p>
+      <p>A field defined as a precondition MUST be processed as follows:</p>
       <ol>
-        <li>If the node exists and the precondition is not met, then the publish shall fail with a &conflict; error condition and a pubsub-specific condition of &lt;precondition-not-met/&gt;.</li>
+        <li>If the node exists and the precondition is not met, then the publish MUST fail with a &conflict; error condition and a pubsub-specific condition of &lt;precondition-not-met/&gt;.</li>
         <li>If the node exists and the precondition is met, then the publish succeeds.</li>
         <li>If the node does not exist and the service supports the "auto-create" feature, then the service shall auto-create the node with default configuration in all respects except those specified in the preconditions, and the publish succeeds.</li>
         <li>If the node does not exist and the service does not support the "auto-create" feature, then the publish shall fail.</li>


### PR DESCRIPTION
This is after a mailing list discussion about the true meaning of publish options.

[Rendered version](https://gultsch.de/files/xep-0060.html).