### PR TITLE
XEP-0357: Use server JID as 'from' address for notifications

### DIFF
--- a/xep-0357.xml
+++ b/xep-0357.xml
@@ -30,6 +30,12 @@
             <jid>lance@lance.im</jid>
         </author>
         <revision>
+            <version>0.3</version>
+            <date>2017-07-07</date>
+            <initials>hw</initials>
+            <remark><p>Use server JID as 'from' address for notifications.</p></remark>
+        </revision>
+        <revision>
             <version>0.2.1</version>
             <date>2016-02-16</date>
             <initials>XEP Editor (mam)</initials>
@@ -189,8 +195,8 @@
         </section2>
         <section2 topic='Business Rules'>
             <p>Each PubSub node is a delivery target for the Push Service, which could represent multiple devices for a single user.</p>
-            <p>In order to prevent information leaks, each node SHOULD be configured with a 'whitelist' access model so that only trusted entities are able to view or subscribe to published notifications. Furthermore, the 'publish-only' affiliation SHOULD be used to allow acceptable entities (such as the user's bare JID) to publish to the node to trigger notifications.</p>
-            <p>Care SHOULD  be taken to ensure that publish requests are coming from the user's server and not from other third-party client applications using the full JID of a user. A Push Service MAY opt to only accept or further process publish requests from bare JIDs to ensure that only a user's server is able to publish, but it SHOULD instead use publish options with credentials shared only with the user's server (see <link url='#publish-options'>Enabling Notifications</link>).</p>
+            <p>In order to prevent information leaks, each node SHOULD be configured with a 'whitelist' access model so that only trusted entities are able to view or subscribe to published notifications. Furthermore, the 'publish-only' affiliation SHOULD be used to allow acceptable entities (such as the server JID and the user's bare JID) to publish to the node to trigger notifications.</p>
+            <p>Care SHOULD  be taken to ensure that publish requests are coming from the user's server and not from other third-party client applications using the full JID of a user. A Push Service MAY opt to only accept or further process publish requests from server JIDs and bare user JIDs to ensure that only a user's server is able to publish, but it SHOULD instead use publish options with credentials shared only with the user's server (see <link url='#publish-options'>Enabling Notifications</link>).</p>
         </section2>
     </section1>
 
@@ -324,7 +330,7 @@
         <p>Other elements MAY be included if relevant for the notification.</p>
         <example caption='Server publishes a push notification'><![CDATA[
 <iq type='set'
-    from='user@example.com'
+    from='example.com'
     to='push-5.client.example'
     id='n12'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
@@ -349,7 +355,7 @@
 
         <example caption='Server publishes a push notification with provided publish options'><![CDATA[
 <iq type='set'
-    from='user@example.com'
+    from='example.com'
     to='push-5.client.example'
     id='n12'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>


### PR DESCRIPTION
Let example 12 and 13 in XEP-0357 use the server JID rather than the user JID for publishing notifications, as suggested [on the list][1].

[1]: https://mail.jabber.org/pipermail/standards/2017-July/033050.html