### PR TITLE
Fix shortname of XEP-0315: Data Forms XML Element

### DIFF
--- a/xep-0315.xml
+++ b/xep-0315.xml
@@ -51,7 +51,7 @@
   <p>In certain protocols that make use of &xep0004;, it can be helpful to include XML-data (for example, when we want to insert a big amount of structured data which is hard to insert as a separate fields). This document defines a method for including XML-data in a data form.</p>
 </section1>
 
-<section1 topic='Media Element' anchor='media'>
+<section1 topic='XML Element' anchor='xml-element'>
   <p>The root element for XML-data is &lt;wrapper/&gt;. This element MUST be qualified by the "urn:xmpp:xml-element" namespace. The &lt;wrapper/&gt; element MUST be contained within a &lt;field/&gt; element qualified by the 'jabber:x:data' namespace.</p>
   <p>The &lt;wrapper/&gt; element SHOULD contain an XML-data which needs to be represented in a form.</p>
   <example caption='PubSub Blog Node Metadata'><![CDATA[

--- a/xep-0315.xml
+++ b/xep-0315.xml
@@ -19,7 +19,7 @@
   </dependencies>
   <supersedes/>
   <supersededby/>
-  <shortname>media-element</shortname>
+  <shortname>xml-element</shortname>
   <author>
     <firstname>Sergey</firstname>
     <surname>Dobrov</surname>


### PR DESCRIPTION
The shortname was 'media-element', which is already taken by XEP-0221:
Data Forms Media Element. It is likley that the shortname of XEP-0315
was errorneously set to 'media-element' caused by the author using
XEP-0221 as template for XEP-0315.

Shortnames of XEPs should be unique, hence this changes the shortname
of XEP-0315 from 'media-element' to 'xml-element'.