### PR TITLE
XEP-0198: Clarify the note about counters

### DIFF
--- a/xep-0198.xml
+++ b/xep-0198.xml
@@ -29,6 +29,12 @@
   &dcridland;
   &mwild;
   <revision>
+    <version>1.5.3</version>
+    <date>2017-06-29</date>
+    <initials>fs/mw</initials>
+    <remark><p>Improve the note about stream management counters in section 4.</p></remark>
+  </revision>
+  <revision>
     <version>1.5.2</version>
     <date>2016-12-08</date>
     <initials>cs (XEP Editor: ssw)</initials>
@@ -275,7 +281,7 @@
   <p class='def'><strong>Definition:</strong> Acknowledging a previously-received ack element indicates that the stanza(s) sent since then have been "handled" by the server. By "handled" we mean that the server has accepted responsibility for a stanza or stanzas (e.g., to process the stanza(s) directly, deliver the stanza(s) to a local entity such as another connected client on the same server, or route the stanza(s) to a remote entity at a different server); until a stanza has been affirmed as handled by the server, that stanza is the responsibility of the sender (e.g., to resend it or generate an error if it is never affirmed as handled by the server).</p>
   <p>Receipt of an &lt;r/&gt; element does not imply that new stanzas have been transmitted by the peer; receipt of an &lt;a/&gt; element only indicates that new stanzas have been processed if the 'h' attribute has been incremented.</p>
   <p>The value of 'h' starts at zero at the point stream management is enabled or requested to be enabled (see note below). The value of 'h' is then incremented to one for the first stanza handled and incremented by one again with each subsequent stanza handled. In the unlikely case that the number of stanzas handled during a stream management session exceeds the number of digits that can be represented by the unsignedInt datatype as specified in &w3xmlschema2; (i.e., 2<span class='super'>32</span>), the value of 'h' SHALL be reset from 2<span class='super'>32</span>-1 back to zero (rather than being incremented to 2<span class='super'>32</span>).</p>
-  <p class='box'>Note: There are two values of 'h' for any given stream: one maintained by the client to keep track of stanzas it has handled from the server, and one maintained by the server to keep track of stanzas it has handled from the client. The client initializes its value to zero when it sends &lt;enable/&gt; to the server, and the server initializes its value to zero when it sends &lt;enabled/&gt; to the client (it is expected that the server will respond immediately to &lt;enable/&gt; and set its counter to zero at that time). After this initialization, the client increments its value of 'h' for each stanza it handles from server, and the server increments its value of 'h' for each stanza it handles from the client.</p>
+  <p class='box'>Note: Each entity maintains two counters for any given stream: a counter of stanzas it has sent, and a counter of stanzas it has received and handled ('h'). The counter for an entity's own sent stanzas is set to zero and started after sending either &lt;enable/&gt; or &lt;enabled/&gt;. The counter for the received stanzas ('h') is set to zero and started after receiving either &lt;enable/&gt; or &lt;enabled/&gt;.</p>
   <p>The following annotated example shows a message sent by the client, a request for acknowledgement, and an ack of the stanza.</p>
    <example caption='Simple stanza acking'><![CDATA[
 <!-- Client -->


### PR DESCRIPTION
Many implementations have failed to get this right on their first
attempt, and so this text aims to clarify the logic required for
an implementation to correctly maintain its counters for a stream.

The text was 95% based on text originally proposed by Florian Schmaus,
but I find it a bit clearer and fixed some grammar in the process.

This is based on, and an alternative to, #671.