### PR TITLE
XEP-0122: Do not put normative language into footnotes

### DIFF
--- a/xep-0122.xml
+++ b/xep-0122.xml
@@ -26,6 +26,12 @@
   <registry/>
   &linuxwolf;
   <revision>
+    <version>1.0.1</version>
+    <date>2018-03-05</date>
+    <initials>fs</initials>
+    <remark>Move normative language from footnote to into text.</remark>
+  </revision>
+  <revision>
     <version>1.0</version>
     <date>2004-09-22</date>
     <initials>psa</initials>
@@ -110,8 +116,9 @@
     <ul>
       <li>Start with "xs:", and be one of the "built-in" datatypes defined in &w3xmlschema2;</li>
       <li>Start with a prefix registered with the &REGISTRAR;</li>
-      <li>Start with "x:", and specify a user-defined datatype<note>While "x:" allows for ad-hoc definitions, its use is NOT RECOMMENDED.</note></li>
+      <li>Start with "x:", and specify a user-defined datatype.</li>
     </ul>
+	<p>Note that while "x:" allows for ad-hoc definitions, its use is NOT RECOMMENDED.</p>
   </section2>
   <section2 topic='Validation Methods' anchor='usecases-validation'>
     <p>In addition to datatypes, the validation method can also be provided. The method is specified via a child element. The validation methods defined in this document are:</p>


### PR DESCRIPTION
where people do not really expect it.