### PR TITLE
XEP-0387: rejected by the council

### DIFF
--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -16,7 +16,7 @@
     </abstract>
     &LEGALNOTICE;
     <number>0387</number>
-    <status>Retracted</status>
+    <status>Rejected</status>
     <lastcall>2017-12-21</lastcall>
     <lastcall>2017-11-15</lastcall>
     <type>Standards Track</type>


### PR DESCRIPTION
Kev pointed out on list that it was already rejected, so retracting it was rather pointless and we should leave it in the state that it was last in. Fixing to be "Rejected" instead of "Retracted".