### PR TITLE
XEP-0060: Register pubsub#persist_items as a Precondition publish-option

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -51,6 +51,12 @@
   &ralphm;
 
   <revision>
+    <version>1.14.1</version>
+    <date>2017-12-07</date>
+    <initials>dg</initials>
+    <remark><p>Register pubsub#persist_items as a Precondition publish-option</p></remark>
+  </revision>
+  <revision>
     <version>1.14</version>
     <date>2017-11-29</date>
     <initials>jt</initials>
@@ -6454,6 +6460,9 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
       <value>whitelist</value>
     </option>
   </field>
+  <field var='pubsub#persist_items'
+         type='boolean'
+         label='Precondition: node configuration with the specified perist_items configuration'/>
 </form_type>
 ]]></code>
     </section3>


### PR DESCRIPTION
` pubsub#persist_items` is used in XEPs like XEP-0048 or XEP-0223 and needs to be registered according to the wording in the publish-options section. Otherwise implementations will just reject the examples given in those XEPs.