### PR TITLE
XEP-0412: take over and push agenda

### DIFF
--- a/xep-0412.xml
+++ b/xep-0412.xml
@@ -269,12 +269,12 @@
           <td>&xep0045;<note>Implementations should take note that future versions of these compliance suites may rely on &xep0369; instead.</note>, &xep0249;</td>
         </tr>
         <tr>
-          <td><strong>Bookmarks</strong></td>
+          <td><strong>Advanced Group Chat</strong></td>
           <td align='center'>&#10005;</td>
           <td align='center'>&#10005;</td>
           <td align='center'>&#10003;&component;</td>
           <td align='center'>&#10003;</td>
-          <td>&xep0048;</td>
+	  <td>&xep0048;, &xep0313;<note>Support for requesting history from a MUC archive as opposed to from the user's account.</note>, &xep0410;</td>
         </tr>
         <tr>
           <td><strong>Persistent Storage of Private Data via PubSub</strong></td>

--- a/xep-0412.xml
+++ b/xep-0412.xml
@@ -53,7 +53,18 @@
     </supersedes>
     <supersededby/>
     <shortname>CS2019</shortname>
-    &jonaswielicki;
+    <author>
+      <firstname>Georg</firstname>
+      <surname>Lukas</surname>
+      <email>georg@op-co.de</email>
+      <jid>georg@yax.im</jid>
+    </author>
+    <revision>
+      <version>0.5.0</version>
+      <date>2019-03-25</date>
+      <initials>gl</initials>
+      <remark><ul><li>Taken over ownership.</li><li>Improved structure of category and level names.</li><li>Added XEP-0313 and XEP-0412 to 'Advanced Group Chat'</li></ul></remark>
+    </revision>
     <revision>
       <version>0.4.0</version>
       <date>2019-01-13</date>
@@ -414,7 +425,7 @@
   <p>
     The author would like to thank Guus der Kinderen, Dele Olajide, Marc
     Laporte, Dave Cridland, Daniel Gultsch, Florian Schmaus, Tobias Markmann,
-    and Georg Lukas for their suggestions.
+    and Jonas Schäfer for their suggestions.
   </p>
 </section1>
 </xep>

--- a/xep-0412.xml
+++ b/xep-0412.xml
@@ -92,13 +92,20 @@
       This document specifies compliance levels for XMPP clients and servers; it
       is hoped that this document will advance the state of the art, and provide
       guidance and eventual certification to XMPP client and server authors.
+    </p>
+    <p>
+      This document defines <strong>Categories</strong> based on
+      typical use cases (Core, Web, IM, Mobile) and <strong>Levels</strong>
+      (Core, Advanced) based on functionality in the respective category.
+    </p>
+    <p>
       Unless explicitly noted, support for the listed specifications is REQUIRED
       for compliance purposes.
       A feature is considered supported if all comma separated feature providers
       listed in the "Providers" column are implemented (unless otherwise noted).
     </p>
   </section1>
-  <section1 topic='Compliance Levels' anchor='levels'>
+  <section1 topic='Compliance Categories' anchor='categories'>
     <section2 topic='Core Compliance Suite' anchor='core'>
       <table caption='XMPP Core Compliance Levels'>
         <tr>
@@ -170,7 +177,7 @@
     <section2 topic='Web Compliance Suite' anchor='web'>
       <p>
         To be considered XMPP web compliant, all features from the core
-        compliance suite must be met, as well as all features in this suite.
+        compliance category must be met, as well as all features in this suite.
       </p>
       <table caption='XMPP Web Compliance Levels'>
         <tr>
@@ -194,7 +201,7 @@
     <section2 topic='IM Compliance Suite' anchor='im'>
       <p>
         To be considered XMPP IM compliant, all features from the core
-        compliance suite must be met, as well as all features in this suite.
+        compliance category must be met, as well as all features in this suite.
       </p>
       <table caption='XMPP IM Compliance Levels'>
         <tr>
@@ -338,7 +345,7 @@
     <section2 topic='Mobile Compliance Suite' anchor='mobile'>
       <p>
         To be considered XMPP mobile compliant, all features from the core
-        compliance suite must be met, as well as all features in this suite.
+        compliance category must be met, as well as all features in this suite.
       </p>
       <table caption='XMPP Mobile Compliance Levels'>
         <tr>


### PR DESCRIPTION
As agreed in the last Council meeting, I'm taking over the toxic Compliance Suite XEP and adding my own agenda to it:

* Better wording of Category and Level
* XEP-0313 and XEP-0412 are now part of "Advanced Group Chat", for lack of a better name