### PR TITLE
Obsolete some deferred XEPs

### DIFF
--- a/xep-0008.xml
+++ b/xep-0008.xml
@@ -10,7 +10,7 @@
   <abstract>This specification provides historical documentation of an IQ-based protocol for exchanging user avatars.</abstract>
   &LEGALNOTICE;
   <number>0008</number>
-  <status>Deferred</status>
+  <status>Obsolete</status>
   <type>Historical</type>
   <sig>Standards</sig>
   <approver>Council</approver>
@@ -19,7 +19,10 @@
     <spec>XMPP IM</spec>
   </dependencies>
   <supersedes/>
-  <supersededby/>
+  <supersededby>
+    <spec>XEP-0084</spec>
+    <spec>XEP-0153</spec>
+  </supersededby>
   <shortname>None</shortname>
   &temas;
   &xvirge;
@@ -29,6 +32,15 @@
     <email>jens@mac.com</email>
   </author>
   &pgmillard;
+  <revision>
+    <version>0.3.1</version>
+    <date>2022-03-08</date>
+    <initials>egp</initials>
+    <remark><ul>
+      <li>Move from deferred to obsolete.</li>
+      <li>Add the two superseding specifications.</li>
+    </ul></remark>
+  </revision>
   <revision>
     <version>0.3</version>
     <date>2005-06-16</date>

--- a/xep-0038.xml
+++ b/xep-0038.xml
@@ -10,12 +10,15 @@
   <abstract>A protocol for specifying exchangeable styles of emoticons and genicons within Jabber IM clients.</abstract>
   &LEGALNOTICE;
   <number>0038</number>
-  <status>Deferred</status>
+  <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <dependencies/>
   <supersedes/>
-  <supersededby/>
+  <supersededby>
+    <spec>Unicode</spec>
+    <spec>XEP-0231</spec>
+  </supersededby>
   <shortname>None</shortname>
   <author>
     <firstname>Adam</firstname>
@@ -23,6 +26,12 @@
     <email>theo@theoretic.com</email>
     <jid>theo@theoretic.com</jid>
   </author>
+  <revision>
+    <version>0.5.1</version>
+    <date>2022-03-08</date>
+    <initials>egp</initials>
+    <remark><p>Obsolete due to the omnipresence of Unicode emoji, as well as Bits of Binary stickers.</p></remark>
+  </revision>
   <revision>
     <version>0.5</version>
     <date>2003-06-02</date>

--- a/xep-0051.xml
+++ b/xep-0051.xml
@@ -10,12 +10,14 @@
   <abstract>This specification defines an XMPP protocol extension that enables a server to redirect connections from one connection manager or server node to another.</abstract>
   &LEGALNOTICE;
   <number>0051</number>
-  <status>Deferred</status>
+  <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <dependencies/>
   <supersedes/>
-  <supersededby/>
+  <supersededby>
+    <spec>RFC6120</spec>
+  </supersededby>
   <shortname>N/A</shortname>
   <author>
     <firstname>Klaus</firstname>
@@ -35,6 +37,12 @@
     <email>florian@florianjensen.com</email>
     <jid>admin@im.flosoft.biz</jid>
   </author>
+  <revision>
+    <version>0.2.1</version>
+    <date>2022-03-08</date>
+    <initials>egp</initials>
+    <remark><p>Obsolete because this feature has been merged into XMPP core, see RFC6120 section 4.9.3.19, which describes the &lt;see-other-host/&gt; stream error.</p></remark>
+  </revision>
   <revision>
     <version>0.2</version>
     <date>2009-07-07</date>


### PR DESCRIPTION
As an attempt to clean up our deferred XEPs into the ones we may want to resurrect in the future, and the ones we know we will never want again, I’m obsoleting these three XEPs which all have a more modern equivalent.