### PR TITLE
XEP-0369: Fix data form jid-multi example

### DIFF
--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -707,8 +707,6 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
         </field>
         <field var='Owner'>
             <value>hecate@shakespeare.example</value>
-        </field>
-        <field var='Owner'>
             <value>greymalkin@shakespeare.example</value>
         </field>
         <field var='Messages Node Subscription'>


### PR DESCRIPTION
The owner field is defines as `jid-multi`, so multiple values should be presented in one field parent, not two.