### PR TITLE
MUC Self-Ping (XEP-0410): Clarify the feature string

### DIFF
--- a/xep-0410.xml
+++ b/xep-0410.xml
@@ -199,7 +199,7 @@
       to a occupant's Ping request to the occupant's own nickname, as
       opposed to routing it to any of the occupant's clients. A service
       implementing this optimization needs to advertise the
-      <tt>self-ping-optimization</tt> feature in the &xep0030; response on
+      <tt>http://jabber.org/protocol/muc#self-ping-optimization</tt> feature in the &xep0030; disco#info response on
       the individual MUC room JIDs, and it MUST respond to a self-ping request
       as follows:</p>
     <ul>


### PR DESCRIPTION
Although the example shows the correct string, the normative text
potentially leaves the impression that the feature string is only
'self-ping-optimization', i.e. without the
'http://jabber.org/protocol/muc#' prefix.