### PR TITLE
XEP-0369: Remove MIX xmlns from pubsub <item/>

### DIFF
--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -36,6 +36,14 @@
   &ksmithisode;
   &skille;
   <revision>
+    <version>0.14.1</version>
+    <date>2019-01-05</date>
+    <initials>lnj</initials>
+    <remark><p>
+      Remove MIX xmlns from pubsub channel info &lt;item/&gt; example
+    </p></remark>
+  </revision>   
+  <revision>
     <version>0.14.0</version>
     <date>2018-12-10</date>
     <initials>sek</initials>
@@ -871,7 +879,7 @@
     type='result'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
     <items node='urn:xmpp:mix:nodes:info'>
-      <item id='2016-05-30T09:00:00' xmlns='urn:xmpp:mix:core:0'>
+      <item id='2016-05-30T09:00:00'>
         <x xmlns='jabber:x:data' type='result'>
           <field var='FORM_TYPE' type='hidden'>
             <value>urn:xmpp:mix:core:0</value>


### PR DESCRIPTION
It's defined differently here: https://xmpp.org/extensions/xep-0369.html#info-node