### PR TITLE
XEP-0060: Introduce 1:1 mapping between publish-options and node configuration

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -51,11 +51,25 @@
   &ralphm;
 
   <revision>
+    <version>1.15.0</version>
+    <date>2017-12-12</date>
+    <initials>dg</initials>
+    <remark>
+      <ul>
+        <li>Specify that unregistered publish-options are mapped 1:1 to node configurations</li>
+        <li>Get rid of per-item OVERRIDE</li>
+        <li>Get rid of METADATA publish-options</li>
+        <li>Remove registration for the obsolete pubsub#access_model publish-options</li> 
+      </ul>
+    </remark>
+  </revision>
+  <revision>
     <version>1.14</version>
     <date>2017-11-29</date>
     <initials>jt</initials>
     <remark><p>Add pubsub#multi-items to features.</p></remark>
   </revision>
+
   <revision>
     <version>1.13.8</version>
     <date>2017-10-10</date>
@@ -2969,8 +2983,8 @@ And by opposing end them?
 </iq>
 ]]></example>
       <p>The &lt;publish-options/&gt; element MUST contain a data form (see <cite>XEP-0004</cite>), whose FORM_TYPE MUST be "http://jabber.org/protocol/pubsub#publish-options" (see <cite>XEP-0068</cite>).</p>
-      <p>Fields and their behaviour MUST be registered with the XMPP Registrar. Each field MUST specify whether it defines METADATA to be attached to the item, a per-item OVERRIDE of the node configuration, or a PRECONDITION to be checked against the node configuration. A pubsub service advertising support for publishing options MUST reject publications with unknown fields.</p>
-      <p>A field defined as a precondition MUST be processed as follows:</p>
+      <p>Each form field denotes a precondition to publishing the request. A pub-sub service advertising support for publishing options MUST check each precondition field against the node configuration of the same name, and it MUST reject the publication upon encountering unknown fields.</p>
+      <p>Preconditions MUST be processed as follows:</p>
       <ol>
         <li>If the node exists and the precondition is not met, then the publish MUST fail with a &conflict; error condition and a pubsub-specific condition of &lt;precondition-not-met/&gt;.</li>
         <li>If the node exists and the precondition is met, then the publish succeeds.</li>
@@ -6422,38 +6436,6 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
          type='text-single'
          label='The type of node data, usually specified by
                 the namespace of the payload (if any)'/>
-</form_type>
-]]></code>
-    </section3>
-    <section3 topic='pubsub#publish-options FORM_TYPE' anchor='registrar-formtypes-publish'>
-      <code><![CDATA[
-<form_type>
-  <name>http://jabber.org/protocol/pubsub#publish-options</name>
-  <doc>XEP-0060</doc>
-  <desc>
-    Forms enabling publication with options; each field must specify whether it
-    defines METADATA to be attached to the item, a per-item OVERRIDE of the node
-    configuration, or a PRECONDITION to be checked against the node configuration.
-  </desc>
-  <field var='pubsub#access_model'
-         type='list-single'
-         label='Precondition: node configuration with the specified access model'>
-    <option label='Access model of authorize'>
-      <value>authorize</value>
-    </option>
-    <option label='Access model of open'>
-      <value>open</value>
-    </option>
-    <option label='Access model of presence'>
-      <value>presence</value>
-    </option>
-    <option label='Access model of roster'>
-      <value>roster</value>
-    </option>
-    <option label='Access model of whitelist'>
-      <value>whitelist</value>
-    </option>
-  </field>
 </form_type>
 ]]></code>
     </section3>


### PR DESCRIPTION
as per discussion on the XSF channel today get rid of both OVERRIDE and metadata publish-options and remove ability to specify new publish-options instead introduce 1:1 mapping to node configuration.