### PR TITLE
XEP-0367: Update to specify the correct ID to use within MUCs

### DIFF
--- a/xep-0367.xml
+++ b/xep-0367.xml
@@ -168,9 +168,9 @@
 <section1 topic='Security Considerations' anchor='security'>
   <p>
     Clients that implement message attachments MUST display the attachments
-    in such a way that they could be confused with the original message and
-    cause someone viewing the conversation to assume they were sent by the
-    sender of the message being attached to.
+    in such a way that they could not be confused with the original message
+    and cause someone viewing the conversation to assume they were sent by
+    the sender of the message being attached to.
   </p>
   <p>
     When matching a received attachment to the original message, clients must

--- a/xep-0367.xml
+++ b/xep-0367.xml
@@ -14,7 +14,7 @@
   </abstract>
   &LEGALNOTICE;
   <number>0367</number>
-  <status>Deferred</status>
+  <status>Experimental</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>
@@ -30,6 +30,13 @@
     <surname>Petchell</surname>
     <email>cpetchell@atlassian.com</email>
   </author>
+  &mwild;
+  <revision>
+    <version>0.3</version>
+    <date>2018-08-18</date>
+    <initials>mw</initials>
+    <remark>Update to use unique stanza ids.</remark>
+  </revision>
   <revision>
     <version>0.2</version>
     <date>2017-09-11</date>
@@ -66,7 +73,7 @@
 <section1 topic='Discovering support' anchor='disco'>
   <p>
     If a client implements message attaching, it MUST specify the
-    'urn:xmpp:message-attaching:0' feature in its service discovery information
+    'urn:xmpp:message-attaching:1' feature in its service discovery information
     features as specified in &xep0030; and the Entity Capabilities profile
     specified in &xep0115;.
   </p>
@@ -83,7 +90,7 @@
     id='miuARo9V'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
 …
-    <feature var='urn:xmpp:message-attaching:0'/>
+    <feature var='urn:xmpp:message-attaching:1'/>
 …
   </query>
 </iq>]]></example>
@@ -91,16 +98,17 @@
 <section1 topic='Usage' anchor='usage'>
   <p>
     Messages that are attached to other messages MUST contain an
-    &lt;attach-to/&gt; element qualified by the 'urn:xmpp:message-attaching:0'
+    &lt;attach-to/&gt; element qualified by the 'urn:xmpp:message-attaching:1'
     namespace and with an 'id' attribute set to the ID of the message that we
-    want to attach to. Messages MAY be attached to any other message, including
-    those sent by other clients, but clients MAY choose to ignore the attach-to
-    directive and display the message normally.
+    want to attach to (important note: the correct ID to use depends on the context,
+    see the business rules below). Messages MAY be attached to any
+    other message, including those sent by other clients, but clients MAY choose
+    to ignore the attach-to directive and display the message normally.
   </p>
   <example caption='User attaches a message'><![CDATA[
 <message to='antonio@milan.lit/ship' from='prospero@milan.lit/island id='RgEGnjqy'>
   <body>storm.png</body>
-  <attach-to id='oldmessage1' xmlns='urn:xmpp:message-attaching:0'/>
+  <attach-to id='SD24VCzSYQ' xmlns='urn:xmpp:message-attaching:1'/>
 </message>]]></example>
   <p>
     Note that indicating that a message should be "attached" to an earlier
@@ -109,42 +117,67 @@
   </p>
 </section1>
 <section1 topic='Business Rules' anchor='rules'>
-  <p>
-    A receiving client MAY choose to show the attached message next to or below
-    the indicated message in whatever display is used for messages or can
-    choose to display the attachment in another way (including as a normal
-    message, completely ignoring the attach-to element).
-  </p>
-  <p>
-    A receiving client SHOULD indicate that the message is an attachment, and
-    not a part of the original message to prevent confusion.
-  </p>
-  <p>
-    &lt;attach-to/&gt; elements MUST NOT be put on any stanza type other than
-    messages.
-  </p>
-  <p>
-    A server may choose to strip some &lt;attach-to/&gt; messages based on
-    local policy (eg. a server might have a policy that only it can create
-    message attachments).
-  </p>
-  <p>Clients MUST send ids on messages if they support attachments.</p>
-  <p>
-    Messages MUST NOT contain more than one &lt;attach-to/&gt; element.
-  </p>
-  <p>
-    Clients and servers MUST NOT include an &lt;attach-to/&gt; element on
-    messages with a non-messaging payload unless they are including it on an
-    error which may be attached to the message that caused the error to be
-    generated.
-  </p>
+  <section2 topic='Using the correct ID' anchor='business-id'>
+    <p>
+      For messages of type 'groupchat', the stanza's 'id' attribute MUST NOT be
+      used for attachments. Instead, in group chat situations, the ID assigned to
+      the stanza by the group chat itself must be used. This is discovered in a
+      &lt;stanza-id&gt; element with a 'by' attribute that matches the bare JID of
+      the group chat, as defined in &xep0359;.
+    </p>
+    <p>
+      For other message types the attacher should use the 'id' from a XEP-0359
+      &lt;origin-id&gt; if present, or the value of the 'id' attribute on the
+      &lt;message&gt; otherwise.
+    </p>
+  </section2>
+  <section2 topic='Display of attached messages' anchor='business-display'>
+    <p>
+      A receiving client MAY choose to show the attached message next to or below
+      the indicated message in whatever display is used for messages or can
+      choose to display the attachment in another way (including as a normal
+      message, completely ignoring the attach-to element).
+    </p>
+    <p>
+      A receiving client SHOULD indicate that the message is an attachment, and
+      not a part of the original message to prevent confusion.
+    </p>
+  </section2>
+  <section2 topic='General' anchor='business-general'>
+    <p>
+      &lt;attach-to/&gt; elements MUST NOT be put on any stanza type other than
+      messages.
+    </p>
+    <p>
+      A server may choose to strip some &lt;attach-to/&gt; messages based on
+      local policy (eg. a server might have a policy that only it can create
+      message attachments).
+    </p>
+    <p>Clients MUST send ids on messages if they support attachments.</p>
+    <p>
+      Messages MUST NOT contain more than one &lt;attach-to/&gt; element.
+    </p>
+    <p>
+      Clients and servers MUST NOT include an &lt;attach-to/&gt; element on
+      messages with a non-messaging payload unless they are including it on an
+      error which may be attached to the message that caused the error to be
+      generated.
+    </p>
+   </section2>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
   <p>
-    Clients that implement message attachments MUST be careful not to display
-    the attachments in such a way that they could be confused with the original
-    message and cause someone viewing the conversation to assume they were sent
-    by the sender of the message being attached to.
+    Clients that implement message attachments MUST display the attachments
+    in such a way that they could be confused with the original message and
+    cause someone viewing the conversation to assume they were sent by the
+    sender of the message being attached to.
+  </p>
+  <p>
+    When matching a received attachment to the original message, clients must
+    ensure they match using the correct ID, as described in the business rules
+    section, e.g. within a group chat only the XEP-0359 stanza-id should be
+    matched against. If this is not available, the message SHOULD be displayed
+    as a normal unattached message.
   </p>
 </section1>
 <section1 topic='IANA Considerations' anchor='iana'>
@@ -153,7 +186,7 @@
 <section1 topic='XMPP Registrar Considerations' anchor='registrar'>
 	<p>This specification defines the following XML namespaces:</p>
 	<ul>
-		<li>urn:xmpp:message-attaching:0</li>
+		<li>urn:xmpp:message-attaching:1</li>
 	</ul>
 	<p>
     The &REGISTRAR; shall include the foregoing namespaces in its disco
@@ -161,7 +194,7 @@
 	</p>
 	<code caption='Registry Submission'><![CDATA[
 <var>
-	<name>urn:xmpp:message-attaching:0</name>
+	<name>urn:xmpp:message-attaching:1</name>
 	<desc>Indicates support for attaching one message to another.</desc>
 	<doc>XEP-xxxx</doc>
 </var>
@@ -173,8 +206,8 @@
 
 <xs:schema
     xmlns:xs='http://www.w3.org/2001/XMLSchema'
-    targetNamespace='urn:xmpp:message-attaching:0'
-    xmlns='urn:xmpp:message-attaching:0'
+    targetNamespace='urn:xmpp:message-attaching:1'
+    xmlns='urn:xmpp:message-attaching:1'
     elementFormDefault='qualified'>
 
   <xs:element name='attach-to'>

--- a/xep-0367.xml
+++ b/xep-0367.xml
@@ -20,6 +20,7 @@
   <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
+    <spec>XEP-0359</spec>
   </dependencies>
   <supersedes/>
   <supersededby/>

--- a/xep-0367.xml
+++ b/xep-0367.xml
@@ -126,6 +126,10 @@
       the group chat, as defined in &xep0359;.
     </p>
     <p>
+      This implies that group chat messages without a &xep0359; stanza-id cannot
+      be attached-to.
+    </p>
+    <p>
       For other message types the attacher should use the 'id' from a XEP-0359
       &lt;origin-id&gt; if present, or the value of the 'id' attribute on the
       &lt;message&gt; otherwise.


### PR DESCRIPTION
The current version of the XEP currently only uses the 'id' attribute, which is a namespace shared by all clients in a MUC, leading to collisions and race conditions.

This update switches it to use the stanza-id assigned to the message by the MUC.