### PR TITLE
XEP-0045: Add avatar support using XEP-0084

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -46,6 +46,12 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.32</version>
+    <date>2019-02-13</date>
+    <initials>egp</initials>
+    <remark><p>Add room avatar support, using XEP-0084.</p></remark>
+  </revision>
+  <revision>
     <version>1.31.2</version>
     <date>2018-07-31</date>
     <initials>jwi</initials>
@@ -550,6 +556,7 @@
     <li>enabling occupants to view an occupant's full JID in a non-anonymous room</li>
     <li>enabling moderators to view an occupant's full JID in a semi-anonymous room</li>
     <li>allowing only moderators to change the room subject</li>
+    <li>allowing only moderators to change the room avatar</li>
     <li>enabling moderators to kick participants and visitors from the room</li>
     <li>enabling moderators to grant and revoke voice (i.e., the privilege to speak) in a moderated room, and to manage the voice list</li>
     <li>enabling admins to grant and revoke moderator status, and to manage the moderator list</li>
@@ -576,6 +583,7 @@
   <section2 topic='General Terms' anchor='terms-general'>
     <dl>
       <di><dt>Affiliation</dt><dd>A long-lived association or connection with a room; the possible affiliations are "owner", "admin", "member", and "outcast" (naturally it is also possible to have no affiliation); affiliation is distinct from role. An affiliation lasts across a user's visits to a room.</dd></di>
+      <di><dt>Avatar</dt><dd>A small image or icon associated with a room, to help human users differentiate it from other rooms.</dd></di>
       <di><dt>Ban</dt><dd>To remove a user from a room such that the user is not allowed to re-enter the room (until and unless the ban has been removed). A banned user has an affiliation of "outcast".</dd></di>
       <di><dt>Bare JID</dt><dd>The &lt;user@host&gt; by which a user is identified outside the context of any existing session or resource; contrast with Full JID and Occupant JID.</dd></di>
       <di><dt>Full JID</dt><dd>The &lt;user@host/resource&gt; by which an online user is identified outside the context of a room; contrast with Bare JID and Occupant JID.</dd></di>
@@ -772,6 +780,13 @@
           <td>No</td>
           <td>No*</td>
           <td>Yes*</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>Modify Avatar</td>
+          <td>No</td>
+          <td>No</td>
+          <td>No*</td>
           <td>Yes</td>
         </tr>
         <tr>
@@ -1271,6 +1286,11 @@
              label='Associated pubsub node'>
         <value>xmpp:pubsub.shakespeare.lit?;node=the-coven-node</value>
       </field>
+      <field var='muc#roominfo_avatar'
+             type='text-multi'
+             label='Room Avatar Hashes'>
+        <value>a31c4bd04de69663cfd7f424a8453f4674da37ff</value>
+      </field>
     </x>
   </query>
 </iq>
@@ -1373,6 +1393,71 @@
     ...
 ]]></code>
     <p>If this information is private, the user MUST return an empty &QUERY; element, in accordance with <cite>XEP-0030</cite>.</p>
+  </section2>
+
+  <section2 topic='Retrieve Avatar Data' anchor='get-avatar'>
+    <p>When an entity has received an avatar hash, whether from the 'muc#roominfo_avatar' field of <link url='#example-10'>a disco#info on the room</link>, or through a notification due to the 'urn:xmpp:avatar:metadata+notify' feature of &xep0115;, it can request the avatar data from the 'urn:xmpp:avatar:data' node, as per &xep0084;:</p>
+    <example caption='Entity Requests Room Avatar Data'><![CDATA[
+<iq from='hag66@shakespeare.lit/pda'
+    id='i8fa1pg8'
+    to='coven@chat.shakespeare.lit'
+    type='get'>
+  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+    <items node='urn:xmpp:avatar:data'>
+      <item id='a31c4bd04de69663cfd7f424a8453f4674da37ff'/>
+    </items>
+  </pubsub>
+</iq>
+]]></example>
+    <example caption='Room Returns Avatar Data'><![CDATA[
+<iq from='coven@chat.shakespeare.lit'
+    id='i8fa1pg8'
+    to='hag66@shakespeare.lit/pda'
+    type='result'>
+  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+    <items node='urn:xmpp:avatar:data'>
+      <item id='a31c4bd04de69663cfd7f424a8453f4674da37ff'>
+        <data xmlns='urn:xmpp:avatar:data'>
+          PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiI+CiA8cmVjdCB4PSIwIiB5PSIwIiB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIGZpbGw9InJlZCIvPgo8L3N2Zz4K
+        </data>
+      </item>
+    </items>
+  </pubsub>
+</iq>
+]]></example>
+    <p>In case the entity only has the hash of the avatar and needs the related metadata for processing, for instance because it isn’t an occupant of the room and thus didn’t receive the metadata notification, it can also request them:</p>
+    <example caption='Entity Requests Room Avatar Metadata'><![CDATA[
+<iq from='hag66@shakespeare.lit/pda'
+    id='6tr530tu'
+    to='coven@chat.shakespeare.lit'
+    type='get'>
+  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+    <items node='urn:xmpp:avatar:metadata'>
+      <item id='a31c4bd04de69663cfd7f424a8453f4674da37ff'/>
+    </items>
+  </pubsub>
+</iq>
+]]></example>
+    <example caption='Room Returns Avatar Metadata'><![CDATA[
+<iq from='coven@chat.shakespeare.lit'
+    id='6tr530tu'
+    to='hag66@shakespeare.lit/pda'
+    type='result'>
+  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+    <items node='urn:xmpp:avatar:metadata'>
+      <item id='a31c4bd04de69663cfd7f424a8453f4674da37ff'>
+        <metadata xmlns='urn:xmpp:avatar:metadata'>
+          <info bytes='126'
+                id='a31c4bd04de69663cfd7f424a8453f4674da37ff'
+                height='32'
+                type='image/svg+xml'
+                width='32'/>
+        </metadata>
+      </item>
+    </items>
+  </pubsub>
+</iq>
+]]></example>
   </section2>
 
 </section1>
@@ -2743,6 +2828,7 @@
     <li>kick a participant or visitor from the room</li>
     <li>grant or revoke voice in a moderated room</li>
     <li>modify the list of occupants who have voice in a moderated room</li>
+    <li>modify the room avatar</li>
   </ol>
   <p>These features are implemented with a request/response exchange using &lt;iq/&gt; elements that contain child elements qualified by the 'http://jabber.org/protocol/muc#admin' namespace. The examples below illustrate the protocol interactions to implement the desired functionality. (Except where explicitly noted below, any of the following administrative requests MUST be denied if the &lt;user@host&gt; of the 'from' address of the request does not match the bare JID portion of one of the moderators; in this case, the service MUST return a &forbidden; error.)</p>
 
@@ -3121,6 +3207,80 @@
 </message>
 ]]></example>
     <p>If a moderator approves the voice request, the service shall grant voice to the occupant and send a presence update as described in the <link url='#grantvoice'>Granting Voice to a Visitor</link> section of this document.</p>
+  </section2>
+
+  <section2 topic='Setting the Room Avatar' anchor='set-avatar'>
+    <p>By default, only users with a role of "moderator" SHOULD be allowed to change the avatar of a room, using the protocol defined in &xep0084;:</p>
+    <example caption='Moderator Publishes Room Avatar Data'><![CDATA[
+<iq from='crone1@shakespeare.lit/desktop'
+    id='avatar1'
+    to='coven@chat.shakespeare.lit'
+    type='set'>
+  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+    <publish node='urn:xmpp:avatar:data'>
+      <item id='a31c4bd04de69663cfd7f424a8453f4674da37ff'>
+        <data xmlns='urn:xmpp:avatar:data'>
+          PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiI+CiA8cmVjdCB4PSIwIiB5PSIwIiB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIGZpbGw9InJlZCIvPgo8L3N2Zz4K
+        </data>
+      </item>
+    </publish>
+  </pubsub>
+</iq>
+]]></example>
+    <example caption='Moderator Publishes Room Avatar Metadata'><![CDATA[
+<iq from='crone1@shakespeare.lit/desktop'
+    id='avatar2'
+    to='coven@chat.shakespeare.lit'
+    type='set'>
+  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+    <publish node='urn:xmpp:avatar:metadata'>
+      <item id='a31c4bd04de69663cfd7f424a8453f4674da37ff'>
+        <metadata xmlns='urn:xmpp:avatar:metadata'>
+          <info bytes='126'
+                id='a31c4bd04de69663cfd7f424a8453f4674da37ff'
+                height='32'
+                type='image/svg+xml'
+                width='32'/>
+        </metadata>
+      </item>
+    </publish>
+  </pubsub>
+</iq>
+]]></example>
+    <p>The service MUST then inform the moderator of success:</p>
+    <example caption='Service Informs Moderator of Success'><![CDATA[
+<iq from='coven@chat.shakespeare.lit'
+    id='avatar1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/>
+<iq from='coven@chat.shakespeare.lit'
+    id='avatar2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/>
+]]></example>
+    <p>The service MUST then send metadata notification to entities that have subscribed to the rooms's avatar metadata node or occupants who have advertised an interest in receiving avatar metadata by including a &xep0115; feature of "urn:xmpp:avatar:metadata+notify".</p>
+    <example caption='Service Sends Metadata Notification to Some Occupants'><![CDATA[
+<message
+    from='coven@chat.shakespeare.lit'
+    to='crone1@shakespeare.lit/desktop'>
+  <event xmlns='http://jabber.org/protocol/pubsub#event'>
+    <items node='urn:xmpp:avatar:metadata'>
+      <item id='a31c4bd04de69663cfd7f424a8453f4674da37ff'>
+        <metadata xmlns='urn:xmpp:avatar:metadata'>
+          <info bytes='126'
+                height='32'
+                id='a31c4bd04de69663cfd7f424a8453f4674da37ff'
+                type='image/svg+xml'
+                width='32'/>
+        </metadata>
+      </item>
+    </items>
+  </event>
+</message>
+
+[ ... ]
+]]></example>
+    <p>Occupants who received this metadata notification can then <link url='#get-avatar'>retrieve data if they don’t have this avatar image in cache</link>.</p>
   </section2>
 
 </section1>


### PR DESCRIPTION
This is a second attempt at getting MUC room avatars, after [Council rejected my previous proposal](https://mail.jabber.org/pipermail/standards/2018-September/035351.html).  This new proposal avoids introducing a new XEP, and instead will eventually allow deprecation/obsolescence of two of the mentioned ones, leaving only XEP-0084.