### PR TITLE
XEP-0065, XEP-0363: Document exposing the service on the user’s domain

### DIFF
--- a/xep-0065.xml
+++ b/xep-0065.xml
@@ -30,6 +30,16 @@
   &stpeter;
   &infiniti;
   <revision>
+    <version>1.9</version>
+    <date>2018-07-25</date>
+    <initials>egp</initials>
+    <remark>
+      <ul>
+        <li>Standardise the user’s domain exposing this feature.</li>
+      </ul>
+    </remark>
+  </revision>
+  <revision>
     <version>1.8.1</version>
     <date>2015-09-17</date>
     <initials>fs</initials>
@@ -265,6 +275,32 @@
     to='requester@example.com/foo'
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
+    <identity category='proxy'
+              type='bytestreams'
+              name='File Transfer Relay'/>
+    <feature var='http://jabber.org/protocol/bytestreams'/>
+  </query>
+</iq>
+]]></example>
+  <p>Alternatively, the proxy may be exposed directly on the Requester’s server. In which case, the Requester should use Service Discovery on this domain, like for every previous disco#items results.</p>
+  <example caption='Requester Sends Service Discovery Request to Server'><![CDATA[
+<iq from='requester@example.com/foo'
+    id='a58f1cc2'
+    to='example.com'
+    type='get'>
+  <query xmlns='http://jabber.org/protocol/disco#info'/>
+</iq>
+]]></example>
+  <p>The server returns its information and the Requester inspects it to determine if it contains an identity of category "proxy" and type "bytestreams".</p>
+  <example caption='Server Replies to Service Discovery Request'><![CDATA[
+<iq from='example.com'
+    id='a58f1cc2'
+    to='requester@example.com/foo'
+    type='result'>
+  <query xmlns='http://jabber.org/protocol/disco#info'>
+    <identity category='server'
+              type='im'
+              name='User’s Server'/>
     <identity category='proxy'
               type='bytestreams'
               name='File Transfer Relay'/>

--- a/xep-0363.xml
+++ b/xep-0363.xml
@@ -31,6 +31,16 @@
     <jid>daniel@gultsch.de</jid>
   </author>
   <revision>
+    <version>0.8.0</version>
+    <date>2018-07-25</date>
+    <initials>egp</initials>
+    <remark>
+      <ul>
+        <li>Standardise the user’s domain exposing this feature.</li>
+      </ul>
+    </remark>
+  </revision>
+  <revision>
     <version>0.7.0</version>
     <date>2018-05-30</date>
     <initials>dg</initials>
@@ -205,6 +215,40 @@
     </x>
   </query>
 </iq>]]></example>
+  <p>Alternatively, the upload service may be exposed directly on the Requester’s server. In which case, the Requester should use Service Discovery on this domain, like for every previous disco#items results.</p>
+  <example caption='Requester Sends Service Discovery Request to Server'><![CDATA[
+<iq from='requester@example.com/foo'
+    id='a58f1cc2'
+    to='example.com'
+    type='get'>
+  <query xmlns='http://jabber.org/protocol/disco#info'/>
+</iq>
+]]></example>
+  <p>The server returns its information and the Requester inspects it to determine if it contains an identity of category "store" and type "file".</p>
+  <example caption='Server Replies to Service Discovery Request'><![CDATA[
+<iq from='example.com'
+    id='a58f1cc2'
+    to='requester@example.com/foo'
+    type='result'>
+  <query xmlns='http://jabber.org/protocol/disco#info'>
+    <identity category='server'
+              type='im'
+              name='User’s Server'/>
+    <identity category='store'
+              type='file'
+              name='HTTP File Upload' />
+    <feature var='urn:xmpp:http:upload:0' />
+    <x type='result' xmlns='jabber:x:data'>
+      <field var='FORM_TYPE' type='hidden'>
+        <value>urn:xmpp:http:upload:0</value>
+      </field>
+      <field var='max-file-size'>
+        <value>5242880</value>
+      </field>
+    </x>
+  </query>
+</iq>
+]]></example>
 </section1>
 <section1 topic='Requesting a slot' anchor='request'>
   <p>A client requests a new upload slot by sending an IQ-get to the upload service containing a &lt;request&gt; child element qualified by the urn:xmpp:http:upload:0 namespace. This element MUST include the attributes filename and size containing the file name and size respectively.</p>


### PR DESCRIPTION
This practice is quite widespread already, and shouldn’t have any
overhead given the domain’s disco#info should already be cached by
XEP-0115/XEP-0390 in the <stream:features/>.