### PR TITLE
add link formatting syntax, taken from MediaWiki and Trac

### DIFF
--- a/xep-0393.xml
+++ b/xep-0393.xml
@@ -402,6 +402,25 @@
 </body>
 ]]></example>
     </section3>
+    <section3 topic='Formatting of URIs' anchor='uris'>
+      <p>
+	Text enclosed by an opening square bracket '[' (U+005B LEFT
+	SQUARE BRACKET) and a closing one ']' (U+005D RIGHT SQUARE
+	BRACKET) with at least two parts of non-whitespace text,
+	separated by at least one whitespace character, are presented
+	as link, if applicable.
+	The first text part is the actual URI or link, that might be
+	hidden. The remaining text until the first closing bracket is
+	the text presentation. This presentation can be
+	underlined or clickable button.
+      </p>
+      <example caption='URI example'><![CDATA[
+<body>
+  There is a [https://xmpp.org/ universal messaging standard] that
+  supports formatting of links.
+</body>
+]]></example>
+    </section3>
   </section2>
 </section1>
 <section1 topic='Implementation Notes' anchor='impl'>


### PR DESCRIPTION
A short discussion in the XSF MUC revealed, that the markdown link syntax confuses users, in respect to order of URI and text, which is reversed HTML anchor, and order of round and square brackets. The MediaWiki/Trac syntax seems to be easier to digest. Also, it is very easy to parse.