### PR TITLE
XEP-0393: clarify language around strong emphasis

### DIFF
--- a/xep-0393.xml
+++ b/xep-0393.xml
@@ -26,6 +26,16 @@
   <shortname>styling</shortname>
   &sam;
   <revision>
+    <version>0.1.4</version>
+    <date>2018-05-01</date>
+    <initials>ssw</initials>
+    <remark>
+      <p>
+        Clarify language around strong emphasis.
+      </p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.1.3</version>
     <date>2018-02-14</date>
     <initials>ssw</initials>
@@ -336,18 +346,6 @@
 </body>
 ]]></example>
     </section3>
-    <section3 topic='Strong' anchor='strong'>
-      <p>
-        Text enclosed by '*' (U+002A ASTERISK) is strong and SHOULD be displayed
-        with a heavier font weight than the surrounding text (bold).
-      </p>
-      <example caption='Strong'><![CDATA[
-<body>
-  The full title is "Twelfth Night, or What You Will" but
-  *most* people shorten it.
-</body>
-]]></example>
-    </section3>
     <section3 topic='Emphasis' anchor='emph'>
       <p>
         Text enclosed by '_' (U+005F LOW LINE) is emphasized and SHOULD be
@@ -357,6 +355,19 @@
 <body>
   The full title is _Twelfth Night, or What You Will_ but
   _most_ people shorten it.
+</body>
+]]></example>
+    </section3>
+    <section3 topic='Strong Emphasis' anchor='strong'>
+      <p>
+        Text enclosed by '*' (U+002A ASTERISK) is strongly emphasized and SHOULD
+        be displayed with a heavier font weight than the surrounding text
+        (bold).
+      </p>
+      <example caption='Strong'><![CDATA[
+<body>
+  The full title is "Twelfth Night, or What You Will" but
+  *most* people shorten it.
 </body>
 ]]></example>
     </section3>


### PR DESCRIPTION
Someone was asking why bold wasn't a form of emphasis; "strong" is just the HTML element name which I borrowed. Clarify the language to read "strong emphasis" to make things more clear.