### PR TITLE
XEP-0387: Obsolete Compliance Suites 2018

### DIFF
--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -18,7 +18,7 @@
     </abstract>
     &LEGALNOTICE;
     <number>0387</number>
-    <status>Draft</status>
+    <status>Obsolete</status>
     <lastcall>2017-12-21</lastcall>
     <lastcall>2017-11-15</lastcall>
     <type>Standards Track</type>
@@ -52,7 +52,9 @@
     <supersedes>
       <spec>XEP-0375</spec>
     </supersedes>
-    <supersededby/>
+    <supersededby>
+      <spec>XEP-0412</spec>
+    </supersededby>
     <shortname>CS2018</shortname>
     &sam;
     &jonaswielicki;

--- a/xep-0412.xml
+++ b/xep-0412.xml
@@ -49,7 +49,7 @@
       <spec>XEP-0368</spec>
     </dependencies>
     <supersedes>
-      <spec>XEP-0378</spec>
+      <spec>XEP-0387</spec>
     </supersedes>
     <supersededby/>
     <shortname>CS2019</shortname>


### PR DESCRIPTION
Now that [Compliance Suites 2019](https://xmpp.org/extensions/xep-0412.xml) has been published, we shouldn’t keep the [2018 version](https://xmpp.org/extensions/xep-0387.xml) lingering in Draft status for any longer.