### PR TITLE
XEP-0166: Mention security-info in section 5.1 too

### DIFF
--- a/xep-0166.xml
+++ b/xep-0166.xml
@@ -37,6 +37,12 @@
   &seanegan;
   &hildjj;
   <revision>
+    <version>1.1.2</version>
+    <date>2018-09-19</date>
+    <initials>egp</initials>
+    <remark><p>Add missing security-info in section 5.1, forgotten in version 0.35.</p></remark>
+  </revision>
+  <revision>
     <version>1.1.1</version>
     <date>2016-05-17</date>
     <initials>ssw</initials>
@@ -716,6 +722,7 @@ PENDING  o-----------------------+   |
       <di><dt>content-reject</dt><dd>Reject a content-add action received from another party.</dd></di>
       <di><dt>content-remove</dt><dd>Remove one or more content definitions from the session.</dd></di>
       <di><dt>description-info</dt><dd>Exchange information about parameters for an application type.</dd></di>
+      <di><dt>security-info</dt><dd>Exchange information about security preconditions.</dd></di>
       <di><dt>session-accept</dt><dd>Definitively accept a session negotiation.</dd></di>
       <di><dt>session-info</dt><dd>Send session-level information, such as a ping or a ringing message.</dd></di>
       <di><dt>session-initiate</dt><dd>Request negotiation of a new Jingle session.</dd></di>


### PR DESCRIPTION
This action has been added in version 0.35, but it was missing from this place.