### PR TITLE
XEP-0060: Add pubsub#multi-items in Publish-Subscribe features

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -977,6 +977,9 @@ And by opposing end them?
       <field var='pubsub#contact' label='People to contact with questions' type='jid-multi'>
         <value>bard@shakespeare.lit</value>
       </field>
+      <field var='pubsub#max_items' label='Max # of items to persist' type='text-single'>
+        <value>120</value>
+      </field>
       <field var='pubsub#owner' label='Node owners' type='jid-multi'>
         <value>hamlet@denmark.lit</value>
       </field>
@@ -5086,7 +5089,7 @@ And by opposing end them?
     </tr>
     <tr>
       <td>multi-items</td>
-      <td>The service supports the storage of multiple items per node.</td>
+      <td>The service supports the storage of multiple items per node. It requires the pubsub#max_items configuration item to be exposed to the user and allow sensible values (above one) to be set in <link url='#owner-configure'>Configure a Node</link>.</td>
       <td>OPTIONAL</td>
       <td>&#160;</td>
     </tr>
@@ -6220,6 +6223,9 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
   <field var='pubsub#type'
          type='text-single'
          label='Payload type'/>
+  <field var='pubsub#max_items'
+         type='text-single'
+         label='Max # of items to persist'/>
 </form_type>
 ]]></code>
     </section3>

--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -5085,6 +5085,12 @@ And by opposing end them?
       <td>Refer to <cite>XEP-0248</cite></td>
     </tr>
     <tr>
+      <td>multi-items</td>
+      <td>The service supports the storage of multiple items per node.</td>
+      <td>OPTIONAL</td>
+      <td>&#160;</td>
+    </tr>
+    <tr>
       <td>multi-subscribe</td>
       <td>A single entity may subscribe to a node multiple times.</td>
       <td>OPTIONAL</td>
@@ -5971,6 +5977,11 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
   <doc>XEP-0060</doc>
 </var>
 <var>
+  <name>http://jabber.org/protocol/pubsub#multi-items</name>
+  <desc>The service supports the storage of multiple items per node.</desc>
+  <doc>XEP-0060</doc>
+</var>
+<var>
   <name>http://jabber.org/protocol/pubsub#multi-subscribe</name>
   <desc>A single entity may subscribe to a node multiple times.</desc>
   <doc>XEP-0060</doc>
@@ -6829,6 +6840,7 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings
                 <xs:enumeration value='meta-data'/>
                 <xs:enumeration value='modify-affiliations'/>
                 <xs:enumeration value='multi-collection'/>
+                <xs:enumeration value='multi-items'/>
                 <xs:enumeration value='multi-subscribe'/>
                 <xs:enumeration value='outcast-affiliation'/>
                 <xs:enumeration value='persistent-items'/>

--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -5089,7 +5089,7 @@ And by opposing end them?
     </tr>
     <tr>
       <td>multi-items</td>
-      <td>The service supports the storage of multiple items per node. It requires the pubsub#max_items configuration item to be exposed to the user and allow sensible values (above one) to be set in <link url='#owner-configure'>Configure a Node</link>.</td>
+      <td>The service supports the storage of multiple items per node. It requires the pubsub#max_items configuration item to be exposed to the user and allow sensible values (higher than one) to be set in <link url='#owner-configure'>Configure a Node</link>.</td>
       <td>OPTIONAL</td>
       <td>&#160;</td>
     </tr>


### PR DESCRIPTION
Adding this features will help clients to be sure that the server can support several items per node, required for future changes on PEP and PEP-related XEPs.