### PR TITLE
XEP-0335: Fix XEP number in schema description

### DIFF
--- a/xep-0335.xml
+++ b/xep-0335.xml
@@ -113,7 +113,7 @@
   <xs:annotation>
     <xs:documentation>
       The protocol documented by this schema is defined in
-      XEP-xxxx: http://www.xmpp.org/extensions/xep-xxxx.html
+      XEP-0335: http://www.xmpp.org/extensions/xep-0335.html
     </xs:documentation>
   </xs:annotation>
 


### PR DESCRIPTION
Replace `xxxx` with the XEP number.

Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>