### PR TITLE
XEP-0128: Remove 'unlikely' statement.

### DIFF
--- a/xep-0128.xml
+++ b/xep-0128.xml
@@ -156,7 +156,7 @@
   </section2>
 </section1>
 <section1 topic='Implementation Notes' anchor='impl'>
-  <p>In general, the XMPP Standards Foundation may choose to define at most one FORM_TYPE for each service discovery identity (category+type) registered with the XMPP Registrar. In addition, particular applications may define application-specific FORM_TYPEs as well, and one entity may have multiple service discovery identities (e.g., an XMPP server might also function as a publish-subscribe service). Therefore, it is possible (and allowed) for a single service discovery result to contain multiple service discovery extension elements (potentially up to two elements for each identity). However, in practice it is unlikely that any given service discovery result will contain more than one service discovery extension element.</p>
+  <p>In general, the XMPP Standards Foundation may choose to define at most one FORM_TYPE for each service discovery identity (category+type) registered with the XMPP Registrar. In addition, particular applications may define application-specific FORM_TYPEs as well, and one entity may have multiple service discovery identities (e.g., an XMPP server might also function as a publish-subscribe service). Therefore, it is possible (and allowed) for a single service discovery result to contain multiple service discovery extension elements (potentially up to two elements for each identity).</p>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
   <p>Applications SHOULD ensure that information disclosed in a disco extension is appropriate for discovery by any entity on the network.</p>


### PR DESCRIPTION
With various XEPs (XEP-0157, XEP-0232, XEP-0363) depending on Service Discovery Extensions,
it is no longer 'unlikely' that more than one extension is added.