### PR TITLE
XEP-0379: minor editing

### DIFF
--- a/xep-0379.xml
+++ b/xep-0379.xml
@@ -322,7 +322,7 @@ https://juicyxmpp.example/i/#romeo@montague.net?preauth=1tMFqYDdKhfe2pwp;name=Ro
         and provide an easy mechanism to remove them and cancel their
         subscription.</p>
     </section2>
-    <section2 topic='Display Names' anchor='security_token'>
+    <section2 topic='Display Names' anchor='security_display'>
       <p>An attacker can lure the user by providing an invitation link with a
         'name' parameter that does not match the JID. Therefore, a client SHOULD
         always display both the JID and the proposed display name when adding a

--- a/xep-0379.xml
+++ b/xep-0379.xml
@@ -95,7 +95,7 @@
 Romeo          mongatague.net  capulet.net     Juliet
    |              |               |               |
    | Send out-of-band invitation link             |
-   | (xmpp:romeo@montague.net?preauth=token)      |
+   | xmpp:romeo@montague.net?roster;preauth=token |
    |- - - - - - - - - - - - - - - - - - - - - - ->|
    |              |               |    roster add |
    |              |               |<--------------|
@@ -171,7 +171,7 @@ xmpp:romeo@montague.net?roster;preauth=1tMFqYDdKhfe2pwp;name=Romeo+Montague
           recommended clients.</li>
       </ol>
 <example caption='Developer-Hosted Landing Page Generated with Fictitious JuicyXMPP Client'><![CDATA[
-https://juicyxmpp.example/i/#romeo@montague.net?preauth=1tMFqYDdKhfe2pwp;name=Romeo+Montague
+https://juicyxmpp.example/i/#romeo@montague.net?roster;preauth=1tMFqYDdKhfe2pwp;name=Romeo+Montague
 ]]></example>
       <p>A possible screen representation of the landing page would be:</p>
       <div class="example">

--- a/xep-0379.xml
+++ b/xep-0379.xml
@@ -137,8 +137,7 @@ xmpp:romeo@montague.net?roster;preauth=1tMFqYDdKhfe2pwp;name=Romeo+Montague
       <p><strong>Server-side implementation:</strong> it is
         possible (but out-of-scope for this document), to let the user's server
         handle generation of links as well as automatic approval of qualified
-        subscription requests. This requires an additional mechanism to query the
-        server for new (and possibly also for pending) invitation links.</p>
+        subscription requests. One such approach is documented in &xep0401;.</p>
 
     </section2>
 


### PR DESCRIPTION
This series fixes a chapter anchor, unifies the action on all xmpp: URIs to `roster` and adds a reference to XEP-0401.