### PR TITLE
XEP-0405: Fix namespace typo in example

### DIFF
--- a/xep-0405.xml
+++ b/xep-0405.xml
@@ -39,6 +39,12 @@
   &ksmithisode;
   &skille;
   <revision>
+    <version>0.4.1</version>
+    <date>2019-04-30</date>
+    <initials>lnj</initials>
+    <remark>Fix typo in the #archive namespace</remark>
+  </revision>
+  <revision>
     <version>0.4.0</version>
     <date>2019-03-19</date>
     <initials>sek</initials>
@@ -209,7 +215,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     <feature var='urn:xmpp:mix:pam:1'/>
-    <feature var='urn:xmpp:mix:pam:1:archive'/>
+    <feature var='urn:xmpp:mix:pam:1#archive'/>
   </query>
 </iq>
 ]]></example>


### PR DESCRIPTION
> In addition to this the server MAY advertize the __'urn:xmpp:mix:pam:1#archive'__ feature