### PR TITLE
ProtoXEP: Cryptographic Hash Function Recommendations for XMPP

### DIFF
--- a/inbox/hash-recommendations.xml
+++ b/inbox/hash-recommendations.xml
@@ -1,0 +1,152 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY % ents SYSTEM 'xep.ent'>
+%ents;
+]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+<header>
+  <title>Cryptographic Hash Function Recommendations for XMPP</title>
+  <abstract>This document provides recommendations for the use of cryptographic hash functions in XMPP protocol extensions.</abstract>
+  &LEGALNOTICE;
+  <number>xxxx</number>
+  <status>ProtoXEP</status>
+  <type>Informational</type>
+  <sig>Standards</sig>
+  <approver>Council</approver>
+  <dependencies>
+  </dependencies>
+  <supersedes/>
+  <supersededby/>
+  <shortname>hashrecs</shortname>
+  &jonaswielicki;
+  <revision>
+    <version>0.0.1</version>
+    <date>2019-01-13</date>
+    <initials>psa</initials>
+    <remark><p>Split from XEP-0300.</p></remark>
+  </revision>
+</header>
+
+<section1 topic='Introduction' anchor='intro'>
+  <p>Various XMPP extensions make use of cryptographic hash functions, but they do so in different ways (e.g., some define XML elements and some define XML attributes) and often mandate support for different algorithms.</p>
+  <p>This specification provides recommendations from the XMPP council as to which cryptographic hash functions should and should not be used by XMPP entities.</p>
+  <section2 topic='Relationship with Specifications' anchor='intro-other-specs'>
+    <p>This recommendation does not specify the hash algorithms themselves; it merely refers to existing algorithms.</p>
+    <p>&xep0300; (which historically has contained the recommendations in this specification) describes a common wire-format to be used to transport hash function values in XMPP.</p>
+  </section2>
+</section1>
+
+<section1 topic='Requirements' anchor='reqs'>
+  <p>This recommendation should meet the following goals:</p>
+  <ul>
+    <li>Provide clear guidance on which hash functions should be supported by an XMPP entity at any point in time.</li>
+    <li>Recommend both a set of well-supported functions as MUST and a set of future functions as SHOULD to allow the ecosystem to transit to newer functions.</li>
+  </ul>
+  <p>This specification is <em>not</em> meant to override recommendations or requirements laid out by other specifications. Other specifications can however defer their recommendations or requirements to this specification.</p>
+</section1>
+
+<section1 topic='Use Cases' anchor='usecases'>
+  <p>A specification which makes use of cryptographic hash functions (such as &xep0234; or &xep0390;) can refer to this specification instead of making recommendations on hash functions on their own.</p>
+  <p>If a protocol specification defers its decision on hash functions to this document, it should support transporting multiple hashes at the same time (preferably using &xep0300;).</p>
+  <p>By default, when an entity receives multiple hash function values for the same input, it SHOULD either (a) use all hash values or (b) the hash value of the algroithm with the most security confidence for verification purposes.</p>
+</section1>
+
+<section1 topic='Hash Functions' anchor='hashes'>
+  <section2 topic='MD2' anchor='hashes-md2'>
+    <p>The MD2 algorithm is not used in any XMPP protocols and has been deprecated by the IETF (see &rfc6149;).</p>
+  </section2>
+  <section2 topic='MD4' anchor='hashes-md4'>
+    <p>The MD4 algorithm is not used in any XMPP protocols and has been deprecated by the IETF (see &rfc6150;).</p>
+  </section2>
+  <section2 topic='MD5' anchor='hashes-md5'>
+    <p>The MD5 algorithm was commonly used in earlier generations of Internet technologies. As explained in &rfc6151;, the MD5 algorithm "is no longer acceptable where collision resistance is required" (such as in digital signatures) and "new protocol designs should not employ HMAC-MD5" either.</p>
+    <p>The currently known best attack against the pre-image resistance property of the MD5 algorithm is slightly better than the generic attack and was released 2009 <note>Yu Sasaki and Kazumaro Aoki, "Finding preimages in full MD5 faster than exhaustive search" &lt;<link url='https://doi.org/10.1007/978-3-642-01001-9_8'>https://doi.org/10.1007/978-3-642-01001-9_8</link>&gt;.</note>.</p>
+    <p>The primary use of MD5 in XMPP protocols is &xep0096;, which will be obsoleted by &xep0234;.</p>
+  </section2>
+  <section2 topic='SHA-0' anchor='hashes-sha0'>
+    <p>The SHA-0 algorithm was developed by the U.S. National Security Agency and first published in 1993. It was never widely deployed and is not used in any XMPP protocols.</p>
+  </section2>
+  <section2 topic='SHA-1' anchor='hashes-sha1'>
+    <p>The SHA-1 algorithm was developed by the U.S. National Security Agency and first published in 1995 to fix problems with SHA-0. The SHA-1 algorithm is currently the most widely-deployed hash function. As described in &rfc4270; in 2005, attacks have been found against the collision resistance property of SHA-1. &rfc6194; notes that as of 2011 no published results indicate improvement upon those attacks. In addition, RFC 6194 notes that "[t]here are no known pre-image or second pre-image attacks that are specific to the full round SHA-1 algorithm".  Furthermore, there is no indication that attacks on SHA-1 can be extended to HMAC-SHA-1.  Nevertheless, the U.S. National Institute of Standards and Technology (NIST) has recommended that SHA-1 not be used for generating digital signatures after December 31, 2010.</p>
+    <p>In fall 2015 the SHA-1 collision cost has been estimated between 75K$ to 120K$ <note>The SHAppening: freestart collisions for SHA-1 &lt;<link url='https://sites.google.com/site/itstheshappening/'>https://sites.google.com/site/itstheshappening/</link>&gt;.</note>.</p>
+    <p>The SHA-1 algorithm is used in a number of XMPP protocols. See <link url='#existing'>Analysis of Existing XMPP Extensions</link> for details.</p>
+  </section2>
+  <section2 topic='SHA-2' anchor='hashes-sha2'>
+    <p>The SHA-2 family of algorithms (SHA-224, SHA-256, SHA-384, and SHA-512) was developed by the U.S. National Security Agency and first published in 2001. Because SHA-2 is somewhat similar to SHA-1, it is thought that the security flaws with SHA-1 described above could be extended to SHA-2 (although no such attacks have yet been found on the full-round SHA-2 algorithms).</p>
+  </section2>
+  <section2 topic='SHA-3' anchor='hashes-sha3'>
+    <p>The SHA-3 family of algorithms (SHA3-224, SHA3-256, SHA3-384, and SHA3-512) is based on the Keccak algortihm developed by Guido Bertoni, Joan Daemen, Michaël Peeters, and Gilles Van Assche, and was pubished by NIST on August 5, 2015 in <span class='ref'><link url='http://dx.doi.org/10.6028/NIST.FIPS.202'>FIPS PUB 202: SHA-3 Standard: Permutation-Based Hash and Extendable-Output Functions</link></span> <note>FIPS PUB 202: SHA-3 Standard: Permutation-Based Hash and Extendable-Output Functions &lt;<link url='http://dx.doi.org/10.6028/NIST.FIPS.202'>http://dx.doi.org/10.6028/NIST.FIPS.202</link>&gt;.</note> after a public hash function competition.</p>
+  </section2>
+  <section2 topic='BLAKE2'  anchor='hashes-blake2'>
+    <p>The BLAKE2 family of algorithms was designed by Jean-Philippe Aumasson, Samuel Neves, Zooko Wilcox-O'Hearn, and Christian Winnerlein. It is described in &rfc7693; and is designed to be highly secure and run well on both software and hardware platforms.</p>
+  </section2>
+</section1>
+
+<section1 topic='Algorithm Recommendations' anchor='recommendations'>
+  <p>Support for version 1 of the 'urn:xmpp:hashes' namespace implies the following:</p>
+  <table caption='Algorithm Recommendations'>
+    <tr>
+      <th>Algorithm</th>
+      <th>Digest Size</th>
+      <th>Support</th>
+    </tr>
+    <tr>
+      <td>MD2</td>
+      <td>128 bits</td>
+      <td>MUST NOT</td>
+    </tr>
+    <tr>
+      <td>MD4</td>
+      <td>128 bits</td>
+      <td>MUST NOT</td>
+    </tr>
+    <tr>
+      <td>MD5</td>
+      <td>128 bit</td>
+      <td>MUST NOT</td>
+    </tr>
+    <tr>
+      <td>SHA-1</td>
+      <td>160 bits</td>
+      <td>SHOULD NOT</td>
+    </tr>
+    <tr>
+      <td>SHA-256</td>
+      <td>256 bits</td>
+      <td>MUST</td>
+    </tr>
+    <tr>
+      <td>SHA-512</td>
+      <td>512 bits</td>
+      <td>SHOULD</td>
+    </tr>
+    <tr>
+      <td>SHA3-256</td>
+      <td>256 bits</td>
+      <td>MUST</td>
+    </tr>
+    <tr>
+      <td>SHA3-512</td>
+      <td>512 bits</td>
+      <td>SHOULD</td>
+    </tr>
+    <tr>
+      <td>BLAKE2b256</td>
+      <td>256 bits</td>
+      <td>MUST</td>
+    </tr>
+    <tr>
+      <td>BLAKE2b512</td>
+      <td>512 bits</td>
+      <td>SHOULD</td>
+    </tr>
+  </table>
+  <p>These recommendations ought to be reviewed yearly by the &COUNCIL;.</p>
+</section1>
+
+<section1 topic='Acknowledgements' anchor='ack'>
+  <p>Thanks to the authors and involved people in &xep0300;; This specification is a mostly verbatim excerpt of a &xep0300; version 0.5.3.</p>
+</section1>
+
+</xep>


### PR DESCRIPTION
Mostly copied from XEP-0300, which this ProtoXEP is supposed to
partially replace in the future.