### PR TITLE
XEP-0234: Add missing length attribute to XML Schema

### DIFF
--- a/xep-0234.xml
+++ b/xep-0234.xml
@@ -25,6 +25,12 @@
   &stpeter;
   &lance;
   <revision>
+    <version>0.18.2</version>
+    <date>2017-08-23</date>
+    <initials>ps</initials>
+    <remark><p>Add missing length attribute to XML schema.</p></remark>
+  </revision>
+  <revision>
     <version>0.18.1</version>
     <date>2017-05-20</date>
     <initials>egp</initials>
@@ -1054,6 +1060,7 @@ a=file-range:1024-*]]></code>
 
   <xs:complexType name='fileTransferRangeType'>
     <xs:attribute name='offset' type='xs:nonNegativeInteger' use='optional' default='0' />
+    <xs:attribute name='length' type='xs:nonNegativeInteger' use='optional' />
     <xs:all xmlns:h='urn:xmpp:hashes:2' minOccurs='0'>
       <xs:element ref='h:hash' minOccurs='0' maxOccurs='unbounded' />
     </xs:all>
@@ -1080,7 +1087,7 @@ a=file-range:1024-*]]></code>
 </section1>
 
 <section1 topic='Acknowledgements' anchor='ack'>
-  <p>Thanks to Diana Cionoiu, Olivier Crête, Viktor Fast, Philipp Hancke, Waqas Hussain, Justin Karneges, Steffen Larsen, Yann Leboulanger, Marcus Lundblad, Robert McQueen, Joe Maissel, Glenn Maynard, Ali Sabil, Sjoerd Simons, Will Thompson, Matthew Wild, and Jiří Zárevúcky for their feedback.</p>
+  <p>Thanks to Diana Cionoiu, Olivier Crête, Viktor Fast, Philipp Hancke, Waqas Hussain, Justin Karneges, Steffen Larsen, Yann Leboulanger, Marcus Lundblad, Robert McQueen, Joe Maissel, Glenn Maynard, Ali Sabil, Sjoerd Simons, Will Thompson, Matthew Wild, Paul Schaub and Jiří Zárevúcky for their feedback.</p>
 </section1>
 
 </xep>


### PR DESCRIPTION
fileTransferRangeType was missing the length attribute in the XML schema.