### PR TITLE
XEP-0319: Make the schema more precise about a date being a xs:dateTime

### DIFF
--- a/xep-0319.xml
+++ b/xep-0319.xml
@@ -25,6 +25,12 @@
   <shortname>idle</shortname>
   &tobias;
   <revision>
+    <version>1.0.1</version>
+    <date>2017-07-17</date>
+    <initials>egp</initials>
+    <remark><p>Make the schema more precise about a date being a xs:dateTime.</p></remark>
+  </revision>
+  <revision>
     <version>1.0</version>
     <date>2015-04-02</date>
     <initials>XEP editor (mam)</initials>
@@ -98,7 +104,7 @@
 
   <xs:element name="idle">
     <xs:complexType>
-      <xs:attribute name="since" use="required" type="xs:string"/>
+      <xs:attribute name="since" use="required" type="xs:dateTime"/>
     </xs:complexType>
   </xs:element>
 


### PR DESCRIPTION
This section is non-normative, and is already specified more strongly in XEP-0082, so it shouldn’t change anything.