### PR TITLE
XEP-0280: remove refs to hints

### DIFF
--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -44,6 +44,14 @@
     <jid>linuxwolf@outer-planes.net</jid>
   </author>
   <revision>
+    <version>0.13.0</version>
+    <date>2017-10-10</date>
+    <initials>ssw</initials>
+    <remark>
+      <p>Remove references to XEP-0334.</p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.12.0</version>
     <date>2017-02-16</date>
     <initials>gl</initials>
@@ -373,7 +381,12 @@
   </p>
 
   <ul>
-    <li> The sending client MAY exclude a &MESSAGE; from being forwarded to other Carbons-enabled resources, by adding a &lt;private/&gt; element qualified by the namespace "urn:xmpp:carbons:2" and a &lt;no-copy/&gt; hint as described in &xep0334; as child elements of the &MESSAGE; stanza.</li>
+    <li>
+      The sending client MAY exclude a &MESSAGE; from being forwarded to other
+      Carbons-enabled resources, by adding a &lt;private/&gt; element qualified
+      by the namespace "urn:xmpp:carbons:2" as a child elements of the &MESSAGE;
+      stanza.
+    </li>
     <li>The sending server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resources of the sender.</li>
     <li>The receiving server MUST NOT deliver forwarded &MESSAGE;s to the other Carbons-enabled resource of the recipient,</li>
     <li>and the receiving server SHOULD remove the &lt;private/&gt; element before delivering to the recipient.</li>
@@ -391,7 +404,6 @@
   <body>Neither, fair saint, if either thee dislike.</body>
   <thread>0e3141cd80894871a68e6fe6b1ec56fa</thread>
   <private xmlns='urn:xmpp:carbons:2'/>
-  <no-copy xmlns='urn:xmpp:hints'/>
 </message>]]></example>
 
   <example caption='Romeo&apos;s server delivers original message, without creating Carbon copies'><![CDATA[
@@ -402,7 +414,6 @@
   <body>Neither, fair saint, if either thee dislike.</body>
   <thread>0e3141cd80894871a68e6fe6b1ec56fa</thread>
   <private xmlns='urn:xmpp:carbons:2'/>
-  <no-copy xmlns='urn:xmpp:hints'/>
 </message>]]></example>
 </section1>
 <section1 topic='Business Rules' anchor='bizrules'>


### PR DESCRIPTION
Remove references to 0334 from carbons in favor of just using the `<private/>` hint and not duplicating functionality. Since 0334 was not advanced by the council due to concerns with how it would be maintained in the future, it seems best to stick with just private for now and not require adding two things. Naturally, the 0334 hints could still be used by clients that support them.