### PR TITLE
XEP-0373: Fix node name of secret key node

### DIFF
--- a/xep-0373.xml
+++ b/xep-0373.xml
@@ -494,7 +494,7 @@
     type='get'
     id='getsecret'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-    <items node='urn:xmpp:openpgp:secret-key:0'
+    <items node='urn:xmpp:openpgp:0:secret-key'
            max_items='1'/>
   </pubsub>
 </iq>]]></example>
@@ -508,7 +508,7 @@
     type='result'
     id='getsecret'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-    <items node='urn:xmpp:openpgp:secret-key:0'>
+    <items node='urn:xmpp:openpgp:0:secret-key'>
       <item>
         <secretkey xmlns='urn:xmpp:openpgp:0'>
             BASE64_OPENPGP_ENCRYPTED_SECRET_KEY
@@ -562,7 +562,7 @@
     from='juliet@example.org/balcony'
     id='create-node'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-    <create node='urn:xmpp:openpgp:secret-key:0'/>
+    <create node='urn:xmpp:openpgp:0:secret-key'/>
     <configure>
       <x xmlns='jabber:x:data' type='submit'>
         <field var='FORM_TYPE' type='hidden'>


### PR DESCRIPTION
Fix the name of the secret key node to follow the same pattern as the other node names.
This was originally part of #644 but I moved the change over here to allow #644 to get merged faster.