### PR TITLE
XEP-0359: Remove <origin-id/>

### DIFF
--- a/xep-0359.xml
+++ b/xep-0359.xml
@@ -24,15 +24,15 @@
   <shortname>stanza-id</shortname>
   &flow;
   <revision>
-	  <version>0.5.0</version>
-	  <date>2017-08-23</date>
-	  <initials>dg</initials>
-	  <remark>
-		  <ul>
-			  <li>Business rules clarifications</li>
-			  <li>Define stanza-ids for messages only</li>
-		  </ul>
-	  </remark>
+    <version>0.5.0</version>
+    <date>2017-08-23</date>
+    <initials>dg</initials>
+    <remark>
+      <ul>
+        <li>Business rules clarifications</li>
+        <li>Define stanza-ids for messages only</li>
+      </ul>
+    </remark>
   </revision>
   <revision>
     <version>0.4.1</version>
@@ -57,7 +57,7 @@
     <initials>fs</initials>
     <remark>
       <p>Rename client-id element to origin-id.</p>
-	  <p>Minor improvements.</p>
+      <p>Minor improvements.</p>
     </remark>
   </revision>
   <revision>
@@ -73,11 +73,11 @@
     <date>2015-09-18</date>
     <initials>fs</initials>
     <remark>
-	  <ul>
-		<li>Refactored client-id from attribute to element.</li>
-		<li>Set short name to 'stanza-id'.</li>
-		<li>Clarified that SID elements must not have additional content.</li>
-	  </ul>
+      <ul>
+        <li>Refactored client-id from attribute to element.</li>
+        <li>Set short name to 'stanza-id'.</li>
+        <li>Clarified that SID elements must not have additional content.</li>
+      </ul>
     </remark>
   </revision>
   <revision>
@@ -91,11 +91,11 @@
     <date>2015-06-22</date>
     <initials>fs</initials>
     <remark>
-	  <ul>
-		<li>Rename the XEP from "Message IDs" to "Stanza IDs"</li>
-		<li>Add 'by' attribute</li>
-	  </ul>
-	</remark>
+      <ul>
+        <li>Rename the XEP from "Message IDs" to "Stanza IDs"</li>
+        <li>Add 'by' attribute</li>
+      </ul>
+    </remark>
   </revision>
   <revision>
     <version>0.0.1</version>
@@ -117,20 +117,20 @@
   <p>In order to create a &stanza-id; extension element, the creating XMPP entity generates and sets the value of the 'id' attribute, and puts its own XMPP address as value of the 'by' attribute. The value of the 'id' attribute must be unique and stable, i.e. it MUST NOT change later for some reason within the scope of the 'by' value. Thus the IDs defined in this extension MUST be unique and stable within the scope of the generating XMPP entity. It is RECOMMENDED that the ID generating service uses UUID and the algorithm defined in &rfc4122; to generate the IDs.</p>
   </section2>
   <section2 topic='Origin generated stanza IDs' anchor='origin-id'>
-	<p>
-	  Some use cases require the originating entity, e.g. a client, to generate the stanza ID. In this case, the client MUST use the &origin-id; element extension element qualified by the 'urn:xmpp:sid:0' namespace. Note that originating entities often want to conceal their XMPP address and therefore the &origin-id; element has no 'by' attribute.
-	</p>
-	<example caption='A message stanza with the stanza ID extension.'><![CDATA[
+  <p>
+    Some use cases require the originating entity, e.g. a client, to generate the stanza ID. In this case, the client MUST use the &origin-id; element extension element qualified by the 'urn:xmpp:sid:0' namespace. Note that originating entities often want to conceal their XMPP address and therefore the &origin-id; element has no 'by' attribute.
+  </p>
+  <example caption='A message stanza with the stanza ID extension.'><![CDATA[
 <message xmlns='jabber:client'
          to='room@muc.example.com'
          type='groupchat'>
   <body>Typical body text</body>
   <origin-id xmlns='urn:xmpp:sid:0' id='de305d54-75b4-431b-adb2-eb6b9e546013'/>
 </message>]]></example>
-	<p>
-	  The server or component MAY add a &stanza-id; element. In that case, it MUST preserve the content of the &origin-id; element.
-	</p>
-	<example caption='A message stanza with the stanza ID extension.'><![CDATA[
+  <p>
+    The server or component MAY add a &stanza-id; element. In that case, it MUST preserve the content of the &origin-id; element.
+  </p>
+  <example caption='A message stanza with the stanza ID extension.'><![CDATA[
 <message xmlns='jabber:client'
          to='room@muc.example.com'
          type='groupchat'>
@@ -144,13 +144,13 @@
 </section1>
 <section1 topic='Business Rules' anchor='rules'>
   <ol>
-	<li>The values of the 'id' attribute SHOULD be unpredictable.</li>
-	<li>Stanza ID generating entities, which encounter a &stanza-id; element where the 'by' attribute matches the 'by' attribute they would otherwise set, MUST delete that element even if they are not adding their own stanza ID.</li>
-	<li>Entities, which are routing stanzas, SHOULD NOT strip any elements qualified by the 'urn:xmpp:sid:0' namespace from message stanzas unless the preceding rule applied to those elements.</li>
-	<li>Stanzas MUST possess, in the direct child level of the stanza, at most one &stanza-id; extension element with the same XMPP address as value of the 'by' attribute.</li>
-	<li>Every &stanza-id; extension element MUST have the 'id' attribute and the 'by' attribute set.</li>
-	<li>Every &stanza-id; and &origin-id; extension element MUST always possess an 'id' attribute and MUST NOT have any child elements or text content.</li>
-	<li>The value of the 'by' attribute MUST be the XMPP address of the entity assigning the unique and stable stanza ID. For one-on-one messages the assigning entity is the account. In groupchats the assigning entity is the room. Note that XMPP addresses are normalized as defined in &rfc6122;.</li>
+    <li>The values of the 'id' attribute SHOULD be unpredictable.</li>
+    <li>Stanza ID generating entities, which encounter a &stanza-id; element where the 'by' attribute matches the 'by' attribute they would otherwise set, MUST delete that element even if they are not adding their own stanza ID.</li>
+    <li>Entities, which are routing stanzas, SHOULD NOT strip any elements qualified by the 'urn:xmpp:sid:0' namespace from message stanzas unless the preceding rule applied to those elements.</li>
+    <li>Stanzas MUST possess, in the direct child level of the stanza, at most one &stanza-id; extension element with the same XMPP address as value of the 'by' attribute.</li>
+    <li>Every &stanza-id; extension element MUST have the 'id' attribute and the 'by' attribute set.</li>
+    <li>Every &stanza-id; and &origin-id; extension element MUST always possess an 'id' attribute and MUST NOT have any child elements or text content.</li>
+    <li>The value of the 'by' attribute MUST be the XMPP address of the entity assigning the unique and stable stanza ID. For one-on-one messages the assigning entity is the account. In groupchats the assigning entity is the room. Note that XMPP addresses are normalized as defined in &rfc6122;.</li>
   </ol>
 </section1>
 <section1 topic='Discovering Support' anchor='disco'>

--- a/xep-0359.xml
+++ b/xep-0359.xml
@@ -151,6 +151,9 @@
 </iq>
 ]]></example>
 </section1>
+<section1 topic='Implementation Notes' anchor='impl'>
+  <p>Older versions of this specification defined an &origin-id; extension element, which was to be set by the emitting client on every message to a MUC. This was done because the 'id' attribute of the message was not guaranteed to stay the same between the original and the broadcasted message. &xep0045; version 1.31 made it a requirement to keep this 'id' attribute, so there is no reason to have this hack anymore.</p>
+</section1>
 <section1 topic='Security Considerations' anchor='security'>
   <p>The value of the 'id' attribute should not provide any further information besides the opaque ID itself. Entities observing the value MUST NOT be able to infer any information from it, e.g. the size of the message archive. The value of 'id' MUST be considered a non-secret value.</p>
   <p>Before processing the stanza ID of a message and using it for deduplication purposes or for MAM catchup, the receiving entity SHOULD ensure that the stanza ID could not have been faked, by verifying that the entity referenced in the by attribute does annouce the 'urn:xmpp:sid:0' namespace in its disco features.</p>

--- a/xep-0359.xml
+++ b/xep-0359.xml
@@ -116,31 +116,6 @@
 ]]></example>
   <p>In order to create a &stanza-id; extension element, the creating XMPP entity generates and sets the value of the 'id' attribute, and puts its own XMPP address as value of the 'by' attribute. The value of the 'id' attribute must be unique and stable, i.e. it MUST NOT change later for some reason within the scope of the 'by' value. Thus the IDs defined in this extension MUST be unique and stable within the scope of the generating XMPP entity. It is RECOMMENDED that the ID generating service uses UUID and the algorithm defined in &rfc4122; to generate the IDs.</p>
   </section2>
-  <section2 topic='Origin generated stanza IDs' anchor='origin-id'>
-  <p>
-    Some use cases require the originating entity, e.g. a client, to generate the stanza ID. In this case, the client MUST use the &origin-id; element extension element qualified by the 'urn:xmpp:sid:0' namespace. Note that originating entities often want to conceal their XMPP address and therefore the &origin-id; element has no 'by' attribute.
-  </p>
-  <example caption='A message stanza with the stanza ID extension.'><![CDATA[
-<message xmlns='jabber:client'
-         to='room@muc.example.com'
-         type='groupchat'>
-  <body>Typical body text</body>
-  <origin-id xmlns='urn:xmpp:sid:0' id='de305d54-75b4-431b-adb2-eb6b9e546013'/>
-</message>]]></example>
-  <p>
-    The server or component MAY add a &stanza-id; element. In that case, it MUST preserve the content of the &origin-id; element.
-  </p>
-  <example caption='A message stanza with the stanza ID extension.'><![CDATA[
-<message xmlns='jabber:client'
-         to='room@muc.example.com'
-         type='groupchat'>
-  <body>Typical body text</body>
-  <stanza-id xmlns='urn:xmpp:sid:0'
-             id='5f3dbc5e-e1d3-4077-a492-693f3769c7ad'
-             by='room@muc.example.com'/>
-  <origin-id xmlns='urn:xmpp:sid:0' id='de305d54-75b4-431b-adb2-eb6b9e546013'/>
-</message>]]></example>
-  </section2>
 </section1>
 <section1 topic='Business Rules' anchor='rules'>
   <ol>
@@ -149,7 +124,7 @@
     <li>Entities, which are routing stanzas, SHOULD NOT strip any elements qualified by the 'urn:xmpp:sid:0' namespace from message stanzas unless the preceding rule applied to those elements.</li>
     <li>Stanzas MUST possess, in the direct child level of the stanza, at most one &stanza-id; extension element with the same XMPP address as value of the 'by' attribute.</li>
     <li>Every &stanza-id; extension element MUST have the 'id' attribute and the 'by' attribute set.</li>
-    <li>Every &stanza-id; and &origin-id; extension element MUST always possess an 'id' attribute and MUST NOT have any child elements or text content.</li>
+    <li>Every &stanza-id; extension element MUST NOT have any child elements or text content.</li>
     <li>The value of the 'by' attribute MUST be the XMPP address of the entity assigning the unique and stable stanza ID. For one-on-one messages the assigning entity is the account. In groupchats the assigning entity is the room. Note that XMPP addresses are normalized as defined in &rfc6122;.</li>
   </ol>
 </section1>
@@ -219,12 +194,6 @@
     <xs:complexType>
       <xs:attribute name='id' type='xs:string' use='required'/>
       <xs:attribute name='by' type='xs:string' use='required'/>
-    </xs:complexType>
-  </xs:element>
-
-  <xs:element name='origin-id'>
-    <xs:complexType>
-      <xs:attribute name='id' type='xs:string' use='required'/>
     </xs:complexType>
   </xs:element>
 

--- a/xep-0359.xml
+++ b/xep-0359.xml
@@ -24,6 +24,17 @@
   <shortname>stanza-id</shortname>
   &flow;
   <revision>
+    <version>0.6.0</version>
+    <date>2018-08-02</date>
+    <initials>egp</initials>
+    <remark>
+      <ul>
+        <li>Remove &origin-id;, which is unneeded since <cite>XEP-0045</cite> version 1.31.</li>
+        <li>Replace tabs with spaces.</li>
+      </ul>
+    </remark>
+  </revision>
+  <revision>
     <version>0.5.0</version>
     <date>2017-08-23</date>
     <initials>dg</initials>


### PR DESCRIPTION
This was a hack for MUC before version 1.31, which is now unnecessary.  A new implementation note describe what it was used for, and why it has been removed.

Rendered version: https://linkmauve.fr/extensions/xep-0359.html