### PR TITLE
Message Retractions protoXEP

### DIFF
--- a/inbox/message-retraction.xml
+++ b/inbox/message-retraction.xml
@@ -16,11 +16,22 @@
   <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
+    <spec>XMPP IM</spec>
+    <spec>XEP-0313</spec>
+    <spec>XEP-0421</spec>
+    <spec>XEP-0422</spec>
   </dependencies>
   <supersedes/>
   <supersededby/>
   <shortname>message-retract</shortname>
   &lance;
+  &jcbrand;
+   <revision>
+    <version>0.0.4</version>
+    <date>2019-09-25</date>
+    <initials>jcb</initials>
+    <remark><p>Remove MUC moderation use-case which will go into a separate XEP</p></remark>
+  </revision>
    <revision>
     <version>0.0.3</version>
     <date>2016-10-19</date>
@@ -41,20 +52,22 @@
   </revision>
 </header>
 <section1 topic='Introduction' anchor='intro'>
-  <p>Occasionally, a &xep0045; room moderator or admin might wish to retract certain chat messages from the room history as part of an effort to address and remedy issues such as message spam, indecent language for the venue, exposing private third-party personal information, etc. However, as with any content moderation tool, the retraction request can <strong>only be considered as a hint</strong> and by itself can not prevent or undo any potential damage caused by the offending message, as clients which don't support message deletion are not obligated to enforce the deletion request and people could have seen or copied the message content already.</p>
+  <p>A chat participant might want to retract a message which they've already sent out, for example if they've mistakenly sent it to the wrong recipient or groupchat.</p>
+  <p>Due to the federated and extensible nature of XMPP it's not possible to remove a message with full certainty and a retraction can only be considered an <strong>unenforceable request</strong> for such removal. Clients which don't support message retraction are not obligated to enforce the request and people could have seen or copied the message contents already.</p>
 </section1>
 <section1 topic='Discovering support' anchor='disco'>
-  <p>If a client or service implements message deletion, it MUST specify the 'urn:xmpp:message-retract:0' feature in its service discovery information features as specified in &xep0030; and the Entity Capabilities profile specified in &xep0115;.</p>
+  <p>If a client or service implements message retraction, it MUST specify the 'urn:xmpp:message-retract:0' feature in its service discovery information features as specified in &xep0030; and the Entity Capabilities profile specified in &xep0115;.</p>
     <example caption='Client requests information about a chat partner&apos;s client'><![CDATA[
 <iq type='get'
-    from='romeo@montague.net/orchard'
+    from='romeo@montague.example/orchard'
+    to='juliet@capulet.example/balcony'
     id='info1'>
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>]]></example>
     <example caption='Partner&apos;s client advertises support for retraction'><![CDATA[
-<iq type='get'
-    to='romeo@montague.net/home'
-    from='montague.net'
+<iq type='result'
+    to='romeo@montague.example/orchard'
+    from='juliet@capulet.example/balcony'
     id='info1'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
 ...
@@ -64,41 +77,51 @@
 </iq>]]></example>
 </section1>
 <section1 topic='Use Case' anchor='usecase'>
-  <p>When a user indicates to the client that a sent message (or a received message for MUC room moderators) is meant to be retracted, the client will send a new message containing a &lt;retract /&gt; element with the "urn:xmpp:message-retract:0" namespace, with an id attribute set to the id of the message to be retracted.</p>
-  <example caption='User sends a message with a mistake in'><![CDATA[
-<message to='room@muc.example.com' id='bad1'>
-  <body>This message contained information not meant for this room.</body>
+  <p>Consider a situation where a user sends a message to the wrong recipient: </p>
+  <example caption="The user's client sends a message to the wrong recipient"><![CDATA[
+<message type='chat' to='lord@capulet.example' id='wrong-recipient-1'>
+  <body>Have not saints lips, and holy palmers too?</body>
+  <origin-id xmlns='urn:xmpp:sid:0' id='origin-id-1'/>
 </message>]]></example>
-  <example caption='User indicates that the message should be retracted'><![CDATA[
-<message to='room@muc.example.com' id='retract1'>
-  <retract id='bad1' xmlns='urn:xmpp:message-retract:0'/>
+
+  <p>The message author notices that the message was sent to the wrong recipient and indicates to their client that the message should be retracted.</p>
+  <p>The client sends out a retraction message which uses &xep0422; to indicate that it applies to the wrongly sent message by referring to its XEP-0359 origin ID.</p>
+
+  <example caption="The client sends out a retraction message"><![CDATA[
+<message type='chat' to='lord@capulet.example' id='retract-message-1'>
+  <apply-to id="origin-id-1" xmlns="urn:xmpp:fasten:0">
+    <retract xmlns='urn:xmpp:message-retract:0'/>
+  </apply-to>
 </message>]]></example>
 </section1>
+
 <section1 topic='Tombstones' anchor='tombstones'>
-  <p>An archiving service MAY replace the contents of a retracted message with a 'tombstone' recording the fact that the message was retracted (but otherwise preserving the fact that the message did once exist in order to aid synchronizing archives). To do so, the archiving service replaces the contents of the message with a &lt;retracted/&gt; element qualified by the 'urn:xmpp:message-retract:0' namespace, which SHOULD include a 'by' attribute specifying the JID of the entity that sent the retraction.</p>
+  <p>An archiving service MAY replace a retracted message with a 'tombstone' recording the fact that the message was retracted (but otherwise preserving the fact that the message did once exist in order to aid synchronizing archives). The message gets replaced with a &lt;retracted/&gt; element which SHOULD include a 'by' attribute specifying the JID of the entity that sent the retraction and a 'stamp' attribute indicating the time at which the retraction took place.</p>
+
   <example caption='Retracted message tombstone in a MAM result'><![CDATA[
-<message id='aeb213' to='juliet@capulet.lit/chamber'>
-  <result xmlns='urn:xmpp:mam:1' queryid='f27' id='28482-98726-73623'>
+<message id='aeb213' to='lord@capulet.example/chamber'>
+  <result xmlns='urn:xmpp:mam:2' queryid='f27' id='28482-98726-73623'>
     <forwarded xmlns='urn:xmpp:forward:0'>
-      <delay xmlns='urn:xmpp:delay' stamp='2010-07-10T23:08:25Z'/>
-      <message xmlns='jabber:client' from="witch@shakespeare.lit" to="macbeth@shakespeare.lit">
-        <retracted xmlns='urn:xmpp:message-retract:0' by='witch@shakespeare.lit' />
-      </message>
-    </forwarded>
-  </result>
+      <delay xmlns='urn:xmpp:delay' stamp='2019-09-20T23:08:25Z'/>
+      <retracted by="romeo@montague.example" stamp='2019-09-20T23:09:32Z' xmlns='urn:xmpp:message-retract:0' />
+  </forwarded>
+</result>
 </message>]]></example>
 </section1>
+
 <section1 topic='Business Rules' anchor='rules'>
-  <p>A receiving client can choose to remove the indicated message from whatever display is used for messages, from any stored history, or choose to display the fact that a message has been removed in another way.</p>
-  <p>A MUC or other service that supports message retraction SHOULD prevent further distribution of the message by the service (e.g., by not replaying the message to new occupants joining the room, omitting the message from history archive requests where possible, or replacing the original message with a 'tombstone').</p>
+  <p>A receiving client can choose to remove the retracted message from whatever display is used for messages, from any stored history, or choose to display the fact that a message has been retracted in another way.</p>
+  <p>A MUC or other service that supports message retraction SHOULD prevent further distribution of the message by the service (e.g., by not replaying the message to new occupants joiningthe room, omitting the message from history archive requests where possible, or replacing the original message with a 'tombstone').</p>
+  <p>Some clients may have been offline while the retraction was issued. The archiving service therefore MUST store the retraction message, regardless of whether the original message is deleted or replaced with a tombstone. These clients will then become aware of the retraction as soon as they catch up with the archive.</p>
   <p>A client MAY inform the user that a no-longer displayed message did previously exist and has been removed.</p>
-  <p>Clients and services MUST set the 'id' attribute on messages if they allow for message retraction.</p>
+  <p>Clients MUST set the XEP-0359 'origin id' attribute on sent messages to make them suitable for message retraction.</p>
   <p>The Sender MUST NOT send a retraction request for a message with non-messaging payloads. For example, a sender MUST NOT send a retraction for a roster item exchange request or a file transfer part.</p>
-  <p>A retraction MUST only be processed when both the original message and retraction request are received from the same full-JID (or from a JID of an appropriate admin or moderator in the case of a MUC room.)</p>
+  <p>A retraction (that's not part of a protoXEP message moderation operation) MUST only be processed when both the original message and the retraction request are received from the same bare-JID (in a one-on-one conversation) or full-JID (in a non-anonymous MUC from &xep0045;).</p>
+  <p>When used in a semi-anonymous MUC, the recipient client MUST check that a message retraction was sent by the author of the retracted message by checking the occupant id from &xep0421;.</p>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
   <p>There can never be a guarantee that a retracted message was never seen or otherwise distributed, and it is encouraged for clients and services when possible to inform users that no such guarantee exists.</p>
-  <p>When used in a &xep0045; context, retractions sent by non-moderators must not be allowed (by the receiver) for messages received before the sender joined the room - particularly a full JID leaving the room then rejoining and retracting a message SHOULD be disallowed, as the entity behind the full JID in the MUC may have changed.</p>
+  <p>To prevent message spoofing, it's very important that the JID or occupant id of message retractions are checked (as explained in the  <link url='#rules'>Business Rules</link> section).</p>
 </section1>
 <section1 topic='IANA Considerations' anchor='iana'>
   <p>None.</p>
@@ -124,21 +147,15 @@
     xmlns='urn:xmpp:message-retract:0'
     elementFormDefault='qualified'>
 
-  <xs:element name='retract'>
-    <xs:complexType>
-      <xs:simpleContent>
-        <xs:extension base='xs:string'>
-          <xs:attribute name='id' type='xs:string' use='required'/>
-        </xs:extension>
-      </xs:simpleContent>
-    </xs:complexType>
-  </xs:element>
+  <xs:element name='retract'></xs:element>
 
   <xs:element name='retracted'>
     <xs:complexType>
       <xs:simpleContent>
         <xs:extension base='xs:string'>
-          <xs:attribute name='by' type='xs:string' use='optional'/>
+          <xs:attribute name='by' type='xs:string' use='required'/>
+          <xs:attribute name='from' type='xs:string' use='optional'/>
+          <xs:attribute name='stamp' type='xs:dateTime' use='required'/>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>

--- a/xep-0402.xml
+++ b/xep-0402.xml
@@ -24,12 +24,7 @@
         <registry/>
         <discuss>standards</discuss>
         &dcridland;
-        <author>
-            <firstname>Jan-Carel</firstname>
-            <surname>Brand</surname>
-            <email>jc@opkode.com</email>
-            <jid>jc@opkode.com</jid>
-        </author>
+        &jcbrand;
   <revision>
     <version>0.2.1</version>
     <date>2018-07-22</date>

--- a/xep.ent
+++ b/xep.ent
@@ -1097,6 +1097,14 @@ IANA Service Location Protocol, Version 2 (SLPv2) Templates</link></span> <note>
     <jid>linkmauve@linkmauve.fr</jid>
   </author>
 " >
+<!ENTITY jcbrand "
+  <author>
+    <firstname>JC</firstname>
+    <surname>Brand</surname>
+    <email>jc@opkode.com</email>
+    <jid>jc@opkode.com</jid>
+  </author>
+" >
 
 <!-- XMPP Extension Protocols -->
 


### PR DESCRIPTION
* The MUC moderation use-case will be split out into a different XEP
* Update this XEP to handle the case where a user retracts their own message
* Use XEP-0422 for the retraction message
* Mention in security considerations that the XEP-0421 occupant id must be checked

In the [standards email list](https://mail.jabber.org/pipermail/standards/2019-September/036412.html) @legastero has agreed to let me edit this XEP, so AFAIK his explicit approval for this PR isn't necessary.

That said, feedback is welcome (on list if not directly related to the PR).
