### PR TITLE
Include source XEP XML files in build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM xmppxsf/xeps-base:latest
 
 ARG NCORES=1
-ARG TARGETS="html inbox-html inbox-xml pdf xeplist refs"
+ARG TARGETS="html inbox-html inbox-xml pdf xeplist refs xml"
 
 COPY *.xml xep.* *.css *.xsl *.js *.xsl Makefile /src/
 COPY resources/*.pdf /src/resources/


### PR DESCRIPTION
This includes the target that copies the source XML files into the build dir, fixing [404 errors](https://xmpp.org/extensions/xep-0203.xml) for these. 