### PR TITLE
Fix typo in XEP-0199

### DIFF
--- a/xep-0199.xml
+++ b/xep-0199.xml
@@ -180,7 +180,7 @@
 <iq from='juliet@capulet.lit/chamber'
     to='romeo@montague.lit/home'
     id='e2e1'
-    type='result'>
+    type='error'>
   <ping xmlns='urn:xmpp:ping'/>
   <error type='cancel'>
     <service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>


### PR DESCRIPTION
8.2.3. of rfc6120 noted type "result" MUST have one or zero childs. I suppose it is a typo because other examples use type "error".