### PR TITLE
XEP-0313: Relax 'communicating archive ID' requirement

### DIFF
--- a/xep-0313.xml
+++ b/xep-0313.xml
@@ -220,7 +220,7 @@
 	</section2>
 	<section2 topic='Communicating the archive ID' anchor='archives_id'>
 		<p>When a message is archived, the server MUST add an &lt;stanza-id/&gt; element as defined in &xep0359; to the message, which informs the recipient of where and under what ID the message is stored. When doing this the server MUST follow the business rules defined in XEP-0359. The 'by' attribute MUST be set to the address of the archive. For regular users that’s the bare JID of the account and for MUC that’s the bare JID of the room.</p>
-		<p>Servers MUST NOT include the &lt;stanza-id/&gt; element in messages addressed to JIDs that do not have permissions to access the archive, such as a users’s outgoing messages to their contacts. However servers SHOULD include the element as a child of the forwarded message when using &xep0280;</p>
+		<p>Servers SHOULD NOT include the &lt;stanza-id/&gt; element in messages addressed to JIDs that do not have permissions to access the archive, such as a users’s outgoing messages to their contacts. However servers SHOULD include the element as a child of the forwarded message when using &xep0280;</p>
 		<example caption='Client receives a message that has been archived'><![CDATA[
 <message to='juliet@capulet.lit/balcony'
 	 from='romeo@montague.lit/orchard'


### PR DESCRIPTION
The requirement keyword changed in this commit stems from the time when this XEP used ``<archived id='...' by='...' />`` instead of XEP-0359.

The 'MUST NOT' requirement keyword implies that something will go horribly wrong, if the ID is sent. This is not the case here.

Sharing the stanza-id on a need-to-know basis is a sensible default, but should not be a requirement.