### PR TITLE
XEP-0045: Clarify wording for a client re-syncing to a MUC

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -1385,6 +1385,7 @@
 </presence>
 ]]></example>
       <p>Before attempting to enter the room, a MUC-compliant client SHOULD first discover its reserved room nickname (if any) by following the protocol defined in the <link url='#reservednick'>Discovering Reserved Room Nickname</link> section of this document.</p>
+      <p>When a MUC service receives an &lt;x/&gt; tagged join stanza from an already-joined client (as identified by the client's full JID), the service SHOULD assume that the client lost its synchronization, and therefore it SHOULD send exactly the same stanzas to the client as if it would actually join the MUC. The server MAY also send a presence update to the other participants according to the received join presence.</p>
     </section3>
 
     <section3 topic='Presence Broadcast' anchor='enter-pres'>

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -1385,7 +1385,7 @@
 </presence>
 ]]></example>
       <p>Before attempting to enter the room, a MUC-compliant client SHOULD first discover its reserved room nickname (if any) by following the protocol defined in the <link url='#reservednick'>Discovering Reserved Room Nickname</link> section of this document.</p>
-      <p>When a MUC service receives an &lt;x/&gt; tagged join stanza from an already-joined client (as identified by the client's full JID), the service SHOULD assume that the client lost its synchronization, and therefore it SHOULD send exactly the same stanzas to the client as if it would actually join the MUC. The server MAY also send a presence update to the other participants according to the received join presence.</p>
+      <p>When a MUC service receives an &lt;x/&gt; tagged join stanza from an already-joined client (as identified by the client's full JID), the service should assume that the client lost its synchronization, and therefore it SHOULD send exactly the same stanzas to the client as if it actually just joined the MUC. The server MAY also send a presence update to the other participants according to the received join presence.</p>
     </section3>
 
     <section3 topic='Presence Broadcast' anchor='enter-pres'>


### PR DESCRIPTION
TL;DR: whenever a client (re)sends a join, the MUC service should return
everything a newly joining client needs to know.

Discussion in
https://mail.jabber.org/pipermail/standards/2016-June/031180.html