### PR TITLE
ProtoXEP: Anonymous unique occupant identifiers for MUCs

### DIFF
--- a/inbox/occupant-id.xml
+++ b/inbox/occupant-id.xml
@@ -1,0 +1,212 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+        <!ENTITY % ents SYSTEM 'xep.ent'>
+        %ents;
+        ]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+<header>
+  <title>Anonymous unique occupant identifiers for MUCs</title>
+  <abstract>This specification defines a method that allows clients to identify a MUC participant across reconnects and renames. It thus prevents impersonification of anonymous users.</abstract>
+  &LEGALNOTICE;
+  <number>xxxx</number>
+  <status>ProtoXEP</status>
+  <type>Standards Track</type>
+  <sig>Standards</sig>
+  <approver>Council</approver>
+  <dependencies>
+    <spec>XMPP Core</spec>
+    <spec>XEP-0001</spec>
+    <spec>XEP-0030</spec>
+    <spec>XEP-0045</spec>
+  </dependencies>
+  <supersedes/>
+  <supersededby/>
+  <shortname>occupant-id</shortname>
+  <author>
+    <firstname>Marvin</firstname>
+    <surname>Wissfeld</surname>
+    <email>xsf@larma.de</email>
+    <jid>jabber@larma.de</jid>
+  </author>
+  <revision>
+    <version>0.0.1</version>
+    <date>2019-07-13</date>
+    <initials>mw</initials>
+    <remark><p>First draft.</p></remark>
+  </revision>
+</header>
+<section1 topic='Introduction' anchor='intro'>
+  <p>
+    &xep0045; allows the creation of semi-anonymous multi-user text chats where
+    the real JID of a occupant can not be discovered by other MUC
+    occupants except moderators. As such users can freely join with using
+    any identity of their choice, allowing to impersonate users while they are
+    not online.
+  </p>
+  <p>
+    With recent standard extensions, it becomes more relevant to be able to
+    know if the occupant that sends one message is the same as the sender
+    of another message, for example for &xep0308;. At the same time it becomes
+    harder for clients to determine this, for example due to the use of &xep0313;
+    with MUCs.
+  </p>
+  <p>
+    This specification defines a method to combat issues arising out of the
+    anonymity of MUC occupants while at the same time ensuring their privacy
+    by not leaking their real JID to other occupants.
+  </p>
+</section1>
+<section1 topic='Discovering support' anchor='disco'>
+  <p>
+    If a MUC implements anonymous unique occupant identifiers, it MUST
+    specify the 'urn:xmpp:occupant-id:0' feature in its service discovery
+    information features as specified in &xep0030;.
+  </p>
+  <example caption='Client requests information about a MUC'><![CDATA[
+<iq type='get'
+    to='coven@chat.shakespeare.lit'
+    from='hag66@shakespeare.lit/pda'
+    id='info1'>
+  <query xmlns='http://jabber.org/protocol/disco#info'/>
+</iq>]]></example>
+  <example caption='MUC advertises support for anonymous unique occupant identifiers'><![CDATA[
+<iq type='result'
+    to='hag66@shakespeare.lit/pda'
+    from='coven@chat.shakespeare.lit'
+    id='info1'>
+  <query xmlns='http://jabber.org/protocol/disco#info'>
+...
+    <feature var='urn:xmpp:occupant-id:0'/>
+...
+  </query>
+</iq>]]></example>
+</section1>
+<section1 topic='Use Cases' anchor='usecases'>
+  <section2 topic="Entering a Room" anchor="enter">
+    <p>
+      When a user enters a room, they send a presence to claim the nickname in
+      the MUC. A MUC that supports anonymous unique occupant identifiers
+      attaches an &lt;occupant-id&gt; element to the presence sent to all
+      occupants in the room.
+    </p>
+    <example caption="Client sends a message"><![CDATA[
+<presence
+    from='hag66@shakespeare.lit/pda'
+    id='n13mt3l'
+    to='coven@chat.shakespeare.lit/thirdwitch'>
+  <x xmlns='http://jabber.org/protocol/muc'/>
+</presence>]]></example>
+    <example caption="Service Sends New Occupant's Presence to All Occupants"><![CDATA[
+<presence
+    from='coven@chat.shakespeare.lit/thirdwitch'
+    id='27C55F89-1C6A-459A-9EB5-77690145D624'
+    to='crone1@shakespeare.lit/desktop'>
+  <x xmlns='http://jabber.org/protocol/muc#user' />
+  <occupant-id xmlns="urn:xmpp:occupant-id:0" id="dd72603deec90a38ba552f7c68cbcc61bca202cd" />
+</presence>]]></example>
+  </section2>
+    <section2 topic="Sending a Message to All Occupants" anchor="message">
+      <p>
+        An occupant sends a message to all other occupants in the room by
+        sending a message of type "groupchat" to the &lt;room@service&gt;. A MUC
+        supporting anonymous unique occupant identifiers attaches an
+        &lt;occupant-id&gt; element to the message sent to all occupants in the
+        room.
+      </p>
+    <example caption="Occupant Sends a Message to All Occupants"><![CDATA[
+<message
+    from='hag66@shakespeare.lit/pda'
+    id='hysf1v37'
+    to='coven@chat.shakespeare.lit'
+    type='groupchat'>
+  <body>Harpier cries: 'tis time, 'tis time.</body>
+</message>]]></example>
+    <example caption="Service Reflects Message to All Occupants"><![CDATA[
+<message
+    from='coven@chat.shakespeare.lit/thirdwitch'
+    id='hysf1v37'
+    to='crone1@shakespeare.lit/desktop'
+    type='groupchat'>
+  <body>Harpier cries: 'tis time, 'tis time.</body>
+  <occupant-id xmlns="urn:xmpp:occupant-id:0" id="dd72603deec90a38ba552f7c68cbcc61bca202cd" />
+</message>]]></example>
+  </section2>
+</section1>
+<section1 topic='Business Rules' anchor='rules'>
+  <p>
+    Messages and presences MUST NOT contain more then one &lt;occupant-id&gt;
+    element. If the message or presence received by the MUC service already
+    contains &lt;occupant-id&gt; element, the MUC service MUST replace such
+    element before reflecting the message or presence including it.
+  </p>
+  <p>
+    The &lt;occupant-id&gt; element MUST be attached to every message and every
+    presence sent by a MUC. This includes messages sent as part of the
+    discussion history after joining a room, requested via &xep0313; or any
+    other means.
+  </p>
+  <p>
+    The &lt;occupant-id&gt; element MUST be ignored if support for the feature
+    is not announced via &xep0030;, as malicious clients might forge occupant
+    identifiers if the room does not support them.
+  </p>
+  <p>
+    A MUC service MAY allow the administrator to enable or disable occupant
+    identifiers on a per-room basis. If occupant identifiers are force enabled
+    for all rooms on a MUC service, it SHOULD additionally specify the 
+    'urn:xmpp:occupant-id:0' feature on the MUC service. It MUST NOT specify
+    the feature on the service otherwise.
+  </p>
+  <section2 topic='Occupant ID generation' anchor='id-generation'>
+    <p>
+      The occupant identifier MUST be generated such that it is stable. This
+      means that if a user joins the same room a second time, the occupant
+      identifier MUST be the same as was assigned the first time. A user in
+      the sense of this specification is identified by its real bare JID.
+    </p>
+    <p>
+      The occupant identifier MUST be generated such that it is unique. This
+      means that it MUST be sufficiently improbable that one user is able to
+      re-create the occupant identifier of another user.
+    </p>
+    <p>
+      The occupant identifier MUST be generated such that it is anonymous. This
+      means that it MUST be sufficiently hard to determine the real bare JID of
+      an occupant from its occupant identifier. Additionally, a MUC service
+      SHOULD generate the identifier such that the occupant identifier of a user
+      in one room of the service does not match the occupant identifier of the
+      same user in another room of the same service.
+    </p>
+    <p>
+      The occupant identifier MUST have a maximum length of 128 characters. The
+      recipient MUST consider the occupant identifier to be an opaque string.
+    </p>
+    <p>
+      One way to ensure these properties is to generate a private secret key for
+      every room and use an HMAC algorithm with a sufficiently secure hash
+      function to generate the occupant identifier from the real bare JID and
+      that secret key. This procedure ensures all the required properties with
+      minimal server side storage requirements.
+    </p>
+  </section2>
+</section1>
+<section1 topic='Security Considerations' anchor='security'>
+  <p>
+    If a MUC uses occupant identifiers, nickname changes will be visible to
+    all occupants of the room. Clients MAY warn users about this circumstance
+    before joining the room.
+  </p>
+</section1>
+<section1 topic='IANA Considerations' anchor='iana'>
+  <p>This document requires no interaction with &IANA;.</p>
+</section1>
+<section1 topic='XMPP Registrar Considerations' anchor='registrar'>
+  <section2 topic='Protocol Namespaces' anchor='ns'>
+    <p>The &REGISTRAR; includes 'urn:xmpp:occupant-id:0' in its registry of protocol namespaces (see &NAMESPACES;).</p>
+    <ul>
+      <li>urn:xmpp:occupant-id:0</li>
+    </ul>
+  </section2>
+</section1>
+</xep>


### PR DESCRIPTION
> This specification defines a method that allows clients to identify a MUC participant across reconnects and renames. It thus prevents impersonification of anonymous users.