### PR TITLE
XEP-0163: Clarify how +notify works

### DIFF
--- a/xep-0163.xml
+++ b/xep-0163.xml
@@ -280,7 +280,7 @@
      ver='zHyEOgxTrkpSdGcQKH8EFPLsriY='/>
 </presence>
 ]]></example>
-    <p>Your server knows to send tune information to Romeo because when the server unpacks the value of the 'ver' attribute ("054H4A7280JuT6+IroVYxgCAjZo=") in accordance with <cite>XEP-0115</cite>, it discovers that Romeo's client advertises a service discovery feature of "http://jabber.org/protocol/tune+notify", where the "+notify" suffix indicates interest in receiving notifications related to the protocol that precedes the suffix. The server can verify this support if needed by sending a service discovery request to Romeo's full JID, where the response would be as follows:</p>
+    <p>Your server knows to send tune information to Romeo because when the server unpacks the value of the 'ver' attribute ("054H4A7280JuT6+IroVYxgCAjZo=") in accordance with <cite>XEP-0115</cite>, it discovers that Romeo's client advertises a service discovery feature of "http://jabber.org/protocol/tune+notify", where the "+notify" suffix indicates interest in receiving notifications of the node whose NodeID precedes the suffix (see <cite>XEP-0060 § 9.2</cite>). The server can verify this support if needed by sending a service discovery request to Romeo's full JID, where the response would be as follows:</p>
     <example caption='Disco#info result from extension'><![CDATA[
 <iq from='romeo@montague.lit/orchard'
     to='juliet@capulet.lit'


### PR DESCRIPTION
It sounded like annoucing the jabber.org/protocol/foo+notify feature
causes one to receive notifications from *all* nodes related to the
jabber.org/protocol/foo protocol, but as per XEP-0060 § 9.2, one will
only receive notifications of the node whose NodeID equals
'jabber.org/protocol/foo'.