### PR TITLE
XEP-0401: Use namespace for ad-hoc command nodes

### DIFF
--- a/xep-0401.xml
+++ b/xep-0401.xml
@@ -103,10 +103,10 @@
   <query xmlns='http://jabber.org/protocol/disco#items'
          node='http://jabber.org/protocol/commands'>
     <item jid='example.com'
-          node='invite'
+          node='urn:xmpp:invite#invite'
           name='Invite user'/>
     <item jid='example.com'
-          node='create-account'
+          node='urn:xmpp:invite#create-account'
           name='Create account'/>
   </query>
 </iq>
@@ -125,14 +125,14 @@
     <example caption="Exceute user invitation command"><![CDATA[
 <iq type='set' from='romeo@example.com' to='example.com' id='exec1'>
   <command xmlns='http://jabber.org/protocol/commands'
-           node='invite'
+           node='urn:xmpp:invite#invite'
            action='execute'/>
 </iq>
 ]]></example>
     <example caption="User invitation finished"><![CDATA[
 <iq type='result' to='romeo@example.com' from='example.com' id='exec2'>
   <command xmlns='http://jabber.org/protocol/commands'
-           node='invite'
+           node='urn:xmpp:invite#invite'
            status='completed'>
     <x xmlns='jabber:x:data' type='result'>
       <item>
@@ -240,7 +240,7 @@
     <example caption="Exceute account creation command"><![CDATA[
 <iq type='set' from='romeo@example.com' to='example.com' id='exec1'>
   <command xmlns='http://jabber.org/protocol/commands'
-           node='create-account'
+           node='urn:xmpp:invite#create-account'
            action='execute'/>
 </iq>
 ]]></example>
@@ -248,7 +248,7 @@
 <iq type='result' to='romeo@example.com' from='example.com' id='exec1'>
   <command xmlns='http://jabber.org/protocol/commands'
            sessionid='config:20020923T213616Z-700'
-           node='create-account'
+           node='urn:xmpp:invite#create-account'
            status='executing'>
     <actions execute='complete'>
       <complete/>
@@ -268,7 +268,7 @@
 <iq type='set' from='romeo@example.com' to='example.com' id='exec2'>
   <command xmlns='http://jabber.org/protocol/commands'
            sessionid='config:20020923T213616Z-700'
-           node='create-account'>
+           node='urn:xmpp:invite#create-account'>
     <x xmlns='jabber:x:data' type='submit'>
       <field var='username'>
         <value>juliet</value>
@@ -281,7 +281,7 @@
 <iq type='result' to='romeo@example.com' from='example.com' id='exec2'>
   <command xmlns='http://jabber.org/protocol/commands'
            sessionid='config:20020923T213616Z-700'
-           node='create-account'
+           node='urn:xmpp:invite#create-account'
            status='completed'>
     <x xmlns='jabber:x:data' type='result'>
       <item>


### PR DESCRIPTION
Add "urn:xmpp:invite" namespace to ad-hoc command nodes to avoid
possible collisions with other extensions.