### PR TITLE
XEP-0060: Add missing @publisher in pubsub schema

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -50,6 +50,14 @@
   &stpeter;
   &ralphm;
   <revision>
+    <version>1.15.7</version>
+    <date>2019-01-27</date>
+    <initials>egp</initials>
+    <remark>
+      <p>Add 'publisher' attribute to &lt;item/&gt; in the http://jabber.org/protocol/pubsub schema, forgotten in revision 1.13.</p>
+    </remark>
+  </revision>
+  <revision>
     <version>1.15.6</version>
     <date>2018-11-22</date>
     <initials>jsc (Editor)</initials>
@@ -6722,6 +6730,7 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings
         <xs:any namespace='##other'/>
       </xs:sequence>
       <xs:attribute name='id' type='xs:string' use='optional'/>
+      <xs:attribute name='publisher' type='xs:string' use='optional'/>
     </xs:complexType>
   </xs:element>
 


### PR DESCRIPTION
This attribute had been added in revision 1.13, but only the pubsub#event schema had been updated, this fixes it for the pubsub schema too.

An example of this attribute being used can be seen in [example 105](https://xmpp.org/extensions/xep-0060.html#example-105).