### PR TITLE
XEP-0157: Add a forgotten dependency on XEP-0128

### DIFF
--- a/xep-0157.xml
+++ b/xep-0157.xml
@@ -16,6 +16,7 @@
   <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
+    <spec>XEP-0128</spec>
   </dependencies>
   <supersedes/>
   <supersededby/>


### PR DESCRIPTION
It was present in the text, but not in the metadata.