### PR TITLE
XEP-0045: Specify 333 status code

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -46,6 +46,14 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.30</version>
+    <date>2017-12-18</date>
+    <initials>jwi</initials>
+    <remark>
+      <p>Add 333 status code with OPTIONAL feature.</p>
+    </remark>
+  </revision>
+  <revision>
     <version>1.29</version>
     <date>2017-09-01</date>
     <initials>gl</initials>
@@ -4870,6 +4878,39 @@
 
 </section1>
 
+<section1 topic='Service Use Cases' anchor='service'>
+  <section2 topic='Service removes user because of error response' anchor='service-error-kick'>
+    <p>A MUC service MAY support adding the 333 status code to presences when a user gets removed by the service due to a technical problem (e.g. s2s link failure).</p>
+    <p>If a MUC service supports this OPTIONAL feature, it MUST include the 333 status code in the resulting presence:</p>
+    <example caption='MUC service removes user because of error'><![CDATA[
+<presence
+    from='harfleur@chat.shakespeare.lit/pistol'
+    to='pistol@shakespeare.lit/harfleur'
+    type='unavailable'>
+  <x xmlns='http://jabber.org/protocol/muc#user'>
+    <item affiliation='none' role='none' />
+    <status code='110'/>
+    <status code='307'/>
+    <status code='333'/>
+  </x>
+</presence>
+]]></example>
+    <p>The status code MUST also be included in presences sent to other occupants:</p>
+    <example caption='MUC service informs other occupants of removal because of an error'><![CDATA[
+<presence
+    from='harfleur@chat.shakespeare.lit/pistol'
+    to='gower@shakespeare.lit/cell'
+    type='unavailable'>
+  <x xmlns='http://jabber.org/protocol/muc#user'>
+    <item affiliation='none' role='none'/>
+    <status code='307'/>
+    <status code='333'/>
+  </x>
+</presence>
+]]></example>
+  </section2>
+</section1>
+
 <section1 topic='Status Codes' anchor='statuscodes'>
   <p>Multi-User Chat uses a &lt;status/&gt; element (specifically, the 'code' attribute of the &lt;status/&gt; element) to communicate information about a user's status in a room. Over time, the number of status codes has grown quite large, and new status codes continue to be requested of the author. Therefore, these codes are now documented in a registry maintained by the XMPP Registrar. For details, refer to the <link url='#registrar-statuscodes'>Status Codes Registry</link> section of this document.</p>
   <p>Note: In general, MUC status codes tend to follow the "philosophy" of status codes that is implicit in &rfc2616; and &rfc1893; (1xx codes are informational, 2xx codes specify that it is fine to continue, 3xx codes specify redirects such as being kicked or banned, x3x codes refer to system status, x7x codes refer to security or policy matters, etc.).</p>
@@ -5437,6 +5478,15 @@
   <purpose>
     Inform user that he or she is being removed from the room
     because the MUC service is being shut down
+  </purpose>
+</statuscode>
+<statuscode>
+  <number>333</number>
+  <stanza>presence</stanza>
+  <context>Removal from room</context>
+  <purpose>
+    Inform users that a user was removed because of an error reply (for example
+    when an s2s link fails between the MUC and the removed users server).
   </purpose>
 </statuscode>
 ]]></code>


### PR DESCRIPTION
Proposal to resolve [standards@ discussion about handling of service-caused removals](https://mail.jabber.org/pipermail/standards/2017-December/034058.html).

TL;DR: Clients should be able to know that a user was removed due to an error and not due to misbehaviour to be able to show a proper UI for this.

Compatibility:

* Server implements it, client does not: existing behaviour continues.
* Client implements it, server does not: existing behaviour continues.
* Client and Server implement it: improved UX by being able to display kicks due to errors differently.