### PR TITLE
XEP-0373: Add pubsub example

### DIFF
--- a/xep-0373.xml
+++ b/xep-0373.xml
@@ -281,7 +281,7 @@
   <p>Two PEP node types are invovled: A "medatata node" is used to store meta information about
   OpenPGP keys used by an entity while the actual public keys are stored in "data nodes".</p>
 
-  <section2 topic='The OpenPGP Public-Key Data Node' anchor='annoucning-pubkey'>
+  <section2 topic='The OpenPGP Public-Key Data Node' anchor='announcing-pubkey'>
 
     <p>The public key data, as specified in <cite>RFC 4880</cite>, is stored in a PEP data
     node. Note that OpenPGP's ASCII Armor is not used, instead the XMPP client MUST encode the
@@ -350,11 +350,50 @@
 
   </section2>
 
-  <section2 topic='Discovering Public Keys' anchor='discover-pubkey'>
+  <section2 topic='Discovering Public Keys of a User' anchor='discover-pubkey-list'>
 
     <p>In order to discover the OpenPGP public keys, the interested entity first queries a remote
-    entities metadata note to learn about its currently annouced OpenPGP keys. Then the public
-    OpenPGP key(s) can be retrieved by querying the data node for a specific fingerprint.</p>
+    entities metadata note to learn about its currently annouced OpenPGP keys.</p>
+
+    <example caption='Requesting the metadata node of a user.'><![CDATA[
+<iq from='romeo@example.org/orchard'
+    to='juliet@example.org'
+    type='get'
+    id='getmeta'>
+  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+    <items node='urn:xmpp:openpgp:0:public-keys'/>
+  </pubsub>
+</iq>]]></example>
+
+    <example caption='Personal Eventing Protocol result containing the metadata node of the user.'><![CDATA[
+<iq from='juliet@example.org'
+    to='romeo@example.org/orchard'
+    type='result'
+    id='getmeta'>
+  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+    <items node='urn:xmpp:openpgp:0:public-keys'>
+      <item>
+        <public-keys-list xmlns='urn:xmpp:openpgp:0'>
+          <pubkey-metadata
+            v4-fingerprint='1357B01865B2503C18453D208CAC2A9678548E35'
+            date='2018-03-01T15:26:12Z'
+            />
+          <pubkey-metadata
+            v4-fingerprint='67819B343B2AB70DED9320872C6464AF2A8E4C02'
+            date='1953-05-16T12:00:00Z'
+            />
+        </public-keys-list>
+      </item>
+    </items>
+  </pubsub>
+</iq>]]></example>
+
+  </section2>
+
+  <section2 topic='Requesting Public Keys' anchor='discover-pubkey'>
+
+    <p>OpenPGP key(s) can be retrieved by querying the data node for a specific
+    fingerprint.</p>
 
     <example caption='Requesting an OpenPGP public key from an XMPP entity.'><![CDATA[
 <iq from='romeo@example.org/orchard'
@@ -868,7 +907,7 @@
 <section1 topic='Acknowledgements' anchor='acknowledgements'>
 
   <p>Thanks to Emmanuel Gil Peyrot, Sergei Golovan, Marc Laporte, Georg
-  Lukas, Adithya Abraham Philip, Brian Cully and fiaxh for their feedback.</p>
+  Lukas, Adithya Abraham Philip, Brian Cully, fiaxh and Paul Schaub for their feedback.</p>
 
   <p>The first draft of this specification was worked out and written
   on the wall of the 'Kymera' room in one of Google's buildings by the


### PR DESCRIPTION
This PR adds an example about how the metadata node is being fetched.
It also fixes a small typo in one of the anchors.