### PR TITLE
XEP-0359: clarifications and removed 'overwrite' wording

### DIFF
--- a/xep-0359.xml
+++ b/xep-0359.xml
@@ -9,7 +9,7 @@
 <xep>
 <header>
   <title>Unique and Stable Stanza IDs</title>
-  <abstract>This specification describes unique and stable IDs for stanzas.</abstract>
+  <abstract>This specification describes unique and stable IDs for messages.</abstract>
   &LEGALNOTICE;
   <number>0359</number>
   <status>Experimental</status>
@@ -23,6 +23,17 @@
   <supersededby/>
   <shortname>stanza-id</shortname>
   &flow;
+  <revision>
+	  <version>0.5.0</version>
+	  <date>2017-08-23</date>
+	  <initials>dg</initials>
+	  <remark>
+		  <ul>
+			  <li>Business rules clarifications</li>
+			  <li>Define stanza-ids for messages only</li>
+		  </ul>
+	  </remark>
+  </revision>
   <revision>
     <version>0.4.1</version>
     <date>2017-05-20</date>
@@ -94,14 +105,14 @@
   </revision>
 </header>
 <section1 topic='Introduction' anchor='intro'>
-  <p>This XEP introduces unique and stable IDs for stanzas, which are beneficial in various ways. For example, they can be used together with &xep0313; to uniquely identify a message within an archive. They are also useful in the context of &xep0045; conferences, as they allow to identify a message reflected by a MUC service back to the originating entity.</p>
+  <p>This XEP introduces unique and stable IDs for messages, which are beneficial in various ways. For example, they can be used together with &xep0313; to uniquely identify a message within an archive. They are also useful in the context of &xep0045; conferences, as they allow to identify a message reflected by a MUC service back to the originating entity.</p>
 </section1>
 <section1 topic='Use Cases' anchor='usecases'>
   <section2 topic='Unique stanza IDs' anchor='stanza-id'>
   <example caption='The stanza ID extension.'><![CDATA[
 <stanza-id xmlns='urn:xmpp:sid:0'
            id='de305d54-75b4-431b-adb2-eb6b9e546013'
-           by='room@muc.xmpp.org'/>
+           by='room@muc.example.com'/>
 ]]></example>
   <p>In order to create a &stanza-id; extension element, the creating XMPP entity generates and sets the value of the 'id' attribute, and puts its own XMPP address as value of the 'by' attribute. The value of the 'id' attribute must be unique and stable, i.e. it MUST NOT change later for some reason within the scope of the 'by' value. Thus the IDs defined in this extension MUST be unique and stable within the scope of the generating XMPP entity. It is RECOMMENDED that the ID generating service uses UUID and the algorithm defined in &rfc4122; to generate the IDs.</p>
   </section2>
@@ -111,7 +122,7 @@
 	</p>
 	<example caption='A message stanza with the stanza ID extension.'><![CDATA[
 <message xmlns='jabber:client'
-         to='room@muc.example.org'
+         to='room@muc.example.com'
          type='groupchat'>
   <body>Typical body text</body>
   <origin-id xmlns='urn:xmpp:sid:0' id='de305d54-75b4-431b-adb2-eb6b9e546013'/>
@@ -121,39 +132,39 @@
 	</p>
 	<example caption='A message stanza with the stanza ID extension.'><![CDATA[
 <message xmlns='jabber:client'
-         to='room@muc.example.org'
+         to='room@muc.example.com'
          type='groupchat'>
   <body>Typical body text</body>
   <stanza-id xmlns='urn:xmpp:sid:0'
              id='5f3dbc5e-e1d3-4077-a492-693f3769c7ad'
-             by='room@muc.example.org'/>
+             by='room@muc.example.com'/>
   <origin-id xmlns='urn:xmpp:sid:0' id='de305d54-75b4-431b-adb2-eb6b9e546013'/>
 </message>]]></example>
   </section2>
 </section1>
 <section1 topic='Business Rules' anchor='rules'>
   <ol>
-	<li>XMPP entities, which are routing stanzas, MUST NOT strip any elements qualified by the 'urn:xmpp:sid:0' namespace from message stanzas. They SHOULD however ensure that those elements contain only the attributes defined herein, and take appropriate countermeasures if this is not the case (e.g. removing those attributes).</li>
 	<li>The values of the 'id' attribute SHOULD be unpredictable.</li>
-	<li>Stanza ID generating entities, which encounter a &stanza-id; element where 'id' is already set and where the 'by' attribute matches their own XMPP address, MUST ignore the existing value of 'id' and override it.</li>
+	<li>Stanza ID generating entities, which encounter a &stanza-id; element where the 'by' attribute matches the 'by' attribute they would otherwise set, MUST delete that element even if they are not adding their own stanza ID.</li>
+	<li>Entities, which are routing stanzas, SHOULD NOT strip any elements qualified by the 'urn:xmpp:sid:0' namespace from message stanzas unless the preceding rule applied to those elements.</li>
 	<li>Stanzas MUST possess, in the direct child level of the stanza, at most one &stanza-id; extension element with the same XMPP address as value of the 'by' attribute.</li>
 	<li>Every &stanza-id; extension element MUST have the 'id' attribute and the 'by' attribute set.</li>
 	<li>Every &stanza-id; and &origin-id; extension element MUST always possess an 'id' attribute and MUST NOT have any child elements or text content.</li>
-	<li>The value of the 'by' attribute MUST be the XMPP address of the entity assigning the unique and stable stanza ID. Note that XMPP addresses are normalized as defined in &rfc6122;</li>
+	<li>The value of the 'by' attribute MUST be the XMPP address of the entity assigning the unique and stable stanza ID. For one-on-one messages the assigning entity is the account. In groupchats the assigning entity is the room. Note that XMPP addresses are normalized as defined in &rfc6122;.</li>
   </ol>
 </section1>
 <section1 topic='Discovering Support' anchor='disco'>
-  <p>An entity that follows the business rules, especially the rule on overriding the ID in elements where the by atttribute matches the entities own XMPP address, SHOULD announce the 'urn:xmpp:sid:0' namespace in its disco features allowing other entities to verify that those business rules are properly enforced.</p>
-  <example caption='Client sends service discovery request to server'><![CDATA[
+  <p>An entity that follows the business rules, especially the rule on overriding the ID in elements where the by atttribute matches the 'by' attribute they would otherwise set, SHOULD announce the 'urn:xmpp:sid:0' namespace in its disco features allowing other entities to verify that those business rules are properly enforced.</p>
+  <example caption='Client sends service discovery request to the room'><![CDATA[
 <iq from='romeo@montague.tld/garden'
     id='somethingrandom'
-    to='montague.tld'
+    to='room@muc.example.com'
     type='get'>
   <query xmlns='http://jabber.org/protocol/disco#info' />
 </iq>
 ]]></example>
   <example caption='Servers includes the stanza ID namespace in its features'><![CDATA[
-<iq from='montague.tld'
+<iq from='room@muc.example.com'
     to='romeo@montague.tld/garden'
     id='somethingrandom'
     type='result'>
@@ -167,6 +178,7 @@
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
   <p>The value of the 'id' attribute should not provide any further information besides the opaque ID itself. Entities observing the value MUST NOT be able to infer any information from it, e.g. the size of the message archive. The value of 'id' MUST be considered a non-secret value.</p>
+  <p>Before processing the stanza ID of a message and using it for deduplication purposes or for MAM catchup, the receiving entity SHOULD ensure that the stanza ID could not have been faked, by verifying that the entity referenced in the by attribute does annouce the 'urn:xmpp:sid:0' namespace in its disco features.</p>
 </section1>
 <section1 topic='IANA Considerations' anchor='iana'>
   <p>This document requires no interaction with &IANA;.</p>


### PR DESCRIPTION
This commit changes some of the wording to clarify that the by attribute
for messages tagged by the server should be either the account jid or
the room jid (as opposed to the server jid for example)

To further clarify this the examples (including the disco example) were
all changed to have the same jid/by-attribute. (A room in that example)

The business rules had some wording that an entity would overwrite the
ID in existing 'faked' stanza-ids instead of removing the faked and
re-adding a non-faked one. However that doesn't work for faked messages
that are not archived (don't have a stanza-id).

rendered version [here](https://gultsch.de/files/xep-0359.html)