### PR TITLE
XEP-0260: mode attr must not be included

### DIFF
--- a/xep-0260.xml
+++ b/xep-0260.xml
@@ -248,7 +248,6 @@ Initiator                        Responder
       <description xmlns='urn:xmpp:example'/>
       <transport xmlns='urn:xmpp:jingle:transports:s5b:1'
                  dstaddr='1a12fb7bc625e55f3ed5b29a53dbe0e4aa7d80ba'
-        	 mode='tcp'
                  sid='vj3hs98y'>
         <candidate cid='ht567dq'
                    host='192.169.1.10'


### PR DESCRIPTION
when sent by responder accroding to requirements above