### PR TITLE
XEP-0234: Use <hash-used/> to signify the hash function being used, instead of an (invalid) empty <hash/>

### DIFF
--- a/xep-0234.xml
+++ b/xep-0234.xml
@@ -873,7 +873,7 @@ a=file-range:1024-*]]></code>
           <name>test.txt</name>
           <range/>
           <size>6144</size>
-          <hash xmlns='urn:xmpp:hashes:2' algo='sha-1'/>
+          <hash-used xmlns='urn:xmpp:hashes:2' algo='sha-1'/>
         </file>
       </description>
       <transport xmlns='urn:xmpp:jingle:transports:s5b:1'

--- a/xep-0234.xml
+++ b/xep-0234.xml
@@ -854,7 +854,7 @@ a=file-range:1024-*]]></code>
     </checksum>
   </jingle>
 </iq>]]></example>
-    <p>If the initiator wishes to communicate only the hashing algorithm at the beginning of the session (e.g., because it has not yet calculated the checksum), it can send an empty &lt;hash/&gt; element (without a checksum in the XML character data as shown in the previous examples) in the session-initiate message; this enables the recipient to check the file during the transfer session (which can be helpful in the case of transfers that are truncated or fail mid-stream).</p>
+    <p>If the initiator wishes to communicate only the hashing algorithm at the beginning of the session (e.g., because it has not yet calculated the checksum), it can send &lt;hash-used/&gt; element in the session-initiate message; this enables the recipient to check the file during the transfer session (which can be helpful in the case of transfers that are truncated or fail mid-stream).</p>
     <example caption="Initiator communicates hashing algorithm in session-initiate"><![CDATA[
 <iq from='romeo@montague.example/dr4hcr0st3lup4c'
     id='nzu25s8'

--- a/xep-0234.xml
+++ b/xep-0234.xml
@@ -1078,6 +1078,7 @@ a=file-range:1024-*]]></code>
       <xs:element name='size' type='xs:positiveInteger'/>
       <xs:element name='range' type='fileTransferRangeType'/>
       <xs:element ref='h:hash' minOccurs='0' maxOccurs='unbounded'/>
+      <xs:element ref='h:hash-used' minOccurs='0' maxOccurs='unbounded'/>
     </xs:sequence>
   </xs:complexType>
 


### PR DESCRIPTION
Most likely smeone just forgot to update the exampe after introducing hash-used in this xep.