### PR TITLE
XEP-0045: Add missing disco#info feature to example 4, 9, 78 and 218

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -1111,6 +1111,7 @@
         category='conference'
         name='Shakespearean Chat Service'
         type='text'/>
+    <feature var='http://jabber.org/protocol/disco#info'/>
     <feature var='http://jabber.org/protocol/muc'/>
   </query>
 </iq>
@@ -1193,6 +1194,7 @@
         category='conference'
         name='A Dark Cave'
         type='text'/>
+    <feature var='http://jabber.org/protocol/disco#info'/>
     <feature var='http://jabber.org/protocol/muc'/>
     <feature var='http://jabber.org/protocol/muc#stable_id'/>
     <feature var='muc_passwordprotected'/>
@@ -1216,6 +1218,7 @@
         category='conference'
         name='A Dark Cave'
         type='text'/>
+    <feature var='http://jabber.org/protocol/disco#info'/>
     <feature var='http://jabber.org/protocol/muc'/>
     <feature var='muc_passwordprotected'/>
     <feature var='muc_hidden'/>
@@ -2632,6 +2635,7 @@
         category='conference'
         name='thirdwitch'
         type='text'/>
+    <feature var='http://jabber.org/protocol/disco#info'/>
   </query>
 </iq>
 ]]></example>
@@ -5716,6 +5720,7 @@ xmpp:coven@chat.shakespeare.lit?invite;jid=hecate@shakespeare.lit;password=cauld
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'
          node='http://jabber.org/protocol/muc#traffic'>
+    <feature var='http://jabber.org/protocol/disco#info'/>
     <feature var='http://jabber.org/protocol/xhtml-im'/>
     <feature var='http://jabber.org/protocol/rosterx'/>
   </query>


### PR DESCRIPTION
As XEP-0030 § 3.1 states that "…every entity MUST support at least the
'http://jabber.org/protocol/disco#info' feature" it needs to be
present in every disco#info result response.