### PR TITLE
XEP-0412: version 0.2.0

### DIFF
--- a/xep-0412.xml
+++ b/xep-0412.xml
@@ -53,6 +53,12 @@
     <supersededby/>
     <shortname>CS2019</shortname>
     &jonaswielicki;
+    <revision>
+      <version>0.2.0</version>
+      <date>2019-01-13</date>
+      <initials>jsc</initials>
+      <remark><ul><li>Remove XEP-0184 from server support (doesn't make sense)</li><li>Do not require Avatars for Core clients</li><li>Add a note for RFC 7622 and do not require it</li><li>Do not require XEP-0368 in core servers</li></ul></remark>
+    </revision>
   <revision>
     <version>0.1.0</version>
     <date>2018-12-16</date>
@@ -102,13 +108,13 @@
           <td align='center'>&#10003;</td>
           <td align='center'>&#10003;</td>
           <td align='center'>&#10003;</td>
-          <td>&rfc6120;, &rfc7622;</td>
+          <td>&rfc6120; <note>&rfc7622; is not listed due to the unclear interoperability impact of using PRECIS and Stringprep in the same ecosystem.</note></td>
         </tr>
         <tr>
           <td><strong>TLS</strong></td>
+          <td align='center'>&#10005;</td>
+          <td align='center'>&#10005;</td>
           <td align='center'>&#10003;<note>Server support of XEP-0368 means having the ability to accept direct TLS connections.</note></td>
-          <td align='center'>&#10003;</td>
-          <td align='center'>&#10003;</td>
           <td align='center'>&#10003;</td>
           <td>&rfc7590;, &xep0368;</td>
         </tr>
@@ -195,7 +201,7 @@
         <tr>
           <td><strong>User Avatars</strong></td>
           <td align='center'>N/A</td>
-          <td align='center'>&#10003;&nocli;</td>
+          <td align='center'>&#10005;</td>
           <td align='center'>N/A</td>
           <td align='center'>&#10003;&nocli;</td>
           <td>&xep0084;</td>
@@ -203,7 +209,7 @@
         <tr>
           <td><strong>User Avatar Compatibility</strong></td>
           <td align='center'>&#10005;</td>
-          <td align='center'>&#10003;&nocli;</td>
+          <td align='center'>&#10005;</td>
           <td align='center'>&#10003;</td>
           <td align='center'>&#10003;&nocli;</td>
           <td>&xep0398;, &xep0153;</td>
@@ -284,7 +290,7 @@
           <td><strong>Message Acknowledgements</strong></td>
           <td align='center'>&#10005;</td>
           <td align='center'>&#10005;</td>
-          <td align='center'>&#10003;</td>
+          <td align='center'>&#10005;</td>
           <td align='center'>&#10003;</td>
           <td>&xep0184;</td>
         </tr>


### PR DESCRIPTION
- removed XEP-0184 from Advanced Server (doesn’t make sense)
- removed XEP-0084 and other avatar things from Core clients
- removed XEP-0368 from Core Server
- un-require RFC 7622 and add a note