### PR TITLE
XEP-0392: Fix a typo

### DIFF
--- a/xep-0392.xml
+++ b/xep-0392.xml
@@ -24,6 +24,14 @@
   <shortname>colors</shortname>
   &jonaswielicki;
   <revision>
+    <version>0.4.1</version>
+    <date>2018-07-28</date>
+    <initials>egp</initials>
+    <remark>
+      <p>Fix a typo. (thanks zinid)</p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.4</version>
     <date>2017-11-29</date>
     <initials>jwi</initials>
@@ -124,7 +132,7 @@
     <p>Note: The goal of this algorithm is to convert arbitrary text into a scalar value which can then be used to calculate a color. As it happens, the CbCr plane of the YCbCr space determines the color (while Y merely defines the lightness); thus, an angle in the CbCr plane serves as a good scalar value to select a color.</p>
     <ol>
       <li>Run the input through SHA-1 (&rfc3174;).</li>
-      <li>Treat the output as little endian and extract the last-significant 16 bits. (These are the first two bytes of the output, with the second byte being the most significant one.)</li>
+      <li>Treat the output as little endian and extract the least-significant 16 bits. (These are the first two bytes of the output, with the second byte being the most significant one.)</li>
       <li>Divide the value by 65536 (use float division) and multiply it by 2&#960; (two Pi).</li>
     </ol>
   </section2>


### PR DESCRIPTION
It’s “least-significant”, not “last”.

Thanks @zinid for noticing.