### PR TITLE
XEP-0393: simplify block handling, reorder sections, fix span definition

### DIFF
--- a/xep-0393.xml
+++ b/xep-0393.xml
@@ -164,12 +164,12 @@
     <di>
       <dt>Span</dt>
       <dd>
-        A group of text that is rendered inline and where the entire group is
-        rendered in the same manner.
+        A group of text that may be rendered inline alongside other spans.
         Spans may be either plain text with no formatting applied, or may be
         formatted text that is enclosed by two styling directives.
         Spans are always children of blocks and may not escape from their
         containing block.
+        Some spans may contain child spans.
         The following all contain spans marked by parenthesis:
         <ul>
           <li>(plain span)</li>
@@ -427,5 +427,8 @@
 </section1>
 <section1 topic='XML Schema' anchor='schema'>
   <p>This document does not define any new XML structure requiring a schema.</p>
+</section1>
+<section1 topic='Acknowledgements' anchor='ack'>
+  <p>The author wishes to thank Kevin Smith for his review and feedback.</p>
 </section1>
 </xep>

--- a/xep-0393.xml
+++ b/xep-0393.xml
@@ -26,6 +26,17 @@
   <shortname>styling</shortname>
   &sam;
   <revision>
+    <version>0.1.3</version>
+    <date>2018-02-14</date>
+    <initials>ssw</initials>
+    <remark>
+      <p>
+        Reorder block and span sections, simplify block parsing, and update the
+        definition of a span.
+      </p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.1.2</version>
     <date>2018-01-13</date>
     <initials>ssw</initials>
@@ -209,18 +220,18 @@
     </p>
     <section3 topic='Plain' anchor='line-block'>
       <p>
-        Groups of lines that are not part of any other block are considered a
-        "plain" block, as are individual lines of text that are not inside of a
-        preformatted text block.
+        Individual lines of text that are not inside of a preformatted text
+        block are considered a "plain" block.
         Plain blocks are not bound by styling directives and do not imply
         formatting themselves, but they may contain spans which imply
         formatting.
+        Plain blocks may not contain child blocks.
       </p>
       <example caption='Plain block text'><![CDATA[
 <body>
-  ((There are four blocks in this body marked by parens,)
+  (There are three blocks in this body marked by parens,)
   (but there is no *formatting)
-  (as spans* may not escape blocks.))
+  (as spans* may not escape blocks.)
 </body>
 ]]></example>
     </section3>
@@ -229,8 +240,7 @@
         A preformatted text block is started by a line beginning with "```"
         (U+0060 GRAVE ACCENT), and ended by a line containing only three grave
         accents or the end of the parent block (whichever comes first).
-        Preformatted text blocks cannot contain child blocks and other styling
-        MUST NOT be rendered inside the block.
+        Preformatted text blocks cannot contain child blocks or spans.
         Text inside a preformatted block SHOULD be displayed in a monospace font.
       </p>
       <example caption='Preformatted block text'><![CDATA[
@@ -247,8 +257,8 @@
   &gt; ```
   &gt; (println &quot;Hello, world!&quot;)
 
-  The entire blockquote is a preformatted text block, but this line is
-  plaintext!
+  The entire blockquote is a preformatted text block, but this line
+  is plaintext!
 </body>
 ]]></example>
     </section3>

--- a/xep-0393.xml
+++ b/xep-0393.xml
@@ -21,7 +21,7 @@
     <spec>XMPP Core</spec>
     <spec>XEP-0001</spec>
   </dependencies>
-  <supersedes/>
+  <supersedes><spec>XEP-0071</spec></supersedes>
   <supersededby/>
   <shortname>styling</shortname>
   &sam;

--- a/xep-0393.xml
+++ b/xep-0393.xml
@@ -202,6 +202,83 @@
   </dl>
 </section1>
 <section1 topic='Business Rules' anchor='rules'>
+  <section2 topic='Blocks' anchor='block'>
+    <p>
+      Parsers implementing message styling will first parse blocks and then
+      parse child blocks or spans if allowed by the specific block type.
+    </p>
+    <section3 topic='Plain' anchor='line-block'>
+      <p>
+        Groups of lines that are not part of any other block are considered a
+        "plain" block, as are individual lines of text that are not inside of a
+        preformatted text block.
+        Plain blocks are not bound by styling directives and do not imply
+        formatting themselves, but they may contain spans which imply
+        formatting.
+      </p>
+      <example caption='Plain block text'><![CDATA[
+<body>
+  ((There are four blocks in this body marked by parens,)
+  (but there is no *formatting)
+  (as spans* may not escape blocks.))
+</body>
+]]></example>
+    </section3>
+    <section3 topic='Preformatted Text' anchor='pre-block'>
+      <p>
+        A preformatted text block is started by a line beginning with "```"
+        (U+0060 GRAVE ACCENT), and ended by a line containing only three grave
+        accents or the end of the parent block (whichever comes first).
+        Preformatted text blocks cannot contain child blocks and other styling
+        MUST NOT be rendered inside the block.
+        Text inside a preformatted block SHOULD be displayed in a monospace font.
+      </p>
+      <example caption='Preformatted block text'><![CDATA[
+<body>
+  ```ignored
+  (println &quot;Hello, world!&quot;)
+  ```
+
+  This should show up as monospace, preformatted text ⤴
+</body>
+]]></example>
+      <example caption='No closing preformatted text sequence'><![CDATA[
+<body>
+  &gt; ```
+  &gt; (println &quot;Hello, world!&quot;)
+
+  The entire blockquote is a preformatted text block, but this line is
+  plaintext!
+</body>
+]]></example>
+    </section3>
+    <section3 topic='Quotations' anchor='quote'>
+      <p>
+        A quotation is indicated by one or more lines with a byte stream
+        beginning with a '&gt;' (U+003E GREATER-THAN SIGN).
+        Block quotes may contain any child block, including other quotations.
+        Lines inside the block quote MUST have leading spaces trimmed before
+        parsing the child block.
+        It is RECOMMENDED that text inside of a block quote be indented or
+        distinguished from the surrounding text in some other way.
+      </p>
+      <example caption='Quotation (LTR)'><![CDATA[
+<body>
+  &gt; That that is, is.
+
+  Said the old hermit of Prague.
+</body>
+]]></example>
+      <example caption='Nested Quotation'><![CDATA[
+<body>
+  &gt;&gt; That that is, is.
+  &gt; Said the old hermit of Prague.
+
+  Who?
+</body>
+]]></example>
+    </section3>
+  </section2>
   <section2 topic='Spans' anchor='span'>
     <p>
       Matches of spans between two styling directives MUST contain some text
@@ -301,83 +378,6 @@
       <example caption='Monospace text'><![CDATA[
 <body>
   Wow, I can write in `monospace`!
-</body>
-]]></example>
-    </section3>
-  </section2>
-  <section2 topic='Blocks' anchor='block'>
-    <p>
-      Parsers implementing message styling will first parse blocks and then
-      parse child blocks or spans if allowed by the specific block type.
-    </p>
-    <section3 topic='Plain' anchor='line-block'>
-      <p>
-        Groups of lines that are not part of any other block are considered a
-        "plain" block, as are individual lines of text that are not inside of a
-        preformatted text block.
-        Plain blocks are not bound by styling directives and do not imply
-        formatting themselves, but they may contain spans which imply
-        formatting.
-      </p>
-      <example caption='Plain block text'><![CDATA[
-<body>
-  ((There are four blocks in this body marked by parens,)
-  (but there is no *formatting)
-  (as spans* may not escape blocks.))
-</body>
-]]></example>
-    </section3>
-    <section3 topic='Preformatted Text' anchor='pre-block'>
-      <p>
-        A preformatted text block is started by a line beginning with "```"
-        (U+0060 GRAVE ACCENT), and ended by a line containing only three grave
-        accents or the end of the parent block (whichever comes first).
-        Preformatted text blocks cannot contain child blocks and other styling
-        MUST NOT be rendered inside the block.
-        Text inside a preformatted block SHOULD be displayed in a monospace font.
-      </p>
-      <example caption='Preformatted block text'><![CDATA[
-<body>
-  ```ignored
-  (println &quot;Hello, world!&quot;)
-  ```
-
-  This should show up as monospace, preformatted text ⤴
-</body>
-]]></example>
-      <example caption='No closing preformatted text sequence'><![CDATA[
-<body>
-  &gt; ```
-  &gt; (println &quot;Hello, world!&quot;)
-
-  The entire blockquote is a preformatted text block, but this line is
-  plaintext!
-</body>
-]]></example>
-    </section3>
-    <section3 topic='Quotations' anchor='quote'>
-      <p>
-        A quotation is indicated by one or more lines with a byte stream
-        beginning with a '&gt;' (U+003E GREATER-THAN SIGN).
-        Block quotes may contain any child block, including other quotations.
-        Lines inside the block quote MUST have leading spaces trimmed before
-        parsing the child block.
-        It is RECOMMENDED that text inside of a block quote be indented or
-        distinguished from the surrounding text in some other way.
-      </p>
-      <example caption='Quotation (LTR)'><![CDATA[
-<body>
-  &gt; That that is, is.
-
-  Said the old hermit of Prague.
-</body>
-]]></example>
-      <example caption='Nested Quotation'><![CDATA[
-<body>
-  &gt;&gt; That that is, is.
-  &gt; Said the old hermit of Prague.
-
-  Who?
 </body>
 ]]></example>
     </section3>


### PR DESCRIPTION
Fixes a broken definition for spans, simplifies some block handling, and reorder sections to be in the order you would probably write a parser.