### PR TITLE
xep-0371: fix gathering-complete text

### DIFF
--- a/xep-0371.xml
+++ b/xep-0371.xml
@@ -715,7 +715,7 @@ Romeo                    Gateway                    Juliet
 
 <section1 topic='Informational Messages' anchor='info'>
   <p>Informational messages can be sent by either party within the context of Jingle to communicate the status of a Jingle ICE "session".  The informational message MUST be an IQ-set containing a &JINGLE; element of type "transport-info", where the informational message is a payload element qualified by the 'urn:xmpp:jingle:transports:ice:info:0' namespace.</p>
-  <p>The only payload element defined so far is the &lt;ice-gathering-complete/&gt; element. This element is used only to signal that gathering of ICE candidates has been completed (i.e., to send an "end-of-candidates indication"), as in the following example.</p>
+  <p>The only payload element defined so far is the &lt;gathering-complete/&gt; element. This element is used only to signal that gathering of ICE candidates has been completed (i.e., to send an "end-of-candidates indication"), as in the following example.</p>
   <example caption="Responder sends end-of-candidates indication"><![CDATA[
 <iq from='juliet@capulet.example/yn0cl4bnw0yr3vym'
     id='xv39z423'


### PR DESCRIPTION
Fixes the text to use the correct element name which is used in the sample and the schema