### PR TITLE
XEP-0410: add application-specific <not-an-occupant/> condition

### DIFF
--- a/xep-0410.xml
+++ b/xep-0410.xml
@@ -192,7 +192,10 @@
       as follows:</p>
     <ul>
       <li><strong>Successful IQ response</strong>: the client is joined to the MUC.</li>
-      <li><strong>Error (&lt;not-acceptable&gt;)</strong>: the client is not joined to the MUC.</li>
+      <li><strong>Error (&lt;not-acceptable&gt;)</strong>: the client is not
+	joined to the MUC. In addition, to allow clients to disambiguate this
+	from other error causes, the server MUST add an application-specific error
+	condition of <tt>&lt;not-an-occupant xmlns="http://jabber.org/protocol/muc" /&gt;</tt></li>
     </ul>
 <example caption='MUC Service Advertises Self-Ping Optimization'><![CDATA[
 <iq from='darkcave@chat.shakespeare.lit'
@@ -201,6 +204,15 @@
     <!-- ... -->
     <feature var='http://jabber.org/protocol/muc#self-ping-optimization'/>
   </query>
+</iq>
+]]></example>
+    <example caption="Server Optimization Response to a Non-Occupant"><![CDATA[
+<iq from='characters@chat.shakespeare.lit/JuliC' id='s2c1' type='error'
+      to='juliet@capulet.lit/client' >
+  <error type="cancel">
+    <not-acceptable xmlns="urn:ietf:params:xml:ns:xmpp-stanzas" />
+    <not-an-occupant xmlns="http://jabber.org/protocol/muc" />
+  </error>
 </iq>
 ]]></example>
   </section2>


### PR DESCRIPTION
Based on https://mail.jabber.org/pipermail/standards/2019-January/035752.html and discussion in xsf@ MUC with @horazont.

Please have a Council discussion.

**Edit**: rendered version: https://op-co.de/tmp/xep-0410.html#serveroptimization