### PR TITLE
XEP-0372: Fix incorrect pubsub URIs

### DIFF
--- a/xep-0372.xml
+++ b/xep-0372.xml
@@ -29,7 +29,7 @@
     <version>0.3</version>
     <date>2019-09-04</date>
     <initials>(mb)</initials>
-    <remark>Make Pubsub URIs conform to RFC5222 in sections 3.3 and 3.4</remark>
+    <remark>Make Pubsub URIs in sections 3.3 and 3.4 conform to &xep0147;.</remark>
   </revision>
   <revision>
     <version>0.2</version>

--- a/xep-0372.xml
+++ b/xep-0372.xml
@@ -29,7 +29,7 @@
     <version>0.3</version>
     <date>2019-09-04</date>
     <initials>(mb)</initials>
-    <remark>Make Pubsub URIs in sections 3.3 and 3.4 conform to &xep0147;.</remark>
+    <remark>Make Pubsub URIs in sections 3.3 and 3.4 conform to XEP-0147.</remark>
   </revision>
   <revision>
     <version>0.2</version>

--- a/xep-0372.xml
+++ b/xep-0372.xml
@@ -26,6 +26,12 @@
   <shortname>Refs</shortname>
   &ksmithisode;
   <revision>
+    <version>0.3</version>
+    <date>2019-09-04</date>
+    <initials>(mb)</initials>
+    <remark>Make Pubsub URIs conform to RFC5222 in sections 3.3 and 3.4</remark>
+  </revision>
+  <revision>
     <version>0.2</version>
     <date>2017-09-11</date>
     <initials>XEP Editor (jwi)</initials>

--- a/xep-0372.xml
+++ b/xep-0372.xml
@@ -114,7 +114,7 @@
   <body>Form received</body>
   <reference xmlns='urn:xmpp:reference:0'
              type='data'
-             uri='xmpp:fdp.shakespeare.lit?node=fdp/submitted/stan.isode.net/accidentreport&item=ndina872be'/>
+             uri='xmpp:fdp.shakespeare.lit?;node=fdp/submitted/stan.isode.net/accidentreport;item=ndina872be'/>
 </message>
 ]]></example>
   </section2>
@@ -127,10 +127,10 @@
          to='romeo@montegue.lit/30d3d8'>
   <reference xmlns='urn:xmpp:reference:0'
              type='data'
-             anchor='xmpp:balcony@channels.shakespeare.lit?node=messages&item=bnhob'
+             anchor='xmpp:balcony@channels.shakespeare.lit?;node=messages;item=bnhob'
              begin='72'
              end='78'
-             uri='xmpp:fdp.shakespeare.lit?node=fdp/submitted/stan.isode.net/accidentreport&item=ndina872be'/>
+             uri='xmpp:fdp.shakespeare.lit?;node=fdp/submitted/stan.isode.net/accidentreport;item=ndina872be'/>
 </message>
 ]]></example>
   </section2>


### PR DESCRIPTION
All these URIs were missing a ";".

Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>