### PR TITLE
XEP-0045: Add Tags configuration and metadata to XEP-0045: Multi-User Chat

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -1211,7 +1211,7 @@
 </iq>
 ]]></example>
     <p>Note: The room SHOULD return the materially-relevant features it supports, such as password protection and room moderation (these are listed fully in the feature registry maintained by the XMPP Registrar; see also the <link url='#registrar'>XMPP Registrar</link> section of this document).</p>
-    <p>A chatroom MAY return more detailed information in its disco#info response using &xep0128;, identified by inclusion of a hidden FORM_TYPE field whose value is "http://jabber.org/protocol/muc#roominfo". Such information might include a more verbose description of the room, the current room subject, and the current number of occupants in the room:</p>
+    <p>A chatroom MAY return more detailed information in its disco#info response using &xep0128;, identified by inclusion of a hidden FORM_TYPE field whose value is "http://jabber.org/protocol/muc#roominfo". Such information might include a more verbose description of the room, the current room subject, some related tags and the current number of occupants in the room:</p>
     <example caption='Room Returns Extended Disco Info Result'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='ik3vs715'
@@ -1256,6 +1256,11 @@
       <field var='muc#roominfo_occupants'
              label='Number of occupants'>
         <value>3</value>
+      </field>
+      <field var='muc#roominfo_tags'
+             label='Tags'>
+        <value>witches</value>
+        <value>coven</value>
       </field>
       <field var='muc#roominfo_ldapgroup'
              label='Associated LDAP Group'>
@@ -3901,6 +3906,10 @@
           type='text-single'
           var='muc#roomconfig_roomdesc'/>
       <field
+          label='Room Tags'
+          type='text-multi'
+          var='muc#roomconfig_tags'/>
+      <field
           label='Natural Language for Room Discussions'
           type='text-single'
           var='muc#roomconfig_lang'/>
@@ -4083,6 +4092,10 @@
       <field var='muc#roomconfig_roomdesc'>
         <value>The place for all good witches!</value>
       </field>
+      <field var='muc#roomconfig_tags'>
+        <value>coven</value>
+        <value>witches</value>
+      </field>
       <field var='muc#roomconfig_enablelogging'>
         <value>0</value>
       </field>
@@ -4216,6 +4229,13 @@
           type='text-single'
           var='muc#roomconfig_roomdesc'>
         <value>The place for all good witches!</value>
+      </field>
+      <field
+          label='The Room Tags'
+          type='text-multi'
+          var='muc#roomconfig_tags'>
+        <value>coven</value>
+        <value>witches</value>
       </field>
       <field
           label='Enable Public Logging?'
@@ -5295,6 +5315,10 @@
       type='text-single'
       label='The Room Password'/>
   <field
+      var='muc#roomconfig_tags'
+      type='text-multi'
+      label='The Room Tags'/>
+  <field
       var='muc#roomconfig_whois'
       type='list-single'
       label='Affiliations that May Discover Real JIDs of Occupants'/>
@@ -5352,6 +5376,10 @@
       var='muc#roominfo_subjectmod'
       type='boolean'
       label='The room subject can be modified by participants'/>
+  <field
+      var='muc#roomconfig_tags'
+      type='text-multi'
+      label='The Room Tags'/>
 </form_type>
 ]]></code>
     </section3>


### PR DESCRIPTION
This allow MUC admins to set some tags beside the title and description to allow better indexation and researches between chatrooms.