### PR TITLE
Reduce final image size by 92%

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Builds all XEPs by default, HTML & PDF
 # docker build . --build-arg NCORES=X --build-arg TARGETS="html pdf"
 # from Dockerfile.base
-FROM xmppxsf/xeps-base:latest
+FROM xmppxsf/xeps-base:latest as build
 
 ARG NCORES=1
 ARG TARGETS="html inbox-html inbox-xml pdf xeplist refs xml"
@@ -14,7 +14,10 @@ COPY texml-xsl/*.xsl /src/texml-xsl/
 
 WORKDIR /src
 RUN OUTDIR=/var/www/html/extensions/ make -j$NCORES $TARGETS
+RUN bash -c 'rm -f /var/www/html/extensions/*.{log,aux,toc,tex,tex.xml,out}'
 
+FROM nginx:1-alpine
+RUN mkdir /usr/share/nginx/html/extensions/
+COPY --from=build /var/www/html/extensions/ /usr/share/nginx/html/extensions/
+RUN sed -ri '/root\s+\/usr\/share\/nginx\/html/s/^(.+)$/\1\nautoindex on;/' /etc/nginx/conf.d/default.conf
 EXPOSE 80
-
-CMD /usr/sbin/nginx -g 'daemon off;'


### PR DESCRIPTION
By performing the build in one image (with all the needed tools)
and then copying over the result files into an image based on
stock nginx, the image size is reduced from 1.4 GB to 111 MB.