### PR TITLE
Limit text width of XEPs on large viewports

### DIFF
--- a/xmpp.css
+++ b/xmpp.css
@@ -2,10 +2,10 @@ BODY {
     background-color: #ffffff;
     color: #000000;
     font-family: Verdana, Arial, Helvetica, Geneva, sans-serif;
-    font-size: small;
     line-height: 130%;
-    margin-left: 7%;
-    margin-right: 7%;
+    width: 90%;
+    max-width: 60em;
+    margin: 0 auto;
     }
 #left {
     border: 0px;


### PR DESCRIPTION
XEPs are currently very hard to read even on fairly standard sized 1080p monitors because the text is more-or-less full width. It would also be nice to scale the fontsize based on the viewport size at a later date, but incremental changes.

/cc @guusdk because I think the website serves this file from somewhere else and it might have to be copy/pasted (sigh)