### PR TITLE
XEP-0390: Explain that ASCII Seperators are invalid only in XML *1.0*

### DIFF
--- a/xep-0390.xml
+++ b/xep-0390.xml
@@ -49,6 +49,14 @@
   <shortname>ecaps2</shortname>
   &jonaswielicki;
   <revision>
+    <version>0.3.2</version>
+    <date>2018-03-05</date>
+    <initials>fs</initials>
+    <remark>
+	  <p>Explain that ASCII Seperators are only invalid in XML 1.0, but not in XML 1.1.</p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.3.1</version>
     <date>2020-04-28</date>
     <initials>fs</initials>
@@ -844,7 +852,7 @@ cDp0aW1lHxw=</code>
 
 <section1 topic='Security Considerations' anchor='security'>
   <section2 topic='Hash Function Input Data Separators' anchor='security-separators'>
-    <p>The codepoints used for separating the different parts in the <link url='#algorithm-input'>Hash Function Input Algortihm</link> (&sepl1; through &sepl4;) are not allowed in well-formed XML character data. As entities are, per &xmppcore;, required to close a stream if non-well-formed XML data is received, these codepoints cannot occur in the input to the algorithm and their use as separators is safe.</p>
+    <p>The codepoints used for separating the different parts in the <link url='#algorithm-input'>Hash Function Input Algortihm</link> (&sepl1; through &sepl4;) are not allowed in well-formed <link url='https://www.w3.org/TR/2008/REC-xml-20081126/#charsets'>XML 1.0 character data</link><note>Note that the "ASCII Seperators" codepoints would be valid, although discouraged, <link url='https://www.w3.org/TR/2006/REC-xml11-20060816/#charsets'>characters of XML 1.1</link>, but XMPP mandates XML 1.0.</note>. As entities are, per &xmppcore;, required to close a stream if non-well-formed XML 1.0 data is received, these codepoints cannot occur in the input to the algorithm and their use as separators is safe.</p>
   </section2>
 
   <section2 topic='Caching' anchor='security-caching'>


### PR DESCRIPTION
but not in XML 1.1.