### PR TITLE
XEP-0313 (editorial): add bumped version into changelog

### DIFF
--- a/xep-0313.xml
+++ b/xep-0313.xml
@@ -53,7 +53,7 @@
     <date>2017-02-17</date>
     <initials>dg, mw</initials>
     <remark>
-      <p>Namespace bump</p>
+      <p>Namespace bump from mam:1 to mam:2</p>
       <p>Added method for server to communicate the archive id</p>
       <p>Incorporated editorial clarifications based on implementation feedback</p>
       <p>Clarifications on the topics of message ordering, message deletion and use of the protocol for synchronization</p>


### PR DESCRIPTION
Because "Namespace bump" is really not helpful when you are doing XEP archeology.