### PR TITLE
xep-0284: Fix xmlns in disco#info examples

### DIFF
--- a/xep-0284.xml
+++ b/xep-0284.xml
@@ -265,13 +265,13 @@
     to='kingclaudius@shakespeare.lit/castle'
     id='disco1'>
     type='get'>
-  <query xmlns='http://xmpp.org/protocol/disco#info'/>
+  <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>
 ]]></example>
   <p>If the host supports Shared XML Editing over XMPP, it MUST return features of "urn:xmpp:sxe:0" and "urn:xmpp:jingle:transports:sxe" &NSNOTE;:</p>
   <example caption='Service discovery response'><![CDATA[
 <iq from='laertes@shakespeare.lit/castle' to='kingclaudius@shakespeare.lit/castle' type='result' id='disco1'>
-  <query xmlns='http://xmpp.org/protocol/disco#info'>
+  <query xmlns='http://jabber.org/protocol/disco#info'>
     <identity category='client' type='pc'/>
     ...
     <feature var='urn:xmpp:sxe:0'/>


### PR DESCRIPTION
XEP-0030 was from the `http://jabber.org/protocol/*` era,
nothing else uses `http://xmpp.org/protocol`.
This appears to be a mistake, which is corrected in this PR.

I have not added a revision block, but can do if it's needed.