### PR TITLE
XEP-0384: Make examples use item id='current'

### DIFF
--- a/xep-0384.xml
+++ b/xep-0384.xml
@@ -28,6 +28,12 @@
     <jid>andy@strb.org</jid>
   </author>
   <revision>
+    <version>0.2.2</version>
+    <date>2018-07-31</date>
+    <initials>egp</initials>
+    <remark><p>Make examples show items published to the id "current", as per <cite>XEP-0060</cite> §12.20.</p></remark>
+  </revision>
+  <revision>
     <version>0.2.1</version>
     <date>2018-05-21</date>
     <initials>mb</initials>
@@ -166,7 +172,7 @@
          id='update_01'>
   <event xmlns='http://jabber.org/protocol/pubsub#event'>
     <items node='eu.siacs.conversations.axolotl.devicelist'>
-      <item>
+      <item id='current'>
         <list xmlns='eu.siacs.conversations.axolotl'>
           <device id='12345' />
           <device id='4223' />
@@ -182,7 +188,7 @@
 <iq from='juliet@capulet.lit' type='set' id='announce1'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
     <publish node='eu.siacs.conversations.axolotl.devicelist'>
-      <item>
+      <item id='current'>
         <list xmlns='eu.siacs.conversations.axolotl'>
           <device id='12345' />
           <device id='4223' />
@@ -192,13 +198,14 @@
     </publish>
   </pubsub>
 </iq>]]></example>
+    <p>NOTE: as per <link url='https://xmpp.org/extensions/xep-0060.html#impl-singleton'><cite>XEP-0060</cite> §12.20</link>, it is RECOMMENDED for the publisher to specify an ItemID of "current" to ensure that the publication of a new item will overwrite the existing item.</p>
     <p>This step presents the risk of introducing a race condition: Two devices might simultaneously try to announce themselves, unaware of the other's existence. The second device would overwrite the first one. To mitigate this, devices MUST check that their own device ID is contained in the list whenever they receive a PEP update from their own account. If they have been removed, they MUST reannounce themselves.</p>
     <p>Furthermore, a device MUST announce it's IdentityKey, a signed PreKey, and a list of PreKeys in a separate, per-device PEP node. The list SHOULD contain 100 PreKeys, but MUST contain no less than 20.</p>
     <example caption='Announcing bundle information'><![CDATA[
 <iq from='juliet@capulet.lit' type='set' id='announce2'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
     <publish node='eu.siacs.conversations.axolotl.bundles:31415'>
-      <item>
+      <item id='current'>
         <bundle xmlns='eu.siacs.conversations.axolotl'>
           <signedPreKeyPublic signedPreKeyId='1'>
             BASE64ENCODED...


### PR DESCRIPTION
This makes it respect XEP-0060 §12.20 on singleton nodes.