### PR TITLE
XEP-0060: Add a pubsub#rsm disco#info feature to clear confusion

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -2236,6 +2236,7 @@ And by opposing end them?
     </section3>
     <section3 topic='Returning Some Items' anchor='subscriber-retrieve-returnsome'>
       <p>A node may have a large number of items associated with it, in which case it may be problematic to return all of the items in response to an items request. In this case, the service SHOULD return some of the items and note that the list of items has been truncated by including a &xep0059; notation.</p>
+      <p>A Pubsub entity supporting &xep0059; SHOULD include a feature of "http://jabber.org/protocol/pubsub#rsm" in its disco#info response, to make it clear that the RSM feature is for PubSub, and not for e.g., &xep0313;.</p>
       <example caption='Service returns some items via result set management'><![CDATA[
 <iq type='result'
     from='pubsub.shakespeare.lit'


### PR DESCRIPTION
This will already be useful as is. Some more PRs should follow regarding RSM/Order-by, and more specific disco#info features in other XEPs.

Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>