### PR TITLE
XEP-0401: Use Data Form for IBR and fix error stanzas

### DIFF
--- a/xep-0401.xml
+++ b/xep-0401.xml
@@ -31,6 +31,16 @@
     <surname>Schink</surname>
   </author>
   <revision>
+    <version>0.2.0</version>
+    <date>2018-02-11</date>
+    <initials>ms</initials>
+    <remark>
+      <p>Used Data Forms for extension of In-Band Registration as required by <strong>XEP-0077</strong> § 4.</p>
+      <p>Added "defined condition" elements in error stanzas as required by <strong>RFC 6120</strong> § 8.3.2.</p>
+      <p>Changed type of "invalid-token" error to "modify".</p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.1.0</version>
     <date>2018-01-25</date>
     <initials>XEP Editor (jwi)</initials>
@@ -325,35 +335,70 @@
     <p>If the server supports and is ready to perform Pre-Authenticated IBR,
       it MUST add a &lt;token&gt; element to the response (TODO: 'token' or
       'preauth'?):</p>
-    <example caption="Receiving registration fields"><![CDATA[
+    <example caption="Receiving registration form"><![CDATA[
 <iq type='result' to='romeo@example.com' from='example.com' id='reg1'>
   <query xmlns='jabber:iq:register'>
-    <username/>
-    <password/>
-    <token/>
+    <x xmlns='jabber:x:data' type='form'>
+      <field type='hidden' var='FORM_TYPE'>
+        <value>urn:xmpp:invite:0</value>
+      </field>
+      <field type='text-single' label='Username' var='username'>
+        <required/>
+      </field>
+      <field type='text-private' label='Password' var='password'>
+        <required/>
+      </field>
+      <field type='text-single' label='Invite token' var='token'>
+        <required/>
+      </field>
+    </x>
   </query>
 </iq>
 ]]></example>
-    <example caption='Registration process aborted (invalid token)'><![CDATA[
+    <example caption='Receiving registration form with error (invalid token)'><![CDATA[
 <iq type='error' from='example.com' id='reg1'>
   <query xmlns='jabber:iq:register'>
-    <username>juliet</username>
-    <password>m1cro$oft</password>
-    <token>BADTOKEN</token>
+    <x xmlns='jabber:x:data' type='form'>
+      <field type='hidden' var='FORM_TYPE'>
+        <value>urn:xmpp:invite:0</value>
+      </field>
+      <field type='text-single' var='username'>
+        <value>juliet<value/>
+      </field>
+      <field type='text-private' var='password'>
+        <value>m1cro$oft<value/>
+      </field>
+      <field type='text-single' var='token'>
+        <value>BADTOKEN<value/>
+      </field>
+    </x>
   </query>
-  <error type='cancel'>
+  <error type='modify'>
+    <bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
     <invalid-token xmlns='urn:xmpp:invite:0'/>
   </error>
 </iq>
 ]]></example>
-    <example caption='Registration process aborted (token expired)'><![CDATA[
+    <example caption='Receiving registration form with error (token expired)'><![CDATA[
 <iq type='error' from='example.com' id='reg1'>
   <query xmlns='jabber:iq:register'>
-    <username>juliet</username>
-    <password>m1cro$oft</password>
-    <token>OLDTOKEN</token>
+    <x xmlns='jabber:x:data' type='form'>
+      <field type='hidden' var='FORM_TYPE'>
+        <value>urn:xmpp:invite:0</value>
+      </field>
+      <field type='text-single' var='username'>
+        <value>juliet<value/>
+      </field>
+      <field type='text-private' var='password'>
+        <value>m1cro$oft<value/>
+      </field>
+      <field type='text-single' var='token'>
+        <value>OLDTOKEN<value/>
+      </field>
+    </x>
   </query>
   <error type='cancel'>
+    <not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
     <token-expired xmlns='urn:xmpp:invite:0'/>
   </error>
 </iq>


### PR DESCRIPTION
 * Use Data Form for In-Band Registration as required by XEP-0077
 * Fix error stanzas as required by RFC 6120 § 8.3.2
 * Change error of "invalid-token" error to "modify"