### PR TITLE
add styling protoxep to inbox

### DIFF
--- a/inbox/styling.xml
+++ b/inbox/styling.xml
@@ -1,0 +1,367 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY % ents SYSTEM 'xep.ent'>
+%ents;
+<!ENTITY rfc7764 "<span class='ref'><link url='http://tools.ietf.org/html/rfc7764'>RFC 7764</link></span> <note>RFC 7764: Guidance on Markdown: Design Philosophies, Stability Strategies, and Select Registrations &lt;<link url='http://tools.ietf.org/html/rfc7764'>http://tools.ietf.org/html/rfc7764</link>&gt;.</note>" >
+<!ENTITY uax9 "<span class='ref'>Unicode Standard Annex #9</span> <note>Unicode Standard Annex #9, &quot;Unicode Bidirectional Algorithm&quot;, edited by Mark Davis, Aharon Lanin, and Andrew Glass. An integral part of The Unicode Standard, &lt;<link url='http://unicode.org/reports/tr9/'>http://unicode.org/reports/tr9/</link>&gt;.</note>" >
+]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+<header>
+  <title>Message Styling</title>
+  <abstract>
+    This specification defines a plain-text formatting syntax for use in
+    exchanging instant messages with simple text styling.
+  </abstract>
+  &LEGALNOTICE;
+  <number>xxxx</number>
+  <status>ProtoXEP</status>
+  <type>Standards Track</type>
+  <sig>Standards</sig>
+  <approver>Council</approver>
+  <dependencies>
+    <spec>XMPP Core</spec>
+    <spec>XEP-0001</spec>
+  </dependencies>
+  <supersedes/>
+  <supersededby/>
+  <shortname>styling</shortname>
+  &sam;
+  <revision>
+    <version>0.0.1</version>
+    <date>2017-10-28</date>
+    <initials>ssw</initials>
+    <remark><p>First draft.</p></remark>
+  </revision>
+</header>
+<section1 topic='Introduction' anchor='intro'>
+  <p>
+    Historically, XMPP has had no system for simple text styling.
+    Instead, specifications like &xep0071; that require full layout engines have
+    been used, leading to numerous security issues with implementations.
+    Some clients have also performed their own formatting based on identifiers
+    in the body.
+    While this has worked well for those clients, it is not interoperable and
+    leads to clients each supporting their own informal styling languages.
+  </p>
+  <p>
+    This specification aims to provide a single, interoperable text styling
+    language that can be used by entities that do not require full layout
+    engines.
+  </p>
+</section1>
+<section1 topic='Requirements' anchor='reqs'>
+  <ul>
+    <li>
+      Clients that do not support this specification MUST still be able to
+      receive messages sent by clients using this specification and display them
+      in a human-readable form.
+    </li>
+    <li>
+      Clients that support this specification MUST NOT be required to use a
+      layout engine such as HTML or LaTeX.
+    </li>
+    <li>
+      Messages formatted using this specification MUST NOT hinder readability on
+      receiving clients regardless of client background color, contrast, or
+      window size.
+    </li>
+    <li>
+      Messages formatted using this specification MUST NOT hinder readability by
+      users with color vision deficiency or impaired vision.
+    </li>
+    <li>
+      Messages formatted with this specification MUST render correctly in
+      locales with right-to-left (RTL) layouts without causing confusion.
+    </li>
+    <li>
+      Clients that support this specification MUST NOT be required to extract
+      metadata unrelated to formatting or text style from the message.
+    </li>
+    <li>
+      Servers MUST NOT need to implement any new functionality for this
+      specification to be supported.
+    </li>
+  </ul>
+</section1>
+<section1 topic='Glossary' anchor='glossary'>
+  <p>
+    Many important terms used in this document are defined in &unicode;.
+    The terms "left-to-right" (LTR) and "right-to-left" (RTL) are defined in
+    &uax9;.
+  </p>
+  <dl>
+    <di>
+      <dt>Formal markup language</dt>
+      <dd>
+        A structured markup language such as LaTeX, SGML, HTML, or XML that is
+        formally defined and may include metadata unrelated to formatting or
+        text style.
+      </dd>
+    </di>
+    <di>
+      <dt>Formatted text</dt>
+      <dd>
+        Text that includes non-textual information coded in a particular way
+        that affects the interpretation of the text by computer programs
+        (&rfc7764;).
+      </dd>
+    </di>
+    <di>
+      <dt>Plain text</dt>
+      <dd>
+        Text that does not convey any particular formatting or interpretation of
+        the text by computer programs.
+      </dd>
+    </di>
+    <di>
+      <dt>Whitespace character</dt>
+      <dd>
+        Any Unicode scalar value which has the property "White_Space" or is in
+        category Z in the Unicode Character Database.
+      </dd>
+    </di>
+  </dl>
+</section1>
+<section1 topic='Use Cases' anchor='usecases'>
+  <ul>
+    <li>
+      As an user sending an instant message to a friend, I want to be able to
+      emphasize an important part of my message.
+    </li>
+    <li>
+      As a software developer, I want to be able to send pre-formatted,
+      monospace, block or inline text to another developer.
+    </li>
+    <li>
+      As a multi-user chat user I want to quote something someone said earlier
+      in the chat and make it evident that the text is a quotation.
+    </li>
+  </ul>
+</section1>
+<section1 topic='Discovering support' anchor='disco'>
+  <section2 topic='Explicit Discovery' anchor='discovery-explicit'>
+    <p>
+      If an entity supports this specification it MUST advertise the fact by
+      returning a feature of 'urn:xmpp:styling:0' &VNOTE; in response to a
+      &xep0030; information request (or by advertising this namespace in the
+      dynamic profile of service discovery defined in &xep0115;).
+    </p>
+    <example caption='Disco response'><![CDATA[
+<iq type='result'
+    from='viola@example.net/seashore-Iaqu8ith'
+    to='captain@example.net/illyria-rohJa9au'
+    id='Uw8riPhe'>
+  <query xmlns='http://jabber.org/protocol/disco#info'>
+    <feature var='urn:xmpp:styling:0' />
+  </query>
+</iq>
+]]></example>
+  </section2>
+  <section2 topic='Implicit Discovery' anchor='discovery-implicit'>
+    <p>
+      An entity supporting this specification SHOULD render all messages
+      &lt;body&gt; elements using this specification and MAY choose to send
+      messages formatted using this specification even if the other end has not
+      advertised support.
+    </p>
+  </section2>
+</section1>
+<section1 topic='Business Rules' anchor='rules'>
+  <section2 topic='Display' anchor='display'>
+    <p>
+      Formatting characters MAY be displayed styled along with the span they
+      apply to or they may be hidden and the styling only applied to the span.
+      For instance, given the string "*emphasis*" both of the following are
+      valid renderings:
+    </p>
+    <ul>
+      <li><strong>*emphasis*</strong></li>
+      <li><strong>emphasis</strong></li>
+    </ul>
+    <p>
+      Examples in this document will display the formatting characters for
+      clarity.
+    </p>
+  </section2>
+  <section2 topic='Inlines' anchor='emph'>
+    <p>
+      Inline styling directives are evaluated lazily from the start of the byte
+      stream (the left in left-to-right languages and the right in right-to-left
+      languages).
+      Matches MUST NOT extend over newlines and MUST start with a whitespace
+      character or be the beginning of the line or the byte stream.
+      Matches MUST contain some text between the two styling directives.
+      Inline styling directives may also be doubled to allow the single
+      character version of the directive to be styled.
+      That is to say, "**emphasis**" is rendered the same as "*emphasis*".
+      For example, the word "emphasized" would be styled in each of the
+      following messages:
+    </p>
+    <ul>
+      <li><strong>*emphasized*</strong></li>
+      <li>foo <strong>*emphasized*</strong> bar</li>
+      <li><strong>*emphasized*</strong>foo<strong>*emphasized*</strong></li>
+      <li><strong>*emphasized*</strong>foo*</li>
+      <li><strong>**emphasi*zed**</strong> foo*</li>
+      <li>* <strong>*emphasized*</strong></li>
+    </ul>
+    <p>
+      Nothing would be formatted in the following messages (where / represents a
+      new line):
+    </p>
+    <ul>
+      <li>not emphasized*</li>
+      <li>*not emphasized</li>
+      <li>*not / emphasized*</li>
+      <li>**</li>
+      <li>****</li>
+    </ul>
+  </section2>
+  <section2 topic='Order of Operations' anchor='oporder'>
+    <p>
+      Block level styling such as preformatted blocks and quotations is always
+      handled before inlines such as emphasis and inline preformatted text.
+    </p>
+  </section2>
+  <section2 topic='Bold' anchor='bold'>
+    <p>
+      Text enclosed by '*' (U+002A ASTERISK) MUST be displayed with a greater
+      weight than the surrounding text (bold face).
+    </p>
+    <example caption='Bold'><![CDATA[
+<body>
+  The full title is **Twelfth Night, or What You Will** but
+  *most* people shorten it.
+</body>
+]]></example>
+  </section2>
+  <section2 topic='Italic' anchor='italic'>
+    <p>
+      Text enclosed by '_'(U+005F LOW LINE) MUST be displayed in italics.
+    </p>
+    <example caption='Italic'><![CDATA[
+<body>
+  The full title is _Twelfth Night, or What You Will_ but
+  __most__ people shorten it.
+</body>
+]]></example>
+  </section2>
+  <section2 topic='Strike through' anchor='strike'>
+    <p>
+      Text enclosed by '~'(U+007E TILDE) MUST be displayed with a horizontal
+      line through the middle (strike through).
+    </p>
+    <example caption='Strike through'><![CDATA[
+<body>
+  Everyone ~dis~likes cake.
+</body>
+]]></example>
+  </section2>
+  <section2 topic='Preformatted Inline Text' anchor='pre-inline'>
+    <p>
+      Text enclosed by a '`' (U+0060 GRAVE ACCENT) MUST be displayed inline in a
+      monospace font.
+      Inline formatting directives inside the inline preformatted text are not
+      rendered.
+      For example, in the following the word "monospace" is valid pre-formatted
+      inline text:
+    </p>
+    <ul>
+      <li>This is <tt>`monospace`</tt></li>
+      <li>This is <tt>`*monospace*`</tt></li>
+      <li>This is <strong><tt>*`monospace and bold`*</tt></strong></li>
+    </ul>
+    <example caption='Monospace text'><![CDATA[
+<body>
+  Wow, I can write in `monospace`, even a literal ``backtick (`)``!
+</body>
+]]></example>
+  </section2>
+  <section2 topic='Preformatted Block Text' anchor='pre-block'>
+    <p>
+      A block of text surrounded by lines consisting of a sequence of three
+      backticks (U+0060 GRAVE ACCENT), "```", is preformatted text and should be
+      displayed exactly as it was entered including whitespace.
+      No other formatting described in this document should be rendered inside
+      a preformatted text block.
+    </p>
+    <example caption='Preformatted block text'><![CDATA[
+<body>
+  ```
+  (println &quot;Hello, world!&quot;)
+  ```
+
+  This should show up as monospaced, preformatted text ⤴
+</body>
+]]></example>
+  </section2>
+  <section2 topic='Quotations' anchor='quote'>
+    <p>
+      A quotation is indicated by one or more lines with a byte stream beginning
+      with a '&gt;' (U+003E GREATER-THAN SIGN) immediately followed by a
+      whitespace character.
+      Inline formatting is rendered inside of quotations.
+    </p>
+    <example caption='Quotation (LTR)'><![CDATA[
+<body>
+  &gt; That that is, is.
+
+  Said the old hermit of Prague.
+</body>
+]]></example>
+    <example caption='Nested Quotation'><![CDATA[
+<body>
+  &gt;&gt; That that is, is.
+  &gt; Said the old hermit of Prague.
+
+  Who?
+</body>
+]]></example>
+  </section2>
+</section1>
+<section1 topic='Implementation Notes' anchor='impl'>
+  <p>
+    The rules for inline styling form a context free grammar that cannot be
+    matched by a regular expression.
+    A simple stack based parser is recommended instead.
+  </p>
+</section1>
+<section1 topic='Accessibility Considerations' anchor='access'>
+  <p>
+    When displaying text with formatting, developers should take care to ensure
+    sufficient contrast exists between styled and unstyled text so that users
+    with vision deficiencies are able to distinguish between the two.
+  </p>
+</section1>
+<section1 topic='Internationalization Considerations' anchor='i18n'>
+  <p>OPTIONAL.</p>
+</section1>
+<section1 topic='Security Considerations' anchor='security'>
+  <p>REQUIRED.</p>
+</section1>
+<section1 topic='IANA Considerations' anchor='iana'>
+  <p>
+    This document requires no interaction with &IANA;.
+  </p>
+</section1>
+<section1 topic='XMPP Registrar Considerations' anchor='registrar'>
+  <p>This specification defines the following XML namespaces:</p>
+  <ul>
+    <li>urn:xmpp:styling:0</li>
+  </ul>
+  <p>
+    The &REGISTRAR; shall include the foregoing namespaces in its disco
+    features registry as defined in &xep0030;.
+  </p>
+  <code caption='Registry Submission'><![CDATA[
+<var>
+  <name>urn:xmpp:styling:0</name>
+  <desc>Indicates support for simple message styling.</desc>
+  <doc>XEP-XXXX</doc>
+</var>]]></code>
+</section1>
+<section1 topic='XML Schema' anchor='schema'>
+  <p>This document does not define any new XML structure requiring a schema.</p>
+</section1>
+</xep>


### PR DESCRIPTION
Add a new protoxep to the inbox.

> This specification defines a plain-text formatting syntax for use in
> exchanging instant messages with simple text styling.