### PR TITLE
XEP-0373: Fix link to RFC-4880 §11.2. Transferable Secret Keys

### DIFF
--- a/xep-0373.xml
+++ b/xep-0373.xml
@@ -590,8 +590,8 @@
         <li>All secret keys that should be included in the backup MUST
         be concatenated in their transferable key format (<cite>RFC
         4880</cite> <link
-        url='http://tools.ietf.org/html/rfc4880#section-11.1'>§
-        11.1</link>).
+        url='http://tools.ietf.org/html/rfc4880#section-11.2'>§
+        11.2</link>).
         </li>
         <li>A backup code is generated from secure random: The backup
         code consists of 24 upper case characters from the Latin


### PR DESCRIPTION
XEP-0373 is falsely linking to RFC-4880 §11.1. Transferable Public Keys, while the context is about secret keys. So instead it should link to the next chapter about Transferable Secret Keys. This is just a nit, but imo it should be corrected.