### PR TITLE
XEP-0050 Ad-Hoc Commands: Clarify 'execute' actions equivalence.

### DIFF
--- a/xep-0050.xml
+++ b/xep-0050.xml
@@ -27,7 +27,7 @@
   &linuxwolf;
   <revision>
     <version>1.2.3</version>
-    <date>2018-02-21</date>
+    <date>2018-04-19</date>
     <initials>fs</initials>
     <remark>Clarify 'execute' actions equivalence.</remark>
   </revision>
@@ -526,7 +526,7 @@
       </li>
       <li>If there is an &lt;actions/&gt; element, the user-agent usually uses a multi-stage dialog or view, such as a wizard.
         <ul>
-          <li>The action "execute" is always allowed, and is equivalent to the action "next" if it is an allowed action, or otherwise equivalent to "complete".</li>
+          <li>The action "execute" is always allowed, and is equivalent to the action specified in the "execute" attribute. If the "execute" attribute is absent, it defaults to the action "next" if it is an allowed action, or otherwise to "complete".</li>
           <li>The "prev" action is typically the "back" or "previous" button or option in a wizard. If &lt;prev/&gt; is not contained by the &lt;actions/&gt;, it is disabled.</li>
           <li>The "next" action is typically the "next" button or option in a wizard. If &lt;next/&gt; is not contained by the &lt;actions/&gt;, it is disabled.</li>
           <li>The "complete" action is typically the "finish" or "done" button or option in a wizard. If &lt;complete/&gt; is not contained by the &lt;actions/&gt;, it is disabled.</li>

--- a/xep-0050.xml
+++ b/xep-0050.xml
@@ -26,6 +26,12 @@
   </schemaloc>
   &linuxwolf;
   <revision>
+    <version>1.2.3</version>
+    <date>2018-02-21</date>
+    <initials>fs</initials>
+    <remark>Clarify 'execute' actions equivalence.</remark>
+  </revision>
+  <revision>
     <version>1.2.2</version>
     <date>2016-12-03</date>
     <initials>XEP Editor (ssw, fs)</initials>
@@ -520,7 +526,7 @@
       </li>
       <li>If there is an &lt;actions/&gt; element, the user-agent usually uses a multi-stage dialog or view, such as a wizard.
         <ul>
-          <li>The action "execute" is always allowed, and is equivalent to the action "next".</li>
+          <li>The action "execute" is always allowed, and is equivalent to the action "next" if it is an allowed action, or otherwise equivalent to "complete".</li>
           <li>The "prev" action is typically the "back" or "previous" button or option in a wizard. If &lt;prev/&gt; is not contained by the &lt;actions/&gt;, it is disabled.</li>
           <li>The "next" action is typically the "next" button or option in a wizard. If &lt;next/&gt; is not contained by the &lt;actions/&gt;, it is disabled.</li>
           <li>The "complete" action is typically the "finish" or "done" button or option in a wizard. If &lt;complete/&gt; is not contained by the &lt;actions/&gt;, it is disabled.</li>


### PR DESCRIPTION
The XEP is slightly ambiguous regarding the equivalence of the
'execute' action, it states that:

- The action "execute" is always allowed, and is equivalent to the
  action "next".
- The "next" action is typically the "next" button or option in a
  wizard. If <next/> is not contained by the <actions/>, it is
  disabled.

So if "next" action is disabled, execute is allowed but equivalent to
a disabled action.

This change tries to clarify that.