### PR TITLE
XEP-0084: Bump the maximum of @width and @height to 65535

### DIFF
--- a/xep-0084.xml
+++ b/xep-0084.xml
@@ -38,6 +38,12 @@
   &temas;
   &xvirge;
   <revision>
+    <version>1.1.2</version>
+    <date>2019-01-27</date>
+    <initials>egp</initials>
+    <remark><p>Bump the maximum value 'width' and 'height' attributes from 255 to 65535 in the schema, to accomodate current usage.</p></remark>
+  </revision>
+  <revision>
     <version>1.1.1</version>
     <date>2016-07-09</date>
     <initials>XEP Editor: ssw</initials>
@@ -361,7 +367,7 @@
         </tr>
         <tr>
           <td>height</td>
-          <td>The height of the image in pixels.</td>
+          <td>The height of the image in pixels, if available.</td>
           <td>RECOMMENDED</td>
         </tr>
         <tr>
@@ -381,7 +387,7 @@
         </tr>
         <tr>
           <td>width</td>
-          <td>The width of the image in pixels</td>
+          <td>The width of the image in pixels, if available.</td>
           <td>RECOMMENDED</td>
         </tr>
       </table>
@@ -399,10 +405,10 @@
       <p>The &lt;pointer/&gt; element MAY possess the following attributes if the publishing application has the relevant information:</p>
       <ul>
         <li><em>bytes</em> -- The size of the image data in bytes.</li>
-        <li><em>height</em> -- The height of the image in pixels.</li>
+        <li><em>height</em> -- The height of the image in pixels, if available.</li>
         <li><em>id</em> -- The SHA-1 hash of the image data for the specified content-type.</li>
         <li><em>type</em> -- The IANA-registered content type of the image data.</li>
-        <li><em>width</em> -- The width of the image in pixels.</li>
+        <li><em>width</em> -- The width of the image in pixels, if available.</li>
       </ul>
       <p>The content of the &lt;pointer/&gt; element MUST be a properly-namespaced child element that specifies information about how to retrieve the avatar from the third-party service. The structure for any such child element is out of scope for this document.</p>
       <p>Even if the &lt;pointer&gt; element is included, it MUST be preceded by at least one instance of the &lt;info/&gt; element so that implementations that do not support the &lt;pointer/&gt; element can display a "fallback" format of the avatar (at a minimum, "image/png").</p>
@@ -584,11 +590,11 @@
       <xs:simpleContent>
         <xs:extension base='empty'>
           <xs:attribute name='bytes' type='xs:unsignedShort' use='required'/>
-          <xs:attribute name='height' type='xs:unsignedByte' use='optional'/>
+          <xs:attribute name='height' type='xs:unsignedShort' use='optional'/>
           <xs:attribute name='id' type='xs:string' use='required'/>
           <xs:attribute name='type' type='xs:string' use='required'/>
           <xs:attribute name='url' type='xs:anyURI' use='optional'/>
-          <xs:attribute name='width' type='xs:unsignedByte' use='optional'/>
+          <xs:attribute name='width' type='xs:unsignedShort' use='optional'/>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>


### PR DESCRIPTION
There are many avatars out there being bigger than 255×255, this lets implementations relying on the schema accept them.