### PR TITLE
xep-0280: Fix off-by-one in dependency

### DIFF
--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -26,7 +26,7 @@
     <spec>XEP-0001</spec>
     <spec>XEP-0030</spec>
     <spec>XEP-0085</spec>
-    <spec>XEP-0296</spec>
+    <spec>XEP-0297</spec>
   </dependencies>
   <supersedes>
     <spec>XEP-0259</spec>
@@ -45,6 +45,14 @@
     <email>linuxwolf@outer-planes.net</email>
     <jid>linuxwolf@outer-planes.net</jid>
   </author>
+  <revision>
+    <version>TBD</version>
+    <date>2019-03-14</date>
+    <initials>ka</initials>
+    <remark>
+      <p>Fix off-by-one in dependencies.</p>
+    </remark>
+  </revision>
   <revision>
     <version>0.12.0</version>
     <date>2017-02-16</date>


### PR DESCRIPTION
XEP-0296 is Deferred and appears unrelated, while XEP-0297 is Draft and
actually used by XEP-0280.