### PR TITLE
XEP-0045: Added standardized roominfo fields for allowinvites and the…

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -46,6 +46,14 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.32.0</version>
+    <date>2018-06-18</date>
+    <initials>dg</initials>
+    <remark>
+      <p>Added standardized roominfo fields for allowinvites and the room name.</p>
+    </remark>
+  </revision>
+  <revision>
     <version>1.31.1</version>
     <date>2018-03-12</date>
     <initials>kis</initials>
@@ -1221,6 +1229,10 @@
       <field var='FORM_TYPE' type='hidden'>
         <value>http://jabber.org/protocol/muc#roominfo</value>
       </field>
+      <field var='muc#roominfo_name'
+             label='Name'>
+        <value>A Dark Cave</value>
+      </field>
       <field var='muc#roominfo_description'
              label='Description'>
         <value>The place for all good witches!</value>
@@ -1264,6 +1276,10 @@
       <field var='muc#roominfo_pubsub'
              label='Associated pubsub node'>
         <value>xmpp:pubsub.shakespeare.lit?;node=the-coven-node</value>
+      </field>
+      <field var='muc#roominfo_allowinvites'
+             label='Occupants are allowed to invite others'>
+        <value>0</value>
       </field>
     </x>
   </query>
@@ -5284,6 +5300,10 @@
       type='text-single'
       label='Maximum Number of History Messages Returned by Room'/>
   <field
+      var='muc#roominfo_allowinvites'
+      type='boolean'
+      label='Occupants are allowed to invite others'/>
+  <field
       var='muc#roominfo_contactjid'
       type='jid-multi'
       label='Contact Addresses (normally, room owner or owners)'/>
@@ -5308,6 +5328,10 @@
       var='muc#roominfo_logs'
       type='text-single'
       label='URL for Archived Discussion Logs'/>
+  <field
+      var='muc#roominfo_name'
+      type='text-single'
+      label='Natural-Language Room Name'/>
   <field
       var='muc#roominfo_occupants'
       type='text-single'


### PR DESCRIPTION
… room name.

The standard doesn’t commend muc services to set the identity name of a room to be the name configured in the room configuration. Some implementations set the identity name to the local part of the jid if the configured room name is empty. Therefore implementations are unable to discover if a room name is empty (=not set) when running disco#info. To circumvent this and to let clients discover (reliably) if a name is set (or not!) this PR adds a standardized roominfo field for the name.

Discovering whether or not an occupant is allowed to invite other members is also useful (clients can hide the button if that’s not the case.)

Rendered version here: https://gultsch.de/files/xep-0045.html