### PR TITLE
XEP-0107: Change the namespace of a private example

### DIFF
--- a/xep-0107.xml
+++ b/xep-0107.xml
@@ -26,6 +26,12 @@
   &stpeter;
   &ralphm;
   <revision>
+    <version>1.2.1</version>
+    <date>2018-03-13</date>
+    <initials>egp</initials>
+    <remark><p>Changed the namespace of an example of proprietary extensibility.</p></remark>
+  </revision>
+  <revision>
     <version>1.2</version>
     <date>2008-10-29</date>
     <initials>psa</initials>
@@ -96,7 +102,7 @@
     <code><![CDATA[
 <mood xmlns='http://jabber.org/protocol/mood'>
   <happy>
-    <ecstatic xmlns='http://ik.nu/ralphm'/>
+    <ecstatic xmlns='https://example.org/'/>
   </happy>
   <text>Yay, the mood spec has been approved!</text>
 </mood>


### PR DESCRIPTION
It was previously using Ralph’s domain, which didn’t make it clear that it was a dummy example.