### PR TITLE
XEP-0410: treat remote-server-{not-found,timeout} like timeout

### DIFF
--- a/xep-0410.xml
+++ b/xep-0410.xml
@@ -30,6 +30,12 @@
     <jid>georg@yax.im</jid>
   </author>
   <revision>
+    <version>1.1.0</version>
+    <date>2019-09-25</date>
+    <initials>jsc</initials>
+    <remark>Treat remote-server-not-found and remote-server-timeout like timeout errors (i.e. undecided).</remark>
+  </revision>
+  <revision>
     <version>1.0.1</version>
     <date>2019-07-30</date>
     <initials>fs</initials>
@@ -182,6 +188,10 @@
       <li><strong>Error (&lt;item-not-found&gt;)</strong>: the client is
 	joined, but the occupant just changed their name (e.g. initiated by
 	a different client).</li>
+      <li><strong>Error (&lt;remote-server-not-found&gt; or &lt;remote-server-timeout&gt;)</strong>: 
+        the remote server is unreachable for unspecified reasons; this can
+	be a temporary network failure or a server outage. No decision can be
+	made based on this; Treat like a timeout (see below).</li>
       <li><strong>Any other error</strong><note>Different service
 	  implementations will send different responses to a client that's not
 	  joined. The recommended error code is &lt;not-acceptable&gt;, however


### PR DESCRIPTION
Rationale is inline. Summary: those errors indicate unreachability
of the server and most certainly not (with confidence) that the
client has been removed from the room.