### PR TITLE
Split the dockerfile into two

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
+# Builds all XEPs by default, HTML & PDF
+# docker build . --build-arg NCORES=X --build-arg TARGETS="target1 target2"
+# from Dockerfile.base
 FROM xmppxsf/xeps-base:latest
+
+ARG NCORES=1
+ARG TARGETS="html pdf"
 
 COPY *.xml xep.* *.css *.xsl *.js *.xsl Makefile /src/
 COPY resources/*.pdf /src/resources/
 
 WORKDIR /src
-RUN OUTDIR=/var/www/html/extensions/ make -j5 html pdf
+RUN OUTDIR=/var/www/html/extensions/ make -j$NCORES $TARGETS
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,10 @@
-FROM debian:8
-MAINTAINER XSF Editors <editor@xmpp.org>
+FROM xmppxsf/xeps-base:latest
 
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get update && apt-get -y dist-upgrade
-RUN apt-get install -y xsltproc libxml2-utils libxml2 texlive fonts-inconsolata make nginx
-
-RUN mkdir /src
 COPY *.xml xep.* *.css *.xsl *.js *.xsl Makefile /src/
-RUN mkdir /src/resources
 COPY resources/*.pdf /src/resources/
-WORKDIR /src
-RUN apt-get install -y curl python python-pip texlive-xetex 
-RUN curl https://pilotfiber.dl.sourceforge.net/project/getfo/texml/texml-2.0.2/texml-2.0.2.tar.gz -o texml-2.0.2.tar.gz && tar -xf texml-2.0.2.tar.gz && pip install texml-2.0.2/ && rm -rf texml-2.0.2
-RUN apt-get install -y texlive-fonts-recommended texlive-fonts-extra
-RUN mkdir /var/www/html/extensions
-RUN OUTDIR=/var/www/html/extensions/ make html pdf
 
-RUN cat /sys/fs/cgroup/cpuset/cpuset.cpus || true
-RUN cat /proc/cpuinfo || true
+WORKDIR /src
+RUN OUTDIR=/var/www/html/extensions/ make -j5 html pdf
 
 EXPOSE 80
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,17 @@
+FROM debian:8
+MAINTAINER XSF Editors <editor@xmpp.org>
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+    apt-get -y dist-upgrade && \
+    apt-get install -y \
+        xsltproc libxml2-utils libxml2 texlive fonts-inconsolata make nginx \
+        curl python python-pip texlive-xetex texlive-fonts-recommended \
+        texlive-fonts-extra
+RUN curl https://pilotfiber.dl.sourceforge.net/project/getfo/texml/texml-2.0.2/texml-2.0.2.tar.gz -o texml-2.0.2.tar.gz && \
+    tar -xf texml-2.0.2.tar.gz && \
+    pip install texml-2.0.2/ && \
+    rm -rf texml-2.0.2
+
+RUN mkdir -p /src/resources /var/www/html/extensions

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,3 +1,7 @@
+# Base docker image for building XEPs
+# Sets up directories and dependencies
+# docker build . -t xmppxsf/xeps-base -f Dockerfile.base
+
 FROM debian:8
 MAINTAINER XSF Editors <editor@xmpp.org>
 


### PR DESCRIPTION
- Create a `Dockerfile.base` that contains all the dependencies and required directory structure
**that image will need to be published to the hub** (as xmppxsf/xeps-base currently)
- Put minimal content into the `Dockerfile` and allow the number of make jobs and the make targets to be parametrized through docker build arguments.

This should, once someone publishes the base image to the hub, cut the full build time in half or more (because the old dockerfile was mixing copy and install operations, therefore invalidating part of the cache whenever the source changed).

Providing the `NCORES` build arg lets the editor/user choose how many jobs should be used at the same time, which defaults to 1, but should be set as high as the number of cores in the build machine. From my (very unscientific) tests, build speed increases proportionally with the number of jobs running, since latex output and CPU performance is the bottleneck.
The `TARGETS` build arg also allows customization of what should be running.