### PR TITLE
MIX CORE (XEP-0369) update

### DIFF
--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -1104,11 +1104,11 @@
       <example caption="Participant Node Subscriber is Notified of Participant Removal"><![CDATA[
 <message from='coven@mix.shakespeare.example'
                 to='hecate@shakespeare.example' id='f5pp2toz'>
-   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-    <retract node='urn:xmpp:mix:nodes:participants'>
-      <item id='123456'/>
-    </retract>
-  </pubsub>                
+   <event xmlns='http://jabber.org/protocol/pubsub#event'>
+    <items node='urn:xmpp:mix:nodes:participants'>
+      <retract id='123456'/>
+    </items>
+  </event>            
 </message>
 ]]></example>
       

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -44,6 +44,7 @@
       ensure conference is type mix, and note registration requirements;
       fix retract id example; 
       clarify that channels always created with default parameters;
+      change to reflect that XEP-0004 does not support multiple languages;
       editorial;
     </p></remark>
   </revision>   
@@ -665,7 +666,7 @@
       <p>
         JID visibility is included in the Information Node as this is information that will be useful for participant clients and may also be important when choosing to join a channel.
       </p>
-      <p>The name and description values MUST contain a "text" element and MAY contain additional text elements. Where multiple text elements are provided, each MUST posses an xml:lang attribute that describes the natural language of the element.  The format of the Information node follows &xep0004;.  This allows configuration to be updated by MIX defined commands and that the results of update commands are the same as the PubSub node.
+      <p>The name and description values MUST contain a "text" element and MAY contain additional text elements.  The format of the Information node follows &xep0004;.  This allows configuration to be updated by MIX defined commands and that the results of update commands are the same as the PubSub node.
       The following example shows the format of a item in the information node for the example coven@mix.shakespeare.example channel.
       </p>
       <example caption="Information Node"><![CDATA[

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -45,6 +45,7 @@
       fix retract id example; 
       clarify that channels always created with default parameters;
       change to reflect that XEP-0004 does not support multiple languages;
+      correct retract to use pubsub syntax;
       editorial;
     </p></remark>
   </revision>   
@@ -1097,21 +1098,20 @@
 </iq>
 ]]></example>
       <p>When the user leaves the channel, the MIX service is responsible for unsubscribing the user from all nodes in the channel and for removing the user from the participants list.  Presence removal is specified in MIX-PRESENCE.
-        Deletion from the participants node functions as if the item (channel participant) had been deleted using the PubSub retract mechanism with notification set to true.    Notification of the participant deletion is sent to clients subscribed to the participants  PubSub node, with the node identified by the stable id, as shown in the example below.
-        </p>
-      <example caption="Reporting when User Leaves a Channel"><![CDATA[
+        Deletion from the participants node functions as if the item (channel participant) had been deleted using the PubSub retract mechanism with notification set to true.    Notification of the participant deletion is sent to clients subscribed to the participants  PubSub node using PubSub protocol, with the node identified by the stable id, as shown in the example below.
+      </p>
+
+      <example caption="Participant Node Subscriber is Notified of Participant Removal"><![CDATA[
 <message from='coven@mix.shakespeare.example'
                 to='hecate@shakespeare.example' id='f5pp2toz'>
-  <event xmlns='http://jabber.org/protocol/pubsub#event'>
-    <items xmlns='urn:xmpp:mix:core:0' node='urn:xmpp:mix:nodes:participants'>
-      <item>
-        <retract id='123456'/>
-      </item>
-    </items>
-  </event>
+   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+    <retract node='urn:xmpp:mix:nodes:participants'>
+      <item id='123456'/>
+    </retract>
+  </pubsub>                
 </message>
 ]]></example>
-
+      
 
     </section3>
 

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -42,6 +42,8 @@
     <remark><p>
       remove node='mix' for channel discovery;
       ensure conference is type mix, and note registration requirements;
+      fix retract id example; 
+      editorial;
     </p></remark>
   </revision>   
   <revision>
@@ -607,7 +609,8 @@
     </section3>
 
     <section3 topic="Participants Node" anchor="participants-node">
-      <p>Each channel participant is represented as an item of the 'urn:xmpp:mix:nodes:participants' channel node.  Each item is named by the Stable Participant ID of the participant. For example '123456' might name the node item associated with participant 'hag66@shakespeare.example'.  Information is stored in a &lt;participant/&gt; element qualified by the 'urn:xmpp:mix:core:0' namespace.   The nick associated with the user is optional and is stored in a &lt;nick/&gt; child element of the &lt;participant/&gt; element.   The nick for each channel participant MUST be different to the nick of other participants.
+      
+      <p>Each channel participant is represented as an item of the 'urn:xmpp:mix:nodes:participants' channel node.  Each item is named by the Stable Participant ID of the participant. For example '123456' might name the node item associated with participant 'hag66@shakespeare.example'.  Information is stored in a &lt;participant/&gt; element qualified by the 'urn:xmpp:mix:core:0' namespace.   
       </p>
       <p>
        A Nick MAY be associated with a participant, which provides a user-oriented  description of the participant.  The nick associated with the user is stored in a &lt;nick/&gt; child element of the &lt;participant/&gt; element.   The nick for each channel participant MUST be different to the nick of other participants (where nicks have been assigned).
@@ -1092,7 +1095,7 @@
 </iq>
 ]]></example>
       <p>When the user leaves the channel, the MIX service is responsible for unsubscribing the user from all nodes in the channel and for removing the user from the participants list.  Presence removal is specified in MIX-PRESENCE.
-        Deletion from the participants node functions as if the item (channel participant) had been deleted using the PubSub retract mechanism with notification set to true.    Notification of the participant deletion is sent to clients subscribed to the participants  PubSub node, as shown in the example below.
+        Deletion from the participants node functions as if the item (channel participant) had been deleted using the PubSub retract mechanism with notification set to true.    Notification of the participant deletion is sent to clients subscribed to the participants  PubSub node, with the node identified by the stable id, as shown in the example below.
         </p>
       <example caption="Reporting when User Leaves a Channel"><![CDATA[
 <message from='coven@mix.shakespeare.example'
@@ -1100,7 +1103,7 @@
   <event xmlns='http://jabber.org/protocol/pubsub#event'>
     <items xmlns='urn:xmpp:mix:core:0' node='urn:xmpp:mix:nodes:participants'>
       <item>
-        <retract id='123456#coven@mix.shakespeare.example'/>
+        <retract id='123456'/>
       </item>
     </items>
   </event>
@@ -1423,7 +1426,7 @@
 
 <section1 topic='Acknowledgements' anchor='ack'>
   <p>Peter St Andre provided key early input to MIX and worked on the original specification with Kevin Smith. </p>
-  <p>Thanks to the following who have made contributions to the ongoing MIX specification development: W. Martin Borgert, Dave Cridland, Tarun Gupta, Philipp Hancke, Waqas Hussain, Timothée Jaussoin, Evgeny Khramtsov, Georg Lukas, Tobias Markmann, Ralph Meijer, Edwin Mons, Emmanuel Gil Peyrot, Manuel Rubio, Florian Schmaus, Lance Stout, Sam Whited, Jonas Wielicki, Matthew Wild and one anonymous reviewer.</p>
+  <p>Thanks to the following who have made contributions to the ongoing MIX specification development: W. Martin Borgert, Dave Cridland, Daniel Gultsch, Tarun Gupta, Philipp Hancke, Waqas Hussain, Timothée Jaussoin, Evgeny Khramtsov, Georg Lukas, Tobias Markmann, Ralph Meijer, Edwin Mons, Emmanuel Gil Peyrot, Manuel Rubio, Florian Schmaus, Lance Stout, Sam Whited, Jonas Wielicki, Matthew Wild and one anonymous reviewer.</p>
 </section1>
 
 </xep>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -36,6 +36,14 @@
   &ksmithisode;
   &skille;
   <revision>
+    <version>0.14.0</version>
+    <date>2018-12-10</date>
+    <initials>sek</initials>
+    <remark><p>
+      remove node='mix' for channel discovery;
+    </p></remark>
+  </revision>   
+  <revision>
     <version>0.13.0</version>
     <date>2018-06-06</date>
     <initials>sek</initials>
@@ -785,16 +793,17 @@
     id='ik3vs715'
     to='coven@mix.shakespeare.example'
     type='get'>
-  <query xmlns='http://jabber.org/protocol/disco#info' node='mix'/>
+  <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>
 ]]></example>
-    <p>If the querying user is allowed to subscribe, the channel MUST return its identity and the features it supports.  Note that a MIX channel MUST support MAM and so the response will always include both MIX and MAM support.  All disco queries on a MIX channel and results returned MUST include the attribute node='mix'.   The reason for this is to facilitate MIX channels and &xep0045; MUC rooms sharing the same JID.   This extra parameter will enable a server to return appropriate information.</p>
+    <p>If the querying user is allowed to subscribe, the channel MUST return its identity and the features it supports.  Note that a MIX channel MUST support MAM and so the response will always include both MIX and MAM support. </p>
+    <p>Note that a node MAY be both a MIX channel and a MUC room.   In this case, the node will return both MIX and MUC information.   MIX and MUC clients MUST be able to handle this.</p>
     <example caption='Channel Returns Disco Info Result'><![CDATA[
 <iq from='coven@mix.shakespeare.example'
     id='ik3vs715'
     to='hag66@shakespeare.example/UUID-c8y/1573'
     type='result'>
-  <query xmlns='http://jabber.org/protocol/disco#info' node='mix'>
+  <query xmlns='http://jabber.org/protocol/disco#info'>
     <identity
         category='conference'
         name='A Dark Cave'
@@ -806,7 +815,10 @@
 ]]></example>
   </section2>
   <section2 topic='Discovering Nodes at a Channel' anchor='disco-channel-nodes'>
-    <p>Use disco#items to find the nodes associated with a channel.   Discovering nodes in MIX MUST use the node='mix' attribute.  The MIX service MUST only return nodes that exist and that the user making the query has rights to subscribe to. </p>
+    <p>Use disco#items to find the nodes associated with a channel.    The MIX service MUST only return nodes that exist and that the user making the query has rights to subscribe to. </p>
+    <p>
+      Discovering nodes in MIX MUST use a node='mix' attribute in this query.   This is to facilitate server implementations that support a single node being both a MIX channel and a MUC room.  MUC rooms use this query to return a list of occupants.  The  node='mix' attribute allows a server to support both MIX and MUC queries without requiring any change to MUC clients.  Where a node only supports a MIX channel, the server MUST reject queries without a node='mix' attribute.
+    </p>
     <example caption='Entity Queries for Nodes at a Channel'><![CDATA[
 <iq from='hag66@shakespeare.example/UUID-c8y/1573'
     id='kl2fax27'

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -1017,7 +1017,7 @@
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
   <join xmlns='urn:xmpp:mix:core:0'
-        jid='123456#coven@mix.shakespeare.example'>
+        id='123456'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:participants'/>
     <subscribe node='urn:xmpp:mix:nodes:info'/>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -43,6 +43,7 @@
       remove node='mix' for channel discovery;
       ensure conference is type mix, and note registration requirements;
       fix retract id example; 
+      clarify that channels always created with default parameters;
       editorial;
     </p></remark>
   </revision>   
@@ -1290,7 +1291,7 @@
     </section3>
     <section3 topic='Creating a Channel' anchor='usecase-admin-create'>
       <p>
-        A client creates a channel by sending a simple request to the MIX service.   A channel MAY be created with default parameters, as shown in the following example.   The result MUST include the name of the channel which MUST match the channel name in the request (if present).  The create is encoded as a &lt;create/&gt; child element of &lt;iq/&gt; element.   The &lt;create/&gt; is qualified by the 'urn:xmpp:mix:core:0' namespace.   The &lt;create/&gt; element MUST have a 'channel' attribute to specify the channel name.  This attribute specifies the value that will be used in the LHS of the JID for the MIX channel.
+        A client creates a channel by sending a simple request to the MIX service.   A channel is always created with default parameters, as shown in the following example.   The result MUST include the name of the channel which MUST match the channel name in the request (if present).  The create is encoded as a &lt;create/&gt; child element of &lt;iq/&gt; element.   The &lt;create/&gt; is qualified by the 'urn:xmpp:mix:core:0' namespace.   The &lt;create/&gt; element MUST have a 'channel' attribute to specify the channel name.  This attribute specifies the value that will be used in the LHS of the JID for the MIX channel.
       </p>
         <example caption="Creating a Channel with Default Parameters" ><![CDATA[
 <iq from='hag66@shakespeare.example/UUID-a1j/7533'
@@ -1309,7 +1310,7 @@
 ]]></example>
 
       <p>
-        When a channel is created with default parameters, the Owner in the configuration is set to the JID that creates the channel.  Where parameters are included, the Owner or Owners MUST be specified explicitly.  If an owner is specified that is not the JID creating the channel, the owner is recommended to verify that this user accepts the responsibility of being an owner of this channel.   Protocol to support this verification may be specified in a future XEP.  Note that the 'Last Change Made By' in configuration node MUST be set to the JID that creates the channel.    Modifying channel parameters is specified in MIX-ADMIN.
+        When a channel is created , the Owner in the configuration is set to the JID that creates the channel.   Modifying channel parameters is specified in MIX-ADMIN.  Consideration should be given to selection of default parameters.  It will typically be desirable to create channels with restrictive default settings that the owner MAY choose to relax.
       </p>
 
     </section3>

--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -41,6 +41,7 @@
     <initials>sek</initials>
     <remark><p>
       remove node='mix' for channel discovery;
+      ensure conference is type mix, and note registration requirements;
     </p></remark>
   </revision>   
   <revision>
@@ -737,7 +738,7 @@
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>
 ]]></example>
-    <p>The MIX service then MUST return its identity and the features it supports, which MUST include the 'urn:xmpp:mix:core:0' feature, and the identity MUST have a category of 'conference' and a type of 'text', as shown in the following example: </p>
+    <p>The MIX service then MUST return its identity and the features it supports, which MUST include the 'urn:xmpp:mix:core:0' feature, and the identity MUST have a category of 'conference' and a type of 'mix', as shown in the following example: </p>
     <example caption="Service responds with Disco Info result" ><![CDATA[
 <iq from='mix.shakespeare.example'
     id='lx09df27'
@@ -747,7 +748,7 @@
     <identity
         category='conference'
         name='Shakespearean Chat Service'
-        type='text'/>
+        type='mix'/>
     <feature var='urn:xmpp:mix:core:0'/>
     <feature var='urn:xmpp:mix:core:0#searchable'>
   </query>
@@ -1277,7 +1278,7 @@
     <identity
         category='conference'
         name='Shakespearean Chat Service'
-        type='text'/>
+        type='mix'/>
     <feature var='urn:xmpp:mix:core:0'/>
     <feature var='urn:xmpp:mix:core:0#create-channel'>
   </query>
@@ -1413,6 +1414,7 @@
 
 <section1 topic='XMPP Registrar Considerations' anchor='registrar'>
   <p>The urn:xmpp:mix namespace needs to be registered.</p>
+  <p>The conference type 'mix' needs to be registered.</p>
 </section1>
 
 <section1 topic='XML Schema' anchor='schema'>


### PR DESCRIPTION
    remove node='mix' for channel discovery;
      ensure conference is type mix, and note registration requirements;
      fix retract id example; 
      clarify that channels always created with default parameters;
      change to reflect that XEP-0004 does not support multiple languages;
      editorial;