### PR TITLE
XEP-0174: Fix samples, <starttls/> does not have an 'optional' element

### DIFF
--- a/xep-0174.xml
+++ b/xep-0174.xml
@@ -387,7 +387,7 @@ R: <?xml version='1.0'?>
   <example caption="Recipient Sends Stream Features"><![CDATA[
 R: <stream:features>
      <starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'>
-       <optional/>
+       <required/>
      </starttls>
    </stream:features>
 ]]></example>
@@ -450,7 +450,7 @@ R: <?xml version='1.0'?>
   <example caption="Recipient Sends Stream Features"><![CDATA[
 R: <stream:features>
      <starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'>
-       <optional/>
+       <required/>
      </starttls>
      <query xmlns='http://jabber.org/protocol/disco#info'
             node='http://code.google.com/p/exodus#QgayPKawpkPSDYmwT/WM94uAlu0='>


### PR DESCRIPTION
As per RFC 6120, <starttls/> only as a <required/> element.