### PR TITLE
XEP-0045: kill GC1.0 with fire

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -534,7 +534,7 @@
 </section1>
 
 <section1 topic='Requirements' anchor='reqs'>
-  <p>This document addresses the minimal functionality provided by Jabber-based multi-user chat services that existed in 2002 when development of MUC began. For the sake of backwards-compatibility, this document uses the original groupchat 1.0 protocol for this baseline functionality, with the result that:</p>
+  <p>This document addresses the minimal functionality provided by Jabber-based multi-user chat services that existed in 2002 when development of MUC began. This design is based on the original groupchat 1.0 protocol, with the result that:</p>
   <ul>
     <li>Each room is identified as a "room JID" &ROOMJID; (e.g., &lt;jdev@conference.jabber.org&gt;), where "room" is the name of the room and "service" is the hostname at which the multi-user chat service is running.</li>
     <li>Each occupant in a room is identified as an "occupant JID" &OCCUPANTJID;, where "nick" is the room nickname of the occupant as specified on entering the room or subsequently changed during the occupant's visit.</li>

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -1905,7 +1905,7 @@
     id='ng91xs69'
     to='coven@chat.shakespeare.lit/thirdwitch'/>
 ]]></example>
-      <p>This behavior can not be distinguished from a presence update from a MUC-supporting client that was desynchronized from the room. Treating this as a groupchat 1.0 join will mask the error and leave the client in a partially-synchronized state. Therefore, starting with version 1.32 of this specification, it is RECOMMENDED that a service receiving a &lt;presence&gt; without an &lt;x&gt; element responds with an explicit kick to that client.</p>
+      <p>This behavior can not be distinguished from a presence update from a MUC-supporting client that was desynchronized from the room. Treating this as a groupchat 1.0 join will mask the error and leave the client in a partially-synchronized state. Therefore, starting with version 1.32 of this specification, it is RECOMMENDED that a service receiving a &lt;presence&gt; without an &lt;x&gt; element from a non-occupant full-JID responds with an explicit kick to that client.</p>
       <example caption='Service Response to groupchat 1.0 join / non-occupant presence update'><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/thirdwitch'

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -515,7 +515,7 @@
   </revision>
 </header>
 <section1 topic='Introduction' anchor='intro'>
-  <p>Traditionally, instant messaging is thought to consist of one-to-one chat rather than many-to-many chat, which is called variously "groupchat" or "text conferencing". Groupchat functionality is familiar from systems such as Internet Relay Chat (IRC) and the chatroom functionality offered by popular consumer IM services. The Jabber/XMPP community developed and implemented a basic groupchat protocol as long ago as 1999. That "groupchat 1.0" (GC) protocol provided a minimal feature set for chat rooms but was rather limited in scope. This specification (Multi-User Chat or MUC) builds on the older groupchat 1.0 protocol in a backwards-compatible manner but provides advanced features such as invitations, room moderation and administration, and specialized room types.</p>
+  <p>Traditionally, instant messaging is thought to consist of one-to-one chat rather than many-to-many chat, which is called variously "groupchat" or "text conferencing". Groupchat functionality is familiar from systems such as Internet Relay Chat (IRC) and the chatroom functionality offered by popular consumer IM services. The Jabber/XMPP community developed and implemented a basic groupchat protocol as long ago as 1999. That "groupchat 1.0" (GC) protocol provided a minimal feature set for chat rooms but was rather limited in scope. This specification (Multi-User Chat or MUC) is not compatible to the groupchat 1.0 protocol, but provides advanced features such as invitations, room moderation and administration, and specialized room types.</p>
 </section1>
 
 <section1 topic='Scope' anchor='scope'>
@@ -579,7 +579,7 @@
       <di><dt>Ban</dt><dd>To remove a user from a room such that the user is not allowed to re-enter the room (until and unless the ban has been removed). A banned user has an affiliation of "outcast".</dd></di>
       <di><dt>Bare JID</dt><dd>The &lt;user@host&gt; by which a user is identified outside the context of any existing session or resource; contrast with Full JID and Occupant JID.</dd></di>
       <di><dt>Full JID</dt><dd>The &lt;user@host/resource&gt; by which an online user is identified outside the context of a room; contrast with Bare JID and Occupant JID.</dd></di>
-      <di><dt>GC</dt><dd>The minimal "groupchat 1.0" protocol developed within the Jabber community in 1999; MUC is backwards-compatible with GC.</dd></di>
+      <di><dt>GC</dt><dd>The minimal "groupchat 1.0" protocol developed within the Jabber community in 1999; Old versions of MUC were backwards-compatible with GC.</dd></di>
       <di><dt>History</dt><dd>A limited number of message stanzas sent to a new occupant to provide the context of current discussion.</dd></di>
       <di><dt>Invitation</dt><dd>A special message sent from one user to another asking the recipient to join a room; the invitation can be sent directly (see &xep0249;) or mediated through the room (as described under <link url='#invite'>Inviting Another User to a Room</link>).</dd></di>
       <di><dt>IRC</dt><dd>Internet Relay Chat.</dd></di>

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -1898,7 +1898,7 @@
       </table>
     </section3>
     <section3 topic='Groupchat 1.0 Protocol' anchor='enter-gc'>
-      <p>In the old groupchat 1.0 protocol, this was done by sending presence with no 'type' attribute to &OCCUPANTJID;, where "room" is the room ID, "service" is the hostname of the chat service, and "nick" is the user's desired nickname within the room:</p>
+      <p>In the old groupchat 1.0 protocol, entering a room was done by sending presence with no 'type' attribute to &OCCUPANTJID;, where "room" is the room ID, "service" is the hostname of the chat service, and "nick" is the user's desired nickname within the room:</p>
       <example caption='User Seeks to Enter a Room (groupchat 1.0)'><![CDATA[
 <presence
     from='hag66@shakespeare.lit/pda'

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -1905,6 +1905,21 @@
     id='ng91xs69'
     to='coven@chat.shakespeare.lit/thirdwitch'/>
 ]]></example>
+      <p>This behavior can not be distinguished from a presence update from a MUC-supporting client that was desynchronized from the room. Treating this as a groupchat 1.0 join will mask the error and leave the client in a partially-synchronized state. Therefore, starting with version 1.32 of this specification, it is RECOMMENDED that a service receiving a &lt;presence&gt; without an &lt;x&gt; element responds with an explicit kick to that client.</p>
+      <example caption='Service Response to groupchat 1.0 join / non-occupant presence update'><![CDATA[
+<presence
+    from='coven@chat.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'>
+  <x xmlns='http://jabber.org/protocol/muc#user'>
+    <item affiliation='none' role='none'>
+      <reason>You are not in the room.</reason>
+    </item>
+    <status code='110'/>
+    <status code='307'/>
+  </x>
+</presence>
+]]></example>
 </section3>
 
   </section2>

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -1905,7 +1905,7 @@
     id='ng91xs69'
     to='coven@chat.shakespeare.lit/thirdwitch'/>
 ]]></example>
-      <p>This behavior can not be distinguished from a presence update from a MUC-supporting client that was desynchronized from the room. Treating this as a groupchat 1.0 join will mask the error and leave the client in a partially-synchronized state. Therefore, starting with version 1.32 of this specification, it is RECOMMENDED that a service receiving a &lt;presence&gt; without an &lt;x&gt; element from a non-occupant full-JID responds with an explicit kick to that client.</p>
+      <p>This behavior can not be distinguished from a presence update from a MUC-supporting client that was desynchronized from the room. Treating this as a groupchat 1.0 join will mask the error and leave the client in a partially-synchronized state. Therefore, starting with version 1.32 of this specification, it is RECOMMENDED that a service receiving a &lt;presence&gt; without an &lt;x&gt; element from a non-occupant full-JID responds with an explicit kick to that client. The kick MUST contain the status codes 110 (occupant's presence), 307 (kick), and 333 (kick due to technical problems).</p>
       <example caption='Service Response to groupchat 1.0 join / non-occupant presence update'><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/thirdwitch'
@@ -1917,6 +1917,7 @@
     </item>
     <status code='110'/>
     <status code='307'/>
+    <status code='333'/>
   </x>
 </presence>
 ]]></example>

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -1397,15 +1397,22 @@
   </section2>
 
   <section2 topic='Entering a Room' anchor='enter'>
-    <section3 topic='Groupchat 1.0 Protocol' anchor='enter-gc'>
-      <p>In order to participate in the discussions held in a multi-user chat room, a user MUST first become an occupant by entering the room. In the old groupchat 1.0 protocol, this was done by sending presence with no 'type' attribute to &OCCUPANTJID;, where "room" is the room ID, "service" is the hostname of the chat service, and "nick" is the user's desired nickname within the room:</p>
-      <example caption='User Seeks to Enter a Room (groupchat 1.0)'><![CDATA[
+    <section3 topic='Basic MUC Protocol' anchor='enter-muc'>
+      <p>In order to participate in the discussions held in a multi-user chat room, a user MUST first become an occupant by entering the room. </p>
+
+      <p>MUC clients MUST signal their ability to speak the MUC protocol by including in the initial presence stanza an empty &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc' namespace (note the absence of the '#user' fragment):</p>
+      <example caption='User Seeks to Enter a Room (Multi-User Chat)'><![CDATA[
 <presence
     from='hag66@shakespeare.lit/pda'
-    id='ng91xs69'
-    to='coven@chat.shakespeare.lit/thirdwitch'/>
+    id='n13mt3l'
+    to='coven@chat.shakespeare.lit/thirdwitch'>
+  <x xmlns='http://jabber.org/protocol/muc'/>
+</presence>
 ]]></example>
+
       <p>In this example, a user with a full JID of "hag66@shakespeare.lit/pda" has requested to enter the room "coven" on the "chat.shakespeare.lit" chat service with a room nickname of "thirdwitch".</p>
+      <p>Note: The presence stanza used to join a room MUST NOT possess a 'type' attribute, i.e., it must be available presence. For further discussion, see the <link url='#bizrules-presence'>Presence</link> business rules.</p>
+
       <p>If the user does not specify a room nickname (note the bare JID on the 'from' address in the following example), the service MUST return a &badjid; error:</p>
       <example caption='No Nickname Specified'><![CDATA[
 <presence
@@ -1416,19 +1423,6 @@
   <error by='coven@chat.shakespeare.lit' type='modify'>
     <jid-malformed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
-</presence>
-]]></example>
-      <p>Note: The presence stanza used to join a room MUST NOT possess a 'type' attribute, i.e., it must be available presence. For further discussion, see the <link url='#bizrules-presence'>Presence</link> business rules.</p>
-    </section3>
-
-    <section3 topic='Basic MUC Protocol' anchor='enter-muc'>
-      <p>Compliant multi-user chat services MUST accept the foregoing as a request to enter a room from any client that knows either the groupchat 1.0 protocol or the multi-user chat (MUC) protocol; however, MUC clients SHOULD signal their ability to speak the MUC protocol by including in the initial presence stanza an empty &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc' namespace (note the absence of the '#user' fragment):</p>
-      <example caption='User Seeks to Enter a Room (Multi-User Chat)'><![CDATA[
-<presence
-    from='hag66@shakespeare.lit/pda'
-    id='n13mt3l'
-    to='coven@chat.shakespeare.lit/thirdwitch'>
-  <x xmlns='http://jabber.org/protocol/muc'/>
 </presence>
 ]]></example>
       <p>Before attempting to enter the room, a MUC-compliant client SHOULD first discover its reserved room nickname (if any) by following the protocol defined in the <link url='#reservednick'>Discovering Reserved Room Nickname</link> section of this document.</p>
@@ -1903,6 +1897,15 @@
         </tr>
       </table>
     </section3>
+    <section3 topic='Groupchat 1.0 Protocol' anchor='enter-gc'>
+      <p>In the old groupchat 1.0 protocol, this was done by sending presence with no 'type' attribute to &OCCUPANTJID;, where "room" is the room ID, "service" is the hostname of the chat service, and "nick" is the user's desired nickname within the room:</p>
+      <example caption='User Seeks to Enter a Room (groupchat 1.0)'><![CDATA[
+<presence
+    from='hag66@shakespeare.lit/pda'
+    id='ng91xs69'
+    to='coven@chat.shakespeare.lit/thirdwitch'/>
+]]></example>
+</section3>
 
   </section2>
 


### PR DESCRIPTION
This patch set delivers (with a bit of delay) on my promise of providing a PR for GC1.0 removal, as discussed and agreed upon in https://mail.jabber.org/pipermail/standards/2018-April/034768.html

It does the following:
* change wording that claims compatibility with GC1.0
* move the GC1 section from the top to the bottom of 'Entering a Room' (thx Zash)
* mandate that a service SHOULD kick a non-occupant sending a GC1.0 join / presence update (thx Kev)