### PR TITLE
XEP-0398: Fix usage of <strong/> vs. <cite/> and German vs. English double quotes

### DIFF
--- a/xep-0398.xml
+++ b/xep-0398.xml
@@ -29,6 +29,14 @@
     <jid>daniel@gultsch.de</jid>
   </author>
   <revision>
+    <version>0.2.1</version>
+    <date>2018-08-27</date>
+    <initials>egp</initials>
+    <remark><ul>
+      <li>Fix typo.</li>
+    </ul></remark>
+  </revision>
+  <revision>
     <version>0.2.0</version>
     <date>2018-01-25</date>
     <initials>XEP Editor (jwi)</initials>

--- a/xep-0398.xml
+++ b/xep-0398.xml
@@ -46,7 +46,7 @@
   <p>Server implementations can aid to resolve this conflict by automatically putting avatars uploaded with <cite>XEP-0084</cite> into <cite>XEP-0153</cite> storage and vice versa. This allows clients to use the more efficient <cite>XEP-0084</cite> for uploading avatars and <cite>XEP-0153</cite> to retrieve avatars in Multi-User Chats.</p>
 </section1>
 <section1 topic='Discovery' anchor='disco'>
-  <p>The conversion is transparent to the uploading entity. However an entity might want to discover if a service will be performing the conversion from <cite>XEP-0084</cite> to <cite>XEP-0153</cite> since using vCard-Based Avatars will make the uploaded avatar publicly available. (See the »Security Considerations« section of this XEP.)</p>
+  <p>The conversion is transparent to the uploading entity. However an entity might want to discover if a service will be performing the conversion from <cite>XEP-0084</cite> to <cite>XEP-0153</cite> since using vCard-Based Avatars will make the uploaded avatar publicly available. (See the “Security Considerations” section of this XEP.)</p>
   <p>The service MUST include a &xep0030; feature of "urn:xmpp:pep-vcard-conversion:0" on the account.</p>
   <example caption='Client sends service discovery request to own account'><![CDATA[
 <iq from='romeo@montague.tld/garden'
@@ -76,7 +76,7 @@
   </section2>
 </section1>
 <section1 topic='Presence Broadcast' anchor='presence'>
-  <p>The »Business Rules« section of <cite>XEP-0153</cite> tells entities to include a hash of the vCard avatar in their presence. However this requires clients to retrieve the avatar on every connect to calculate the hash. To avoid this, services MUST include the hash on behalf of their users in every available presence that does not contain an empty photo element wrapped in an x element qualified by the 'vcard-temp:x:update' namespace. Empty x elements qualified by the 'vcard-temp:x:update' namespace (those without a photo element as child) MUST be overwritten. Presences where the content of the photo element is not empty and not equal to the hash calculated by the service MAY be overwritten.</p>
+  <p>The “Business Rules” section of <cite>XEP-0153</cite> tells entities to include a hash of the vCard avatar in their presence. However this requires clients to retrieve the avatar on every connect to calculate the hash. To avoid this, services MUST include the hash on behalf of their users in every available presence that does not contain an empty photo element wrapped in an x element qualified by the 'vcard-temp:x:update' namespace. Empty x elements qualified by the 'vcard-temp:x:update' namespace (those without a photo element as child) MUST be overwritten. Presences where the content of the photo element is not empty and not equal to the hash calculated by the service MAY be overwritten.</p>
   <example caption='Client sends presence to server'><![CDATA[
 <presence/>]]></example>
   <example caption='Server forwards presence to other entities that have presence subscription'><![CDATA[

--- a/xep-0398.xml
+++ b/xep-0398.xml
@@ -42,11 +42,11 @@
   </revision>
 </header>
 <section1 topic='Introduction' anchor='intro'>
-  <p>&xep0084; and &xep0153; are usually considered to stand in competition with each other. <strong>XEP-0084</strong> even talks about superseeding <strong>XEP-0153</strong> in the future. While <strong>XEP-0084</strong> provides a more efficient interface to upload avatars by seperating meta data and data (thus saving the client from having to download its own avatar on every connect) it has the significant downside of not working with &xep0045;.</p>
-  <p>Server implementations can aid to resolve this conflict by automatically putting avatars uploaded with <strong>XEP-0084</strong> into <strong>XEP-0153</strong> storage and vice versa. This allows clients to use the more efficient <strong>XEP-0084</strong> for uploading avatars and <strong>XEP-0153</strong> to retrieve avatars in Multi-User Chats.</p>
+  <p>&xep0084; and &xep0153; are usually considered to stand in competition with each other. <cite>XEP-0084</cite> even talks about superseeding <cite>XEP-0153</cite> in the future. While <cite>XEP-0084</cite> provides a more efficient interface to upload avatars by seperating meta data and data (thus saving the client from having to download its own avatar on every connect) it has the significant downside of not working with &xep0045;.</p>
+  <p>Server implementations can aid to resolve this conflict by automatically putting avatars uploaded with <cite>XEP-0084</cite> into <cite>XEP-0153</cite> storage and vice versa. This allows clients to use the more efficient <cite>XEP-0084</cite> for uploading avatars and <cite>XEP-0153</cite> to retrieve avatars in Multi-User Chats.</p>
 </section1>
 <section1 topic='Discovery' anchor='disco'>
-  <p>The conversion is transparent to the uploading entity. However an entity might want to discover if a service will be performing the conversion from <strong>XEP-0084</strong> to <strong>XEP-0153</strong> since using vCard-Based Avatars will make the uploaded avatar publicly available. (See the »Security Considerations« section of this XEP.)</p>
+  <p>The conversion is transparent to the uploading entity. However an entity might want to discover if a service will be performing the conversion from <cite>XEP-0084</cite> to <cite>XEP-0153</cite> since using vCard-Based Avatars will make the uploaded avatar publicly available. (See the »Security Considerations« section of this XEP.)</p>
   <p>The service MUST include a &xep0030; feature of "urn:xmpp:pep-vcard-conversion:0" on the account.</p>
   <example caption='Client sends service discovery request to own account'><![CDATA[
 <iq from='romeo@montague.tld/garden'
@@ -66,17 +66,17 @@
 </iq>]]></example>  
   </section1>
 <section1 topic='Conversion' anchor='conversion'>
-  <p>Modern clients are expected to use PEP (<strong>XEP-0084</strong>) as interface to upload their avatar and use vCard (<strong>XEP-0153</strong>) only as a read only fallback. Thus a service MUST support conversion from PEP to vCard. A service MAY support conversion from vCard to PEP in order to display avatars in clients that only support <strong>XEP-0084</strong>.</p>
+  <p>Modern clients are expected to use PEP (<cite>XEP-0084</cite>) as interface to upload their avatar and use vCard (<cite>XEP-0153</cite>) only as a read only fallback. Thus a service MUST support conversion from PEP to vCard. A service MAY support conversion from vCard to PEP in order to display avatars in clients that only support <cite>XEP-0084</cite>.</p>
   <section2 topic='From PEP to vCard' anchor='pep2vcard'>
     <p>Upon receiving a publication request to the 'urn:xmpp:avatar:metadata' node the service MUST look up the corresponding item published in the 'urn:xmpp:avatar:data' node and store the content of the data element as a photo in the vcard. Services MUST consider the fact that the metadata node might contain multiple info elements and MUST pick the info element that does not point to an exernal URL. Services SHOULD verify that the SHA-1 hash of the image matches the id.</p>
   </section2>
   <section2 topic='From vCard to PEP' anchor='vcard2pep'>
-    <p>Upon receiving a vCard publication request with a valid photo attached to it a service MUST first publish an item to the 'urn:xmpp:avatar:data' node on behalf of the requesting entity. The id of that item MUST be the SHA-1 hash of the image as described in <strong>XEP-0084</strong>. Afterwards the service MUST publish a new item to the 'urn:xmpp:avatar:metadata' node with one info element that represents the newly published image using the type value from the vCard as a type attribute in the info element.</p>
+    <p>Upon receiving a vCard publication request with a valid photo attached to it a service MUST first publish an item to the 'urn:xmpp:avatar:data' node on behalf of the requesting entity. The id of that item MUST be the SHA-1 hash of the image as described in <cite>XEP-0084</cite>. Afterwards the service MUST publish a new item to the 'urn:xmpp:avatar:metadata' node with one info element that represents the newly published image using the type value from the vCard as a type attribute in the info element.</p>
     <p>After publication the service SHOULD send out notification messages to all subscribers of the metadata node.</p>
   </section2>
 </section1>
 <section1 topic='Presence Broadcast' anchor='presence'>
-  <p>The »Business Rules« section of <strong>XEP-0153</strong> tells entities to include a hash of the vCard avatar in their presence. However this requires clients to retrieve the avatar on every connect to calculate the hash. To avoid this, services MUST include the hash on behalf of their users in every available presence that does not contain an empty photo element wrapped in an x element qualified by the 'vcard-temp:x:update' namespace. Empty x elements qualified by the 'vcard-temp:x:update' namespace (those without a photo element as child) MUST be overwritten. Presences where the content of the photo element is not empty and not equal to the hash calculated by the service MAY be overwritten.</p>
+  <p>The »Business Rules« section of <cite>XEP-0153</cite> tells entities to include a hash of the vCard avatar in their presence. However this requires clients to retrieve the avatar on every connect to calculate the hash. To avoid this, services MUST include the hash on behalf of their users in every available presence that does not contain an empty photo element wrapped in an x element qualified by the 'vcard-temp:x:update' namespace. Empty x elements qualified by the 'vcard-temp:x:update' namespace (those without a photo element as child) MUST be overwritten. Presences where the content of the photo element is not empty and not equal to the hash calculated by the service MAY be overwritten.</p>
   <example caption='Client sends presence to server'><![CDATA[
 <presence/>]]></example>
   <example caption='Server forwards presence to other entities that have presence subscription'><![CDATA[
@@ -100,11 +100,11 @@
   <p>The hash MUST also be injected into directed presences such as MUC joins</p>
 </section1>
 <section1 topic='Implementation Notes' anchor='impl'>
-  <p>Implementing clients SHOULD use the more efficient <strong>XEP-0084</strong> to access their own avatar storage and implement <strong>XEP-0153</strong> only to download avatars from other entities if they do not have mutual presence subscription with said entity. (For example participants in a Multi-User Chat.)</p>
+  <p>Implementing clients SHOULD use the more efficient <cite>XEP-0084</cite> to access their own avatar storage and implement <cite>XEP-0153</cite> only to download avatars from other entities if they do not have mutual presence subscription with said entity. (For example participants in a Multi-User Chat.)</p>
   <p>Services will inject the hash in directed presences automatically but will not resend the presence if the avatar gets updated. Thus clients MAY resend directed available presence to all Multi-User Chats after receiving a 'urn:xmpp:avatar:metadata' update notification. The service will then inject an updated version of the hash. To avoid sending unnecassary presence updates, resending should only occur if the service annouces the 'urn:xmpp:pep-vcard-conversion:0' feature.</p>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
-  <p><strong>XEP-0084</strong> has a default access model that only allows entities with mutual presence subscription to access the published avatar. <strong>XEP-0153</strong> has no access control at all. Clients that discover the disco feature 'urn:xmpp:pep-vcard-conversion:0' on the account MAY warn users that uploading an avatar will make that avatar accessible to anyone who knows the Jabber ID.</p>
+  <p><cite>XEP-0084</cite> has a default access model that only allows entities with mutual presence subscription to access the published avatar. <cite>XEP-0153</cite> has no access control at all. Clients that discover the disco feature 'urn:xmpp:pep-vcard-conversion:0' on the account MAY warn users that uploading an avatar will make that avatar accessible to anyone who knows the Jabber ID.</p>
   <p>In the future services MAY decide to perform PEP to vCard conversion only if the access model of the 'urn:xmpp:avatar:data' node has been set to 'open' as described in &xep0060;. However the ability to change the access model of nodes isn’t widely implemented yet and thus this paragraph exists only to act as a reminder that the privacy implications described in the previous paragraph can be avoided</p>
 </section1>
 <section1 topic='IANA Considerations' anchor='iana'>

--- a/xep-0398.xml
+++ b/xep-0398.xml
@@ -66,7 +66,7 @@
 </iq>]]></example>  
   </section1>
 <section1 topic='Conversion' anchor='conversion'>
-  <p>Modern clients are expected to use PEP (<cite>XEP-0084</cite>) as interface to upload their avatar and use vCard (<cite>XEP-0153</cite>) only as a read only fallback. Thus a service MUST support conversion from PEP to vCard. A service MAY support conversion from vCard to PEP in order to display avatars in clients that only support <cite>XEP-0084</cite>.</p>
+  <p>Modern clients are expected to use PEP (<cite>XEP-0084</cite>) as the interface to upload their avatar and use vCard (<cite>XEP-0153</cite>) only as a read only fallback. Thus a service MUST support conversion from PEP to vCard. A service MAY support conversion from vCard to PEP in order to display avatars in clients that only support <cite>XEP-0084</cite>.</p>
   <section2 topic='From PEP to vCard' anchor='pep2vcard'>
     <p>Upon receiving a publication request to the 'urn:xmpp:avatar:metadata' node the service MUST look up the corresponding item published in the 'urn:xmpp:avatar:data' node and store the content of the data element as a photo in the vcard. Services MUST consider the fact that the metadata node might contain multiple info elements and MUST pick the info element that does not point to an exernal URL. Services SHOULD verify that the SHA-1 hash of the image matches the id.</p>
   </section2>


### PR DESCRIPTION
This parses nicer.