### PR TITLE
make xml: Include  XEP XML dependencies in output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,8 @@ xep-%.html: $(OUTDIR)/xep-%.html ;
 .PHONY: xep-%.pdf
 xep-%.pdf: $(OUTDIR)/xep-%.pdf ;
 
-$(all_xep_xmls): $(OUTDIR)/%.xml: %.xml $(OUTDIR)
-	cp $< $@
+$(all_xep_xmls): $(OUTDIR)/%.xml: %.xml $(XMLDEPS)
+	xmllint --nonet --noent --loaddtd --dropdtd $< --output $@
 
 $(OUTDIR)/xep.xsl: xep.xsl $(OUTDIR)
 	cp $< $@

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ all_xeps=$(xeps) $(proto_xeps)
 xep_xmls=$(patsubst %.xml,$(OUTDIR)/%.xml,$(xeps))
 proto_xep_xmls=$(patsubst %.xml,$(OUTDIR)/%.xml,$(proto_xeps))
 all_xep_xmls=$(xep_xmls) $(proto_xep_xmls)
+xep_ancillary=$(patsubst %,$(OUTDIR)/%,xep.xsl)
 
 xep_htmls=$(patsubst %.xml,$(OUTDIR)/%.html,$(xeps))
 proto_xep_htmls=$(patsubst %.xml,$(OUTDIR)/%.html,$(proto_xeps))
@@ -64,7 +65,7 @@ xeplist: $(OUTDIR)/xeplist.xml
 html: $(xep_htmls)
 
 .PHONY: xml
-xml: $(xep_xmls)
+xml: $(xep_xmls) $(xep_ancillary)
 
 .PHONY: inbox-html
 inbox-html: $(proto_xep_htmls)
@@ -90,7 +91,10 @@ xep-%.html: $(OUTDIR)/xep-%.html ;
 .PHONY: xep-%.pdf
 xep-%.pdf: $(OUTDIR)/xep-%.pdf ;
 
-$(all_xep_xmls): $(OUTDIR)/%.xml: %.xml
+$(all_xep_xmls): $(OUTDIR)/%.xml: %.xml $(OUTDIR)
+	cp $< $@
+
+$(OUTDIR)/xep.xsl: xep.xsl $(OUTDIR)
 	cp $< $@
 
 $(OUTDIR)/xeplist.xml: $(wildcard *.xml) $(wildcard inbox/*.xml)

--- a/xep.xsl
+++ b/xep.xsl
@@ -34,7 +34,7 @@ OR OTHER DEALINGS IN THE SOFTWARE.
 
 <xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='1.0'>
 
-  <xsl:output doctype-public='-//W3C//DTD XHTML 1.0 Transitional//EN' doctype-system='http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd' method='xml'/>
+  <xsl:output doctype-public='-//W3C//DTD XHTML 1.0 Transitional//EN' doctype-system='http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd' method='html'/>
 
   <xsl:template name="status-notice">
     <xsl:param name="thestatus"/>


### PR DESCRIPTION
This should help with "undefined entity" errors when viewing the XEP XML
files online.

E.g. https://xmpp.org/extensions/xep-0030.xml currently shows:

```
XML Parsing Error: undefined entity
Location: https://xmpp.org/extensions/xep-0030.xml
Line Number 11, Column 5:
    &LEGALNOTICE;
----^
```