### PR TITLE
XEP-0260: Fix the schema to mark @sid as required

### DIFF
--- a/xep-0260.xml
+++ b/xep-0260.xml
@@ -656,7 +656,7 @@ Romeo                               Juliet
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
-      <xs:attribute name='sid' type='xs:string' use='optional'/>
+      <xs:attribute name='sid' type='xs:string' use='required'/>
     </xs:complexType>
   </xs:element>
 

--- a/xep-0260.xml
+++ b/xep-0260.xml
@@ -37,6 +37,12 @@
     <jid>nx@jabber.org</jid>
   </author>
   <revision>
+    <version>1.0.2</version>
+    <date>2018-05-04</date>
+    <initials>egp</initials>
+    <remark><p>Fix the schema to mention @sid is required rather than optional.</p></remark>
+  </revision>
+  <revision>
     <version>1.0.1</version>
     <date>2016-05-17</date>
     <initials>ssw</initials>


### PR DESCRIPTION
It was marked as optional, despite the text saying otherwise.