### PR TITLE
XEP-0050: Fix variable name in example 14

### DIFF
--- a/xep-0050.xml
+++ b/xep-0050.xml
@@ -418,7 +418,7 @@
            sessionid='config:20020923T213616Z-700'
            node='config'>
     <x xmlns='jabber:x:data' type='submit'>
-      <field var='mode'>
+      <field var='runlevel'>
         <value>3</value>
       </field>
       <field var='state'>


### PR DESCRIPTION
According to the previous example, the first variable should be called `runlevel` instead of `mode`.