### PR TITLE
XEP-0166: Relax transport element requirement

### DIFF
--- a/xep-0166.xml
+++ b/xep-0166.xml
@@ -1195,7 +1195,7 @@ PENDING  o-----------------------+   |
     </section3>
     <section3 topic='session-accept' anchor='def-action-session-accept'>
       <p>The <strong>session-accept</strong> action is used to definitively accept a session negotiation (implicitly this action also serves as a content-accept). A session-accept action indicates a willingness to proceed with the session (which might necessitate further negotiation before media can be exchanged). The session-accept action indicates acceptance <em>only</em> of the content definition(s) whose disposition type is "session" (the default value of the &CONTENT; element's 'disposition' attribute), not any content definition(s) whose disposition type is something other than "session" (e.g., "early-session" for early media).</p>
-      <p>In the session-accept stanza, the &JINGLE; element MUST contain one or more &lt;content/&gt; elements, each of which MUST contain one &lt;description/&gt; element and one &lt;transport/&gt; element.</p>
+      <p>In the session-accept stanza, the &JINGLE; element MUST contain one or more &lt;content/&gt; elements, each of which MUST contain one &lt;description/&gt; element and one &lt;transport/&gt; element or no &lt;transport/&gt; if it was negotiatied with a transport-replace request earlier.</p>
     </section3>
     <section3 topic='session-info' anchor='def-action-session-info'>
       <p>The <strong>session-info</strong> action is used to send session-level information, such as a session ping or (for Jingle RTP sessions) a ringing message.</p>


### PR DESCRIPTION
It's possible a responder may want to replace transport before session/content accept.
In this case it's necessary to send initial transport offer twice (with replace and with accept) which basically looks wrong.
Instead it's better to omit transport element when it was already negotiated.

This change probably needs ns bump.
