### PR TITLE
XEP-0184: Make the schema require @id in <received/>

### DIFF
--- a/xep-0184.xml
+++ b/xep-0184.xml
@@ -28,6 +28,12 @@
   &stpeter;
   &hildjj;
   <revision>
+    <version>1.4.0</version>
+    <date>2018-08-02</date>
+    <initials>egp</initials>
+    <remark><p>Make the 'id' attribute required, this extension makes no sense otherwise.</p></remark>
+  </revision>
+  <revision>
     <version>1.3.0</version>
     <date>2019-05-15</date>
     <initials>gl</initials>
@@ -209,7 +215,7 @@
   <received xmlns='urn:xmpp:receipts' id='richard2-4.1.247'/>
 </message>
 ]]></example>
-  <p>When the recipient sends an ack message, it SHOULD ensure that the message stanza contains only one child element, namely the &lt;received/&gt; element qualified by the 'urn:xmpp:receipts' namespace. In addition, it SHOULD include an 'id' attribute that echoes the 'id' attribute of the content message. Naturally, intermediate entities might add other extension elements to the message when routing or delivering the receipt message, e.g., a &lt;delay/&gt; element as specified in &xep0203;.</p>
+  <p>When the recipient sends an ack message, it SHOULD ensure that the message stanza contains only one child element, namely the &lt;received/&gt; element qualified by the 'urn:xmpp:receipts' namespace, which MUST include an 'id' attribute that echoes the 'id' attribute of the content message. Naturally, intermediate entities might add other extension elements to the message when routing or delivering the receipt message, e.g., a &lt;delay/&gt; element as specified in &xep0203;.</p>
   <p class='box'>Note: It is a good practice to use the same message type as the message that requested the receipt, however a client SHOULD also accept receipts with a different message type. When sending a Receipt for a type='groupchat' message (which is NOT RECOMMENDED), the Receipt must be sent to the bare JID of the room and not to the full JID of the sender.</p>
 </section1>
 
@@ -248,7 +254,7 @@
     <xs:complexType>
       <xs:simpleContent>
         <xs:extension base='empty'>
-          <xs:attribute name='id' type='xs:string' use='optional'/>
+          <xs:attribute name='id' type='xs:string' use='required'/>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>


### PR DESCRIPTION
Even though the text only says “[an entity] SHOULD include an 'id' attribute”, there is really nothing to do without one.