### PR TITLE
XEP-0184: add a box about types and JIDs

### DIFF
--- a/xep-0184.xml
+++ b/xep-0184.xml
@@ -204,7 +204,7 @@
 </message>
 ]]></example>
   <p>When the recipient sends an ack message, it SHOULD ensure that the message stanza contains only one child element, namely the &lt;received/&gt; element qualified by the 'urn:xmpp:receipts' namespace. In addition, it SHOULD include an 'id' attribute that echoes the 'id' attribute of the content message. Naturally, intermediate entities might add other extension elements to the message when routing or delivering the receipt message, e.g., a &lt;delay/&gt; element as specified in &xep0203;.</p>
-  <p class='box'>Note: It is a good practice to use the same message type as the message that requested the receipt, however a client should also accept receipts with a different message type. When sending a Receipt for a type='groupchat' message (which is NOT RECOMMENDED), the Receipt must be sent to the bare JID of the room and not to the full JID of the sender.</p>
+  <p class='box'>Note: It is a good practice to use the same message type as the message that requested the receipt, however a client SHOULD also accept receipts with a different message type. When sending a Receipt for a type='groupchat' message (which is NOT RECOMMENDED), the Receipt must be sent to the bare JID of the room and not to the full JID of the sender.</p>
 </section1>
 
 <section1 topic='Security Considerations' anchor='security'>

--- a/xep-0184.xml
+++ b/xep-0184.xml
@@ -204,6 +204,7 @@
 </message>
 ]]></example>
   <p>When the recipient sends an ack message, it SHOULD ensure that the message stanza contains only one child element, namely the &lt;received/&gt; element qualified by the 'urn:xmpp:receipts' namespace. In addition, it SHOULD include an 'id' attribute that echoes the 'id' attribute of the content message. Naturally, intermediate entities might add other extension elements to the message when routing or delivering the receipt message, e.g., a &lt;delay/&gt; element as specified in &xep0203;.</p>
+  <p class='box'>Note: It is a good practice to use the same message type as the message that requested the receipt, however a client should also accept receipts with a different message type. When sending a Receipt for a type='groupchat' message (which is NOT RECOMMENDED), the Receipt must be sent to the bare JID of the room and not to the full JID of the sender.</p>
 </section1>
 
 <section1 topic='Security Considerations' anchor='security'>


### PR DESCRIPTION
Because it led to ambiguity in the past, here is a small informational box about reflecting the message type in Receipts.