### PR TITLE
XEP-0223: Add a warning about publish-options support

### DIFF
--- a/xep-0223.xml
+++ b/xep-0223.xml
@@ -26,6 +26,12 @@
   <shortname>N/A</shortname>
   &stpeter;
   <revision>
+    <version>1.1</version>
+    <date>2018-03-28</date>
+    <initials>jwi</initials>
+    <remark>Make discovery of support mandatory, add security considerations (in reaction to CVE-2018-6591).</remark>
+  </revision>
+  <revision>
     <version>1.0</version>
     <date>2008-09-08</date>
     <initials>psa</initials>
@@ -211,7 +217,7 @@
 </section1>
 
 <section1 topic='Determining Support' anchor='support'>
-  <p>Before an account owner attempts to complete any of the use cases defined herein, its client SHOULD verify that the account owner's server supports both PEP and the "publish-options" feature; to do so, it MUST send a &xep0030; information request to the server (or cache <cite>Entity Capabilities</cite> information received from the server).</p>
+  <p>Before an account owner attempts to complete any of the use cases defined herein, its client MUST verify that the account owner's server supports both PEP and the "publish-options" feature; to do so, it MUST send a &xep0030; information request to the server (or cache <cite>Entity Capabilities</cite> information received from the server).</p>
   <example caption='Account owner queries server regarding protocol support'><![CDATA[
 <iq from='juliet@capulet.lit/balcony'
     to='capulet.lit'
@@ -238,7 +244,8 @@
 </section1>
 
 <section1 topic='Security Considerations' anchor='security'>
-  <p>This document introduces no security considerations above and beyond those specified in <cite>XEP-0060</cite> and <cite>XEP-0163</cite>.</p>
+  <p>Since private data is to be stored in a mechanism originally intended to <em>publish</em> data, it is REQUIRED for entities to ensure that the restrictive &lt;publish-options/&gt; will actually be honored by the server by performing the feature discovery procedure as specified in <link url='#support'>Determining Support</link>. If an entity using that procedure finds that the server does not support &lt;publish-options/&gt;, it MUST NOT store private data in PubSub, unless it can ensure privacy of the data with other means.</p>
+  <p>The Security Considerations specified in <cite>XEP-0060</cite> and <cite>XEP-0163</cite> need to be taken into account.</p>
 </section1>
 
 <section1 topic='IANA Considerations' anchor='iana'>


### PR DESCRIPTION
In light of [CVE-2018-6591](https://gultsch.de/converse_bookmarks.html), it seems reasonable to make this clearer.

Variants (Council, feel free to mix and match):

* Raise the discovery to a MUST.
* Move "Determining Support" before the examples of the publish flow.