### PR TITLE
Build xeps container on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-addons:
-  apt:
-    packages:
-      - xsltproc
-      - libxml2-utils
+sudo: required
+services:
+  - docker
+before_install:
+  - docker pull xmppxsf/xeps-base
 script:
-  - make all
+  - docker build -t xmppxsf/xeps .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builds all XEPs by default, HTML & PDF
-# docker build . --build-arg NCORES=X --build-arg TARGETS="target1 target2"
+# docker build . --build-arg NCORES=X --build-arg TARGETS="html pdf"
 # from Dockerfile.base
 FROM xmppxsf/xeps-base:latest
 


### PR DESCRIPTION
This makes what is built on CI a bit closer to what gets deployed and means we only have to keep track of deps in a single place.

~Blocking on xsf/xep-docker-base#1~