### PR TITLE
XEP-0153: Clarify encoding of update hash

### DIFF
--- a/xep-0153.xml
+++ b/xep-0153.xml
@@ -27,6 +27,12 @@
   </schemaloc>
   &stpeter;
   <revision>
+    <version>1.1</version>
+    <date>2018-02-26</date>
+    <initials>jwi</initials>
+    <remark>Clarify encoding of the photo hash in the presence update.</remark>
+  </revision>
+  <revision>
     <version>1.0</version>
     <date>2006-08-16</date>
     <initials>psa</initials>
@@ -110,14 +116,15 @@
     <example caption="User&apos;s Server Acknowledges Publish"><![CDATA[
 <iq to='juliet@capulet.com' type='result' id='vc1'/>
 ]]></example>
-    <p>Next, the user's client computes the SHA1 hash of the avatar image data itself (not the base64-encoded version) in accordance with &rfc3174;. This hash is then included in the user's presence information as the XML character data of the &lt;photo/&gt; child of an &X; element qualified by the 'vcard-temp:x:update' namespace, as shown in the following example:</p>
+    <p>Next, the user's client computes the SHA1 hash of the avatar image data itself (not the base64-encoded version) in accordance with &rfc3174;. This hash is then included in the user's presence information. This is done by putting the hash encoded as hexadecimal digits as the XML character data of the &lt;photo/&gt; child of an &X; element qualified by the 'vcard-temp:x:update' namespace, as shown in the following example:</p>
     <example caption="User&apos;s Client Includes Avatar Hash in Presence Broadcast"><![CDATA[
 <presence from='juliet@capulet.com/balcony'>
   <x xmlns='vcard-temp:x:update'>
-    <photo>sha1-hash-of-image</photo>
+    <photo>01b87fcd030b72895ff8e88db57ec525450f000d</photo>
   </x>
 </presence>
 ]]></example>
+    <p>Note that while XML Schema defines the canonical representation of hexadecimal values to be upper-case, the historical use throughout the XMPP ecosystem has established lower-case use. Entities need to be able to process both and may prefer to emit lower-case for compatibility.</p>
     <p>The user's server then broadcasts that presence information to all contacts who are subscribed to the user's presence information.</p>
   </section2>
   <section2 topic='Contact Retrieves Avatar' anchor='retrieve'>
@@ -270,7 +277,7 @@
   <xs:element name='x'>
     <xs:complexType>
       <xs:sequence>
-        <xs:element name='photo' minOccurs='0' type='xs:base64Binary'/>
+        <xs:element name='photo' minOccurs='0' type='xs:hexBinary'/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
As per list discussion https://mail.jabber.org/pipermail/standards/2018-February/034362.html .