### PR TITLE
XEP-0095, XEP-0096: Deprecate

### DIFF
--- a/xep-0095.xml
+++ b/xep-0095.xml
@@ -18,7 +18,7 @@
     <spec>XEP-0030</spec>
   </dependencies>
   <supersedes/>
-  <supersededby/>
+  <supersededby><spec>XEP-0166</spec></supersededby>
   <shortname>si</shortname>
   <schemaloc>
     <url>http://www.xmpp.org/schemas/si.xsd</url>
@@ -27,6 +27,12 @@
   &temas;
   &linuxwolf;
   &reatmon;
+  <revision>
+    <version>1.2</version>
+    <date>2017-11-29</date>
+    <initials>XEP Editor (ssw)</initials>
+    <remark>Deprecated by vote of the council.</remark>
+  </revision>
   <revision>
     <version>1.1</version>
     <date>2004-04-13</date>

--- a/xep-0096.xml
+++ b/xep-0096.xml
@@ -18,7 +18,7 @@
     <spec>XEP-0095</spec>
   </dependencies>
   <supersedes/>
-  <supersededby/>
+  <supersededby><spec>XEP-0234</spec></supersededby>
   <shortname>si-filetransfer</shortname>
   <schemaloc>
     <url>http://www.xmpp.org/schemas/file-transfer.xsd</url>
@@ -27,6 +27,12 @@
   &linuxwolf;
   &reatmon;
   &stpeter;
+  <revision>
+    <version>1.3</version>
+    <date>2017-11-29</date>
+    <initials>XEP Editor (ssw)</initials>
+    <remark>Deprecated by vote of the council.</remark>
+  </revision>
   <revision>
     <version>1.2</version>
     <date>2004-04-13</date>

--- a/xep-0166.xml
+++ b/xep-0166.xml
@@ -17,7 +17,7 @@
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>
-  <supersedes/>
+  <supersedes><spec>XEP-0095</spec></supersedes>
   <supersededby/>
   <shortname>jingle</shortname>
   <schemaloc>

--- a/xep-0234.xml
+++ b/xep-0234.xml
@@ -19,7 +19,7 @@
     <spec>XEP-0261</spec>
     <spec>XEP-0300</spec>
   </dependencies>
-  <supersedes/>
+  <supersedes><spec>XEP-0096</spec></supersedes>
   <supersededby/>
   <shortname>NOT_YET_ASSIGNED</shortname>
   &stpeter;

--- a/xep-0234.xml
+++ b/xep-0234.xml
@@ -10,7 +10,8 @@
   <abstract>This specification defines a Jingle application type for transferring a file from one entity to another. The protocol provides a modular framework that enables the exchange of information about the file to be transferred as well as the negotiation of parameters such as the transport to be used.</abstract>
   &LEGALNOTICE;
   <number>0234</number>
-  <status>Experimental</status>
+  <status>Proposed</status>
+  <lastcall>2017-12-12</lastcall>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <dependencies>
@@ -21,7 +22,7 @@
   </dependencies>
   <supersedes><spec>XEP-0096</spec></supersedes>
   <supersededby/>
-  <shortname>NOT_YET_ASSIGNED</shortname>
+  <shortname>jingle-ft</shortname>
   &stpeter;
   &lance;
   <revision>


### PR DESCRIPTION
Also mark XEP-0166 and XEP-0234 as superseding the older specs.

Second commit issues LC for 0234.