### PR TITLE
Hide overflow (with scroll) on long code blocks

### DIFF
--- a/xmpp.css
+++ b/xmpp.css
@@ -58,6 +58,7 @@ pre {
     background-color: #e0e9f2;
     padding: 0.4em;
     border: 1px solid #369;
+    overflow: scroll;
     }
 ul {
     list-style: disc outside;
@@ -154,5 +155,5 @@ A:visited.pagehead {
     white-space: nowrap;
     }
 .event {
-	color: #336699;
-}
+    color: #336699;
+    }


### PR DESCRIPTION
Fixes #514

![overflow](https://user-images.githubusercontent.com/512573/30712132-971ef920-9ed0-11e7-9199-56fa0553c62d.png)