### PR TITLE
XEP-0059: Add 'exact(-index)' attribute to RSM's <count/> and <first/>

### DIFF
--- a/xep-0059.xml
+++ b/xep-0059.xml
@@ -34,6 +34,12 @@
     <jid>jlseguineau@im.antepo.com</jid>
   </author>
   <revision>
+    <version>1.1</version>
+    <date>2018-06-2f</date>
+    <initials>fs</initials>
+    <remark><p>Add backwards compatible 'exact' attribute to &lt;count/&gt; and 'exact-index' to &lt;first/&gt;</p></remark>
+  </revision>
+  <revision>
     <version>1.0</version>
     <date>2006-09-20</date>
     <initials>psa</initials>
@@ -191,7 +197,9 @@
 ]]></example>
     <p>Responding entity support for paging through a result set is optional. If it does support paging (not just <link url='#limit'>Limiting the Number of Items</link>), then in each page it returns, the responding entity MUST include &lt;first/&gt; and &lt;last/&gt; elements that specify the unique ID (UID) for the first and last items in the page. If there is only one item in the page, then the first and last UIDs MUST be the same. If there are no items in the page, then the &lt;first/&gt; and &lt;last/&gt; elements MUST NOT be included.</p>
     <p>The responding entity may generate these UIDs in any way, as long as the UIDs are unique in the context of all possible members of the full result set. Each UID MAY be based on part of the content of its associated item, as shown below, or on an internal table index. Another possible method is to serialize the XML of the item and then hash it to generate the UID. Note: The requesting entity MUST treat all UIDs as opaque.</p>
-    <p>The responding entity SHOULD also include the number of items in the full result set (which MAY be approximate) encapsulated in a &lt;count/&gt; element. The &lt;first/&gt; element SHOULD include an 'index' attribute. This integer specifies the position within the full set (which MAY be approximate) of the first item in the page. If that item is the first in the full set, then the index SHOULD be '0'. If the last item in the page is the last item in the full set, then the value of the &lt;first/&gt; element's 'index' attribute SHOULD be the specified count minus the number of items in the last page.</p>
+    <p>The responding entity SHOULD also include the number of items in the full result set encapsulated in a &lt;count/&gt; element. The number of items may be approximate. The responding entity may signal an exact number by extending &lt;count/&gt; by an attribute with the name 'exact' and its value set to 'true'. Alternatively it may set the valule of the 'exact' attribute to 'false', to signal the inexactness of the number. Note that the 'exact' attribute is optional and has no default value, meaning that the absence of the 'exact' attribute neither signals exactness or inexactness. Hence it is RECOMMENDED for responding entities to set the 'exact' attribute.</p>
+	<p>The &lt;first/&gt; element SHOULD include an 'index' attribute. This integer specifies the position within the full set of the first item in the page. The position may be approximate. The responding entity may signal an exact position by extending &lt;first/&gt; by an attribute with the name 'exact-index' with its value set to 'true'. Alternatively it may set the valule of the 'exact-index' attribute to 'false', to signal the inexactness of the position. Note that the 'exact-index' attribute is optional and has no default value, meaning that the absence of the 'exact-index' attribute neither signals exactness or inexactness. Hence it is RECOMMENDED for responding entities to set the 'exact-index' attribute.</p>
+	<p>If that item is the first in the full set, then the index SHOULD be '0'. If the last item in the page is the last item in the full set, then the value of the &lt;first/&gt; element's 'index' attribute SHOULD be the specified count minus the number of items in the last page.</p>
     <p>Note: The &lt;count/&gt; element and 'index' attribute enable important functionality for requesting entities (for example, a scroll-bar user-interface component). They MAY be omitted, but <em>only</em> if it would be either impossible or exceptionally resource intensive to calculate reasonably accurate values.</p>
     <example caption='Returning the First Page of a Result Set'><![CDATA[
 <iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page1'>
@@ -210,9 +218,9 @@
       <nick>Pete</nick>
     </item>
     <set xmlns='http://jabber.org/protocol/rsm'>
-      <first index='0'>stpeter@jabber.org</first>
+      <first index='0' exact-index='true'>stpeter@jabber.org</first>
       <last>peterpan@neverland.lit</last>
-      <count>800</count>
+      <count exact='true'>800</count>
     </set>
   </query>
 </iq>
@@ -415,7 +423,7 @@
 <iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='count1'>
   <query xmlns='jabber:iq:search'>
     <set xmlns='http://jabber.org/protocol/rsm'>
-      <count>800</count>
+      <count exact='true'>800</count>
     </set>
   </query>
 </iq>
@@ -533,7 +541,7 @@
       <xs:sequence>
         <xs:element name='after' type='xs:string' minOccurs='0' maxOccurs='1'/>
         <xs:element name='before' type='xs:string' minOccurs='0' maxOccurs='1'/>
-        <xs:element name='count' type='xs:int' minOccurs='0' maxOccurs='1'/>
+        <xs:element ref='count' minOccurs='0' maxOccurs='1'/>
         <xs:element ref='first' minOccurs='0' maxOccurs='1'/>
         <xs:element name='index' type='xs:int' minOccurs='0' maxOccurs='1'/>
         <xs:element name='last' type='xs:string' minOccurs='0' maxOccurs='1'/>
@@ -542,11 +550,22 @@
     </xs:complexType>
   </xs:element>
 
+  <xs:element name='count'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='xs:int'>
+          <xs:attribute name='exact' type='xs:boolean' use='optional'/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
   <xs:element name='first'>
     <xs:complexType>
       <xs:simpleContent>
         <xs:extension base='xs:string'>
           <xs:attribute name='index' type='xs:int' use='optional'/>
+          <xs:attribute name='exact-index' type='xs:boolean' use='optional'/>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>
@@ -556,6 +575,6 @@
 ]]></code>
 </section1>
 <section1 topic='Acknowledgements' anchor='ack'>
-  <p>Thanks to Olivier Goffart, Jon Perlow, and Andrew Plotkin for their feedback.</p>
+  <p>Thanks to Olivier Goffart, Jon Perlow, Andrew Plotkin and Florian Schmaus for their feedback.</p>
 </section1>
 </xep>


### PR DESCRIPTION
RSM specifies that the number or position included in a RSM response
may be approximate. But some protocols benefit from knowledge whether
the value is exact or approximate. For example a MAM synchronization
algorithm, which syncs a slave archive, potentially having multiple
holes, from a master archive, may use an optimized algorithm if the
master archive returns exact counts.

This commit adds signaling to RSM that the values are exact and not
approximate in a backwards compatible fashion.