### PR TITLE
XEP-0373: Replace "ID" with "fingerprint"

### DIFF
--- a/xep-0373.xml
+++ b/xep-0373.xml
@@ -324,7 +324,7 @@
   <section2 topic='The OpenPGP Public Key Metadata Node' anchor='announcing-pubkey-list'>
 
     <p>To update the public keys used by an entity, the metadata node is updated. Before adding a
-    OpenPGP key ID to the metadata node, the publisher MUST ensure that the public key is available
+    OpenPGP key fingerprint to the metadata node, the publisher MUST ensure that the public key is available
     at the corresponding data node.</p>
 
     <p> The ID of the metadata node is 'urn:xmpp:openpgp:0:public-keys'. It contains a


### PR DESCRIPTION
The client adds a keys fingerprint to the metadata node, not the key id.