### PR TITLE
XEP-0373: Specify values that send_last_published_item should be set to

### DIFF
--- a/xep-0373.xml
+++ b/xep-0373.xml
@@ -18,7 +18,7 @@
   devices.</abstract>
   &LEGALNOTICE;
   <number>0373</number>
-  <status>Deferred</status>
+  <status>Experimental</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>
@@ -46,6 +46,17 @@
     <email>look@my.amazin.horse</email>
     <jid>valodim@stratum0.org</jid>
   </author>
+  <revision>
+    <version>0.2.1</version>
+    <date>2017-11-13</date>
+    <initials>fs</initials>
+    <remark>
+      <ul>
+        <li>Recommend setting the PubSub configuration field 'send_last_published_item' to 'on_sub'.</li>
+        <li>Only recommend persistent PubSub nodes.</li>
+      </ul>
+    </remark>
+  </revision>
   <revision>
     <version>0.2</version>
     <date>2017-09-11</date>
@@ -265,9 +276,9 @@
     child element of the &lt;pubkeys/&gt; element qualified by the
     'urn:xmpp:openpgp:0' namespace. Note that OpenPGP's ASCII Armor is
     not used, instead the XMPP client MUST encode the public key using
-    Base64. Client SHOULD only try to store the public key if the
+    Base64. Clients MAY only try to store the public key if the
     Personal Eventing Protocol service supports persistent-items, thus
-    it SHOULD check if the service reports the
+    they possibly check if the service reports the
     'http://jabber.org/protocol/pubsub#persistent-items' feature.</p>
 
     <example caption='Saving the public key in the PEP node.'><![CDATA[
@@ -487,6 +498,9 @@
         <field var='pubsub#access_model'>
           <value>whitelist</value>
         </field>
+        <field var='pubsub#send_last_published_item'>
+          <value>on_sub</value>
+        </field>
       </x>
     </configure>
   </pubsub>
@@ -556,6 +570,16 @@
 
   </section2>
 
+  <section2 topic='PubSub Node Configuration' anchor='pubsub-node-configuration'>
+
+    <p>The PubSub nodes specified by herein SHOULD be configured to either never send the latest
+    item, or to send the latest item only when a new entity subscribed. Thus the nodes
+    'send_last_published_item' configuration option SHOULD be set to either 'never' or 'on_sub' (see
+    <cite>XEP-0060</cite> <link
+    url='https://xmpp.org/extensions/xep-0060.html#registrar-formtypes-config'>§ 16.4.4</link>).</p>
+
+  </section2>
+
 </section1>
 
 <section1 topic='Implementors Advice' anchor='implementors-advice'>
@@ -619,7 +643,6 @@
 
   <section2 topic='XMPP Address Normalization' anchor='xmpp-address-normalization'>
 
-    <!-- TODO s/6122/7622/ after https://github.com/xsf/xeps/pull/138 -->
     <p>The format of XMPP addresses, sometimes called JIDs, is well
     defined. Thus they need to be normalized, as defined in
     &rfc7622;. When implementations are required to compare XMPP
@@ -781,3 +804,8 @@
 
 </section1>
 </xep>
+
+<!-- Local Variables: -->
+<!-- fill-column: 100 -->
+<!-- indent-tabs-mode: nil -->
+<!-- End: -->


### PR DESCRIPTION
Also weaken the requirement regarding PEP persistence.