### PR TITLE
XEP-0030: Service Discovery - Removed the order restriction of identities/features in the disco-info XML schema

### DIFF
--- a/xep-0030.xml
+++ b/xep-0030.xml
@@ -874,8 +874,20 @@ xmpp:romeo@montague.net?disco;type=get;request=items
   <xs:element name='query'>
     <xs:complexType>
       <xs:sequence minOccurs='0'>
-        <xs:element ref='identity' maxOccurs='unbounded'/>
-        <xs:element ref='feature' maxOccurs='unbounded'/>
+        <xs:choice>
+          <xs:sequence>
+            <xs:element ref='feature' maxOccurs='unbounded'/>
+            <xs:element ref='identity'/>
+          </xs:sequence>
+          <xs:sequence>
+            <xs:element ref='identity' maxOccurs='unbounded'/>
+            <xs:element ref='feature'/>
+          </xs:sequence>
+        </xs:choice>
+        <xs:choice minOccurs='0' maxOccurs='unbounded'>
+          <xs:element ref='identity'/>
+          <xs:element ref='feature'/>
+        </xs:choice>
       </xs:sequence>
       <xs:attribute name='node' type='xs:string' use='optional'/>
     </xs:complexType>


### PR DESCRIPTION
I was using the XML schema files provided by XEP-0030 to validate some XMPP traffic and stumbled upon a stanza that did not pass the validation process because the order of identities and features was wrong.

I carefully read the specification and asked the jdev muc for advice, we came to the conclusion that the schema file is too restrictive and the order of identities and features should not be forced.

This PR removes the order forced by the current schema.