### PR TITLE
XEP-0308: Allow message correction in MUC.

### DIFF
--- a/xep-0308.xml
+++ b/xep-0308.xml
@@ -22,6 +22,12 @@
   <shortname>message-correct</shortname>
   &ksmith;
   <revision>
+    <version>1.1.0</version>
+    <date>2019-01-11</date>
+    <initials>egp</initials>
+    <remark><p>Add support for corrections in MUCs, including in history.</p></remark>
+  </revision>
+  <revision>
     <version>1.0</version>
     <date>2013-04-08</date>
     <initials>psa</initials>
@@ -100,11 +106,17 @@
   <p>While it's not possible to prevent this protocol from being used in such a way, it is not intended that it provides a way to continue expanding a previous message indefinitely and clients, in as much as it is sensible, should present use of this extension only for correction rather than for providing a continuous stream, for which &xep0301; can be used instead.</p>
   <p>Correction MUST only be used to change the details of a stanza (e.g. the message body) and not to change the nature of the stanza (e.g. correction MUST NOT be used to turn a chat message into a pubsub notification)</p>
   <p>While it is possible to use this protocol to correct messages older than the most recent received from a full JID, such use is out of scope for this document and support for this SHOULD NOT be assumed without further negotiation.</p>
+  <p>A &xep0045; room SHOULD reject any correction attempt made by a different real bare JID than the one from which the message originates.  In order to notify clients of this behaviour, it MUST include the 'urn:xmpp:message-correct:0' feature in its disco#info if it applies this rule.</p>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
   <p>The replacement message could have an entirely different meaning from the original message, so clients will need to make users aware that the displayed message has been edited. It is also suggested that clients make the original message available in some way, although this UI consideration is out of the scope of this document.</p>
   <p>There exist some payload types where correction is problematic, for some deployments. In particular, care needs to be taken that security labels from &xep0258; are handled in an appropriate manner for the security domains of a given deployment.</p>
-  <p>When used in a &xep0045; context, corrections must not be allowed (by the receiver) for messages received before the sender joined the room - particularly a full JID leaving the room then rejoining and correcting a message SHOULD be disallowed, as the entity behind the full JID in the MUC may have changed.</p>
+  <p>When used in a &xep0045; context, the receiver of a correction should check if the room advertises the 'urn:xmpp:message-correct:0' feature in its disco#info.  If it does so, the receiver can trust any message correction received through this room, be it live or from history.  Otherwise, if this feature isn’t advertised by the room, the receiver should verify each correction coming its way, for instance:</p>
+  <ul>
+    <li>If the room is non-anonymous and the bare JID of the sender of both the message and its correction is the same, allow it.</li>
+    <li>If the room is semi-anonymous and the message came live from the same occupant, allow it.</li>
+    <li>If the room is semi-anonymous and the message came from the history, from another sender, or from someone with the same nick but who left and came back, reject it.</li>
+  </ul>
 </section1>
 <section1 topic='IANA Considerations' anchor='iana'>
   <p>None.</p>
@@ -118,6 +130,20 @@
   </section2>
   <section2 topic='Protocol Versioning' anchor='registrar-versioning'>
     &NSVER;
+  </section2>
+  <section2 topic='Service Discovery Features' anchor='registrar-features'>
+    <p>The &REGISTRAR; includes 'urn:xmpp:message-correct:0' in its registry of disco#info features.</p>
+    <code><![CDATA[
+<var>
+  <name>urn:xmpp:message-correct:0</name>
+  <desc>
+    For a XEP-0045 room, this features indicates that it will reject message
+    corrections which apply to messages sent by the same nick but by a
+    different real bare JID.
+  </desc>
+  <doc>XEP-0308</doc>
+</var>
+]]></code>
   </section2>
 </section1>
 <section1 topic='XML Schema' anchor='schema'>


### PR DESCRIPTION
Corrections done in MUC used to always be untrusted when coming from the
room’s history, because —according to this XEP— another entity could
have taken the same in-room full JID.

This addition makes the room responsible for rejecting such illegal
correction attempts, and advertise that in its disco#info, which clients
can then trust properly.

This also relaxes the rule on identity checking in non-anonymous rooms,
by making it rely on the real bare JID of the occupant.