### PR TITLE
XEP-0393: clarify quote termination and trimming

### DIFF
--- a/xep-0393.xml
+++ b/xep-0393.xml
@@ -26,6 +26,16 @@
   <shortname>styling</shortname>
   &sam;
   <revision>
+    <version>0.2.0</version>
+    <date>2019-09-02</date>
+    <initials>ssw</initials>
+    <remark>
+      <p>
+        Clarify block quote termination and white space trimming.
+      </p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.1.4</version>
     <date>2018-05-01</date>
     <initials>ssw</initials>
@@ -276,9 +286,12 @@
       <p>
         A quotation is indicated by one or more lines with a byte stream
         beginning with a '&gt;' (U+003E GREATER-THAN SIGN).
+        They are terminated by the first new line that is not followed by a
+        greater-than sign, or the end of the parent block (whichever comes
+        first).
         Block quotes may contain any child block, including other quotations.
-        Lines inside the block quote MUST have leading spaces trimmed before
-        parsing the child block.
+        Lines inside the block quote MUST have the first leading whitespace
+        character trimmed before parsing the child block.
         It is RECOMMENDED that text inside of a block quote be indented or
         distinguished from the surrounding text in some other way.
       </p>


### PR DESCRIPTION
Tweak whitespace trimming in block quotes to indicate that only the first space should be trimmed. Also clarify how block quotes are terminated.