### PR TITLE
XEP-0234, XEP-0300: Add hash-used element to hashes and make use of it in Jingle File Transfer

### DIFF
--- a/xep-0234.xml
+++ b/xep-0234.xml
@@ -25,6 +25,12 @@
   &stpeter;
   &lance;
   <revision>
+    <version>0.18.2</version>
+    <date>2017-08.21</date>
+    <initials>ps</initials>
+    <remark><p>Make use of &lt;hash-used/&gt; from XEP-0300.</p></remark>
+  </revision>
+  <revision>
     <version>0.18.1</version>
     <date>2017-05-20</date>
     <initials>egp</initials>
@@ -354,7 +360,12 @@
     <tr>
       <td>hash</td>
       <td>A hash of the file content, using the &lt;hash/&gt; element defined in &xep0300; and qualifed by the 'urn:xmpp:hashes:2' namespace. Multiple hashes MAY be included for hash agility.</td>
-      <td>REQUIRED when offering a file, otherwise OPTIONAL</td>
+      <td>See &lt;hash-used/&gt;</td>
+    </tr>
+    <tr>
+      <td>hash-used</td>
+      <td>Alternatively to a &lt;hash/&gt; element, the initiator can also include a &lt;hash-used/&gt; element. This avoids the need to read the file twice to calculate the hash.</td>
+      <td>Either a &lt;hash/&gt; or a &lt;hash-used/&gt; element MUST be included when offering a file.</td>
     </tr>
     <tr>
       <td>media-type</td>
@@ -785,7 +796,7 @@ a=file-range:1024-*]]></code>
   <section2 topic='Checksum' anchor='hash'>
     <p>At any time during the lifetime of the file transfer session, the File Sender can communicate the checksum of the file to the File Receiver.</p>
     <p>This can be done in the session-initiate message if the File Sender already knows the checksum, as shown above in Example 3.</p>
-    <p>After the session-initiate message, this can also be done by sending a session-info message containing a &lt;checksum/&gt; element qualified by the 'urn:xmpp:jingle:apps:file-transfer:5' namespace. The &lt;checksum/&gt; element SHOULD contain 'creator' and 'name' attributes sufficient to identitfy the content the checksum belongs to.  Additionally, the &lt;checksum/&gt; element MUST contain a &lt;file/&gt; element which MUST contain at least one &lt;hash/&gt; element qualified by the 'urn:xmpp:hashes:2' namespace. Each &lt;hash/&gt; element contains a checksum of the file data produced in accordance with the hashing function specified by the 'algo' attribute, which MUST be one of the functions listed in the &ianahashes;.</p>
+    <p>After the session-initiate message, this can also be done by sending a session-info message containing a &lt;checksum/&gt; element qualified by the 'urn:xmpp:jingle:apps:file-transfer:5' namespace. In such a case however, the session-initiate message MUST contain a &lt;hash-used/&gt; element. The &lt;checksum/&gt; element SHOULD contain 'creator' and 'name' attributes sufficient to identitfy the content the checksum belongs to.  Additionally, the &lt;checksum/&gt; element MUST contain a &lt;file/&gt; element which MUST contain at least one &lt;hash/&gt; or &lt;hash-used/&gt; element qualified by the 'urn:xmpp:hashes:2' namespace. Each &lt;hash/&gt; element contains a checksum of the file data produced in accordance with the hashing function specified by the 'algo' attribute, which MUST be one of the functions listed in the &ianahashes;.</p>
     <example caption="Initiator sends checksum in session-info"><![CDATA[
 <iq from='romeo@montague.example/dr4hcr0st3lup4c'
     id='kqh401b5'
@@ -1080,7 +1091,7 @@ a=file-range:1024-*]]></code>
 </section1>
 
 <section1 topic='Acknowledgements' anchor='ack'>
-  <p>Thanks to Diana Cionoiu, Olivier Crête, Viktor Fast, Philipp Hancke, Waqas Hussain, Justin Karneges, Steffen Larsen, Yann Leboulanger, Marcus Lundblad, Robert McQueen, Joe Maissel, Glenn Maynard, Ali Sabil, Sjoerd Simons, Will Thompson, Matthew Wild, and Jiří Zárevúcky for their feedback.</p>
+  <p>Thanks to Diana Cionoiu, Olivier Crête, Viktor Fast, Philipp Hancke, Waqas Hussain, Justin Karneges, Steffen Larsen, Yann Leboulanger, Marcus Lundblad, Robert McQueen, Joe Maissel, Glenn Maynard, Ali Sabil, Sjoerd Simons, Will Thompson, Matthew Wild, Paul Schaub and Jiří Zárevúcky for their feedback.</p>
 </section1>
 
 </xep>

--- a/xep-0300.xml
+++ b/xep-0300.xml
@@ -415,7 +415,7 @@
 
 <section1 topic='Acknowledgements' anchor='ack'>
   <p>Thanks to Dave Cridland, Waqas Hussain, Glenn Maynard, Remko
-  Tronçon, and Christian Schudt for their input.</p>
+  Tronçon, Paul Schaub and Christian Schudt for their input.</p>
 </section1>
 
 </xep>

--- a/xep-0300.xml
+++ b/xep-0300.xml
@@ -25,6 +25,12 @@
   &ksmith;
   &tobias;
   <revision>
+    <version>0.5.2</version>
+    <date>2017-08-21</date>
+    <initials>ps</initials>
+    <remark><p>Add hash-used element</p></remark>
+  </revision>
+  <revision>
     <version>0.5.1</version>
     <date>2017-03-17</date>
     <initials>fs</initials>
@@ -93,6 +99,8 @@
   <p>An XMPP protocol can include more than one instance of the &lt;hash/&gt; element, as long as each one has a different value for the 'algo' attribute:</p>
   <code><![CDATA[<hash xmlns='urn:xmpp:hashes:2' algo='sha-1'>2AfMGH8O7UNPTvUVAM9aK13mpCY=</hash>
 <hash xmlns='urn:xmpp:hashes:2' algo='sha-256'>2XarmwTlNxDAMkvymloX3S5+VbylNrJt/l5QyPa+YoU=</hash>]]></code>
+  <p>In certain scenarios it makes sense to communicate the hash algorithm that is used prior to the calculation of the hash value.</p>
+  <code><![CDATA[<hash-used xmlns='urn:xmpp:hashes:2' algo='sha-256'/>]]></code>
   <p>The value of the 'algo' attribute MUST be one of the values from the &ianahashes; maintained by &IANA;, or one of the values
   defined in the following table.</p>
   <table caption='Additional Hash Function Textual Names'>
@@ -390,6 +398,14 @@
           <xs:attribute name='algo' type='xs:NCName' use='required'/>
         </xs:extension>
       </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='hash-used'>
+    <xs:complexType>
+      <xs:extension base='empty'>
+        <xs:attribute name='algo' type='xs:NCName' use='required'/>
+      </xs:extension>
     </xs:complexType>
   </xs:element>
 


### PR DESCRIPTION
As discussed in https://mail.jabber.org/pipermail/standards/2017-August/033116.html