### PR TITLE
XEP-0280: remove error note, add XEP-0333

### DIFF
--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -298,8 +298,8 @@
     <ul>
       <li>it is of type "chat".</li>
       <li>it is of type "normal" and contains a &lt;body&gt; element.</li>
-      <li>it contains payload elements typically used in IM (&xep0184;, &xep0085;).</li>
-      <li>it is of type "error" and it was sent in response to a &MESSAGE; that was eligible for carbons delivery (Note that as this would require message tracking and correlation on the server, it is unlikely to be generally appropriate for most implementations).</li>
+      <li>it contains payload elements typically used in IM (&xep0184;, &xep0085;, &xep0333;).</li>
+      <li>it is of type "error" and it was sent in response to a &MESSAGE; that was eligible for carbons delivery.</li>
       <li>it matches the MUC-related rules outlined below.</li>
     </ul>
     <p>To properly handle messages exchanged with a MUC (or similar service), the server must be able to identify MUC-related messages. This can be accomplished by tracking the clients' presence in MUCs, or by checking for the <tt>&lt;x xmlns="http://jabber.org/protocol/muc#user"&gt;</tt> element in messages. The following rules apply to MUC-related messages:


### PR DESCRIPTION
These are some editorial changes of the Carbon Eligibility Rules:

* removed the "note" regarding non-tracking of message errors, because it was just a note and message errors **are** important.
* added XEP-0333 as another example for "typical" IM payloads