### PR TITLE
Build refs for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM xmppxsf/xeps-base:latest
 
 ARG NCORES=1
-ARG TARGETS="html inbox-html inbox-xml pdf xeplist"
+ARG TARGETS="html inbox-html inbox-xml pdf xeplist refs"
 
 COPY *.xml xep.* *.css *.xsl *.js *.xsl Makefile /src/
 COPY resources/*.pdf /src/resources/


### PR DESCRIPTION
xmpp.org/extensions/refs wasn't built.  As these files are referenced
from xml2rfc.tools.ietf.org, we probably should.