### PR TITLE
XEP-0084: Use an existing XML Schema data type for bytes

### DIFF
--- a/xep-0084.xml
+++ b/xep-0084.xml
@@ -38,6 +38,12 @@
   &temas;
   &xvirge;
   <revision>
+    <version>1.1.4</version>
+    <date>2019-09-20</date>
+    <initials>egp</initials>
+    <remark><p>Use xs:unsignedInt for bytes, the previous revision introduced xs:unsignedInteger which isn’t a valid XML Schema data type.</p></remark>
+  </revision>
+  <revision>
     <version>1.1.3</version>
     <date>2019-09-11</date>
     <initials>vv</initials>
@@ -595,7 +601,7 @@
     <xs:complexType>
       <xs:simpleContent>
         <xs:extension base='empty'>
-          <xs:attribute name='bytes' type='xs:unsignedInteger' use='required'/>
+          <xs:attribute name='bytes' type='xs:unsignedInt' use='required'/>
           <xs:attribute name='height' type='xs:unsignedShort' use='optional'/>
           <xs:attribute name='id' type='xs:string' use='required'/>
           <xs:attribute name='type' type='xs:string' use='required'/>


### PR DESCRIPTION
The previous revision was using `xs:unsignedInteger` which isn’t defined.