### PR TITLE
XEP-0060: Expose pubsub#access_model and pubsub#publish_model 

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -1053,6 +1053,12 @@ And by opposing end them?
       <field var='pubsub#contact' label='People to contact with questions' type='jid-multi'>
         <value>bard@shakespeare.lit</value>
       </field>
+      <field var='pubsub#access_model' label='Access model' type='list-single'>
+        <value>open</value>
+      </field>
+      <field var='pubsub#publish_model' label='Publish model' type='list-single'>
+        <value>publishers</value>
+      </field>
       <field var='pubsub#max_items' label='Max # of items to persist' type='text-single'>
         <value>120</value>
       </field>
@@ -6300,6 +6306,12 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
   <field var='pubsub#language'
          type='list-single'
          label='The default language of the node'/>
+  <field var='pubsub#access_model'
+         type='list-single'
+         label='Access model'/>
+  <field var='pubsub#publish_model'
+         type='list-single'
+         label='Publish model'/>
   <field var='pubsub#num_subscribers'
          type='text-single'
          label='The number of subscribers to the node'/>


### PR DESCRIPTION
This will allow clients to display proper information regarding the nodes configuration in their UI, especially when combined with the Affiliations and Subscriptions states (hide the publish icon, display an "open/public" node icon…).