### PR TITLE
XEP-0050: Remove the status attribute from the request

### DIFF
--- a/xep-0050.xml
+++ b/xep-0050.xml
@@ -26,6 +26,12 @@
   </schemaloc>
   &linuxwolf;
   <revision>
+    <version>1.2.3</version>
+    <date>2018-05-28</date>
+    <initials>egp</initials>
+    <remark>Remove a suggestion to set the 'status' attribute by the requester, since this attribute MUST be ignored by the responder if set (§4.1).</remark>
+  </revision>
+  <revision>
     <version>1.2.2</version>
     <date>2016-12-03</date>
     <initials>XEP Editor (ssw, fs)</initials>
@@ -504,7 +510,7 @@
   </section2>
   <section2 topic='Session Lifetime' anchor='impl-session'>
     <p>The execution of a command exists within the concept of a session. Each session is identified by the 'sessionid' attribute, and SHOULD be valid only between one requester/responder pair. The responder is responsible for determining the session lifetime, with some help from the requester.</p>
-    <p>The requester starts a new session for a command by simply sending a &lt;command/&gt; with the 'node' attribute (and optionally the 'status' attribute with a value of "execute"). Once the 'sessionid' attribute is given to the requester, it is the requester's responsibility to maintain it for the session's lifetime. A session ends when the responder sends a &lt;command status='completed'/&gt; or the requester sends a &lt;command action='cancel'/&gt; with the provided 'sessionid' value.</p>
+    <p>The requester starts a new session for a command by simply sending a &lt;command/&gt; with the 'node' attribute. Once the 'sessionid' attribute is given to the requester, it is the requester's responsibility to maintain it for the session's lifetime. A session ends when the responder sends a &lt;command status='completed'/&gt; or the requester sends a &lt;command action='cancel'/&gt; with the provided 'sessionid' value.</p>
     <p>Once a session has ended, its 'sessionid' value SHOULD NOT be used again. It is the responder's responsibility to ensure that each 'sessionid' value is unique.</p>
     <p>It may be possible for a requester to be executing more than one session of the same command with a given responder. If the responder does not allow more than one session of the same command with the same requester, the responder MUST return a &notallowed; error (see &xep0086;).</p>
   </section2>


### PR DESCRIPTION
Remove a suggestion to set the status attribute by the requester, since this attribute MUST be ignored by the responder if set (§4.1).