### PR TITLE
XEP-0391 & XEP-0396: JET improvements

### DIFF
--- a/xep-0391.xml
+++ b/xep-0391.xml
@@ -146,7 +146,6 @@ established, data can be encrypted and exchanged. Both parties MUST keep a copy 
                    type='direct'/>
       </transport>
       <security xmlns='urn:xmpp:jingle:jet:0'
-                name='a-file-offer'
                 cipher='urn:xmpp:ciphers:aes-256-gcm-nopadding'
                 type='urn:xmpp:encryption:stub:0'>
         <encrypted xmlns='urn:xmpp:encryption:stub:0'>
@@ -190,7 +189,6 @@ established, data can be encrypted and exchanged. Both parties MUST keep a copy 
                    type='direct'/>
       </transport>
       <security xmlns='urn:xmpp:jingle:jet:0'
-                name='a-file-request'
                 cipher='urn:xmpp:ciphers:aes-256-gcm-nopadding'
                 type='urn:xmpp:encryption:stub:0'>
         <encrypted xmlns='urn:xmpp:encryption:stub:0'>
@@ -238,7 +236,6 @@ established, data can be encrypted and exchanged. Both parties MUST keep a copy 
                    type='direct'/>
       </transport>
       <security xmlns='urn:xmpp:jingle:jet:0'
-                name='restart'
                 cipher='urn:xmpp:ciphers:aes-256-gcm-nopadding'
                 type='urn:xmpp:encryption:stub:0'>
         <encrypted xmlns='urn:xmpp:encryption:stub:0'>

--- a/xep-0391.xml
+++ b/xep-0391.xml
@@ -254,6 +254,20 @@ established, data can be encrypted and exchanged. Both parties MUST keep a copy 
   <p>Jingle Encrypted Transports leaves it open to the encryption profile to specify suitable cipher modes and key lengths.</p>
 </section1>
 
+<section1 topic='Use with SCE' anchor='sce'>
+  <p>&xep0420; can be used to encrypt arbitrary extension elements. Combining SCE with JET allows encryption of file metadata since the elements of &xep0234; are sent in encrypted form.</p>
+  <p>This has the effect, that the Transport Secret no longer needs to be encrypted separately, as it is already contained in SCEs &lt;content/&gt; element which is encrypted.</p>
+  <p>Therefore we can simplify the format of the &security; element for the key transport drastically.</p>
+  <example caption='Simplified key transport format'><![CDATA[
+<security xmlns='urn:xmpp:jingle:jet:0'
+          cipher='urn:xmpp:ciphers:aes-128-gcm-nopadding'
+          type='urn:xmpp:encryption:sce:0'>
+  <key>BASE64-ENCODED-KEY</key>
+  <iv>BASE64-ENCODED-IV</key>
+</security>]]>
+  </example>
+</section1>
+
 <section1 topic='Determining Support' anchor='support'>
   <p>To advertise its support for the Jingle Encrypted Transports, when replying to service discovery information ("disco#info") requests an entity MUST return URNs for any version, or extension of this protocol that the entity supports -- e.g., "urn:xmpp:jingle:jet:0" for this version, or "urn:xmpp:jingle:jet-stub:0" for a stub encryption method &VNOTE;.</p>
   <example caption="Service discovery information request"><![CDATA[
@@ -279,7 +293,7 @@ established, data can be encrypted and exchanged. Both parties MUST keep a copy 
 <section1 topic='Security Considerations' anchor='security'>
   <p>The initiator SHOULD NOT use the generated key TK as IV, but instead generate a seperate random IV.</p>
   <p>Instead of falling back to unencrypted transfer in case something goes wrong, implementations MUST instead abort the Jingle session, informing the user.</p>
-  <p>IMPORTANT: This approach does not deal with metadata. In case of &xep0234;, an attacker with access to the sent stanzas can for example still see the name of the file and other information included in the &lt;file/&gt; element.</p>
+  <p>IMPORTANT: This approach does not deal with metadata. In case of &xep0234;, an attacker with access to the sent stanzas can for example still see the name of the file and other information included in the &lt;file/&gt; element. A possible solution to this problem is the combination with &xep0420; as described <link url='#sce'>above</link>.</p>
   <p>The responder MUST check, whether the envelope element belongs to the initiator to prevent MitM attacks</p>
 </section1>
 

--- a/xep-0391.xml
+++ b/xep-0391.xml
@@ -33,6 +33,17 @@
   <discuss>jingle</discuss>
   &paulschaub;
   <revision>
+    <version>0.2.0</version>
+    <date>2019-10-04</date>
+    <initials>ps</initials>
+    <remark>
+      <p>Remove ciphers section. Profiles must define their own ciphers.</p>
+      <p>Clarify usage of the "size" element</p>
+      <p>Remove redundant "name" attribute from the security element</p>
+      <p>Propose usage with SCE</p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.1.2</version>
     <date>2018-07-31</date>
     <initials>vv</initials>

--- a/xep-0391.xml
+++ b/xep-0391.xml
@@ -111,6 +111,7 @@ established, data can be encrypted and exchanged. Both parties MUST keep a copy 
 
   <section2 topic='File Offer'>
     <p>In this scenario Romeo wants to send an encrypted text file over to Juliet. First, he generates a fresh AES-256 transport key and IV. In this case TK and IV are serialized into TS which is then encrypted using Romeos end-to-end-encryption session with Juliet.</p>
+    <p>Note: The &lt;size/&gt; element contains the size of the unencrypted file.
     <p>The resulting envelope element (EE) is sent as part of the security element along with the rest of the jingle stanza over to Juliet.</p>
     <example caption="Romeo initiates an encrypted file offer"><![CDATA[
 <iq from='romeo@montague.example/dr4hcr0st3lup4c'

--- a/xep-0391.xml
+++ b/xep-0391.xml
@@ -78,7 +78,7 @@
     <tr>
       <td>Transport Key</td>
       <td>TK</td>
-      <td>(Symmetric) key that is used to encrypt/decrypt the bytestreams sent/received through Jingle transports. This key encrypts the data two entities want to exchange. Examples for TK can be found under <link url='#ciphers'>"Ciphers"</link>.</td>
+      <td>(Symmetric) key that is used to encrypt/decrypt the bytestreams sent/received through Jingle transports. This key encrypts the data two entities want to exchange.</td>
     </tr>
     <tr>
       <td>Initialization Vector</td>
@@ -99,7 +99,7 @@
 </section1>
 <section1 topic='Principle' anchor='principle'>
   <p>Lets assume Romeo wants to initiate an encrypted Jingle session with Juliet. Prior to the Jingle session initiation, an already existing, established and (ideally) authenticated end-to-end encryption session between Romeo and Juliet MUST exist. This session is needed to transfer the Transport Secret from Romeo to Juliet.</p>
-  <p>When this precondition is met, Romeo initially generates a transport key (TK) and associated initialization vector (IV). These will later be used by the sender to encrypt, and respectively by the recipient to decrypt data that is exchanged. This protocol defines a set of usable <link url='#ciphers'>ciphers</link> from which Romeo might choose. TK and IV together form the transport secret (TS).</p>
+  <p>When this precondition is met, Romeo initially generates a transport key (TK) and associated initialization vector (IV). These will later be used by the sender to encrypt, and respectively by the recipient to decrypt data that is exchanged. TK and IV together form the transport secret (TS).</p>
   <p>Next Romeo uses his established encryption session with Juliet to encrypt TS. The resulting envelope element (EE) will be part of the Jingle session initiation as child of the JET &security;
 element.</p>
   <p>When Juliet receives Romeos session request, she decrypts EE to retrieve TS, from which she can obtain TK and IV. Now she and Romeo can go on with the session negotiation. Once the session is
@@ -110,7 +110,7 @@ established, data can be encrypted and exchanged. Both parties MUST keep a copy 
   <p>In order to initiate an encrypted file transfer, the initiator includes a JET &security; element in the Jingle file transfer request.</p>
 
   <section2 topic='File Offer'>
-    <p>In this scenario Romeo wants to send an encrypted text file over to Juliet. First, he generates a fresh AES-256 transport key and IV. In this case TK and IV are serialized into TS which is then encrypted using Romeos end-to-end-encryption session with Juliet.</p>
+    <p>In this scenario Romeo wants to send an encrypted text file over to Juliet. First, he generates a fresh AES-128 transport key and IV. In this case TK and IV are serialized into TS which is then encrypted using Romeos end-to-end-encryption session with Juliet.</p>
     <p>Note: The &lt;size/&gt; element contains the size of the unencrypted file.
     <p>The resulting envelope element (EE) is sent as part of the security element along with the rest of the jingle stanza over to Juliet.</p>
     <example caption="Romeo initiates an encrypted file offer"><![CDATA[
@@ -146,7 +146,7 @@ established, data can be encrypted and exchanged. Both parties MUST keep a copy 
                    type='direct'/>
       </transport>
       <security xmlns='urn:xmpp:jingle:jet:0'
-                cipher='urn:xmpp:ciphers:aes-256-gcm-nopadding'
+                cipher='urn:xmpp:ciphers:aes-128-gcm-nopadding'
                 type='urn:xmpp:encryption:stub:0'>
         <encrypted xmlns='urn:xmpp:encryption:stub:0'>
           <payload>BASE64-ENCODED-ENCRYPTED-SECRET</payload>
@@ -189,7 +189,7 @@ established, data can be encrypted and exchanged. Both parties MUST keep a copy 
                    type='direct'/>
       </transport>
       <security xmlns='urn:xmpp:jingle:jet:0'
-                cipher='urn:xmpp:ciphers:aes-256-gcm-nopadding'
+                cipher='urn:xmpp:ciphers:aes-128-gcm-nopadding'
                 type='urn:xmpp:encryption:stub:0'>
         <encrypted xmlns='urn:xmpp:encryption:stub:0'>
           <payload>BASE64-ENCODED-ENCRYPTED-SECRET</payload>
@@ -236,7 +236,7 @@ established, data can be encrypted and exchanged. Both parties MUST keep a copy 
                    type='direct'/>
       </transport>
       <security xmlns='urn:xmpp:jingle:jet:0'
-                cipher='urn:xmpp:ciphers:aes-256-gcm-nopadding'
+                cipher='urn:xmpp:ciphers:aes-128-gcm-nopadding'
                 type='urn:xmpp:encryption:stub:0'>
         <encrypted xmlns='urn:xmpp:encryption:stub:0'>
           <payload>BASE64-ENCODED-ENCRYPTED-SECRET</payload>
@@ -250,27 +250,8 @@ established, data can be encrypted and exchanged. Both parties MUST keep a copy 
 </section1>
 
 <section1 topic='Ciphers' anchor='ciphers'>
-  <p>In order to encrypt the transported bytestream, the initiator must transmit a cipher key to the responder. There are multiple options available:</p>
-  <table caption='Available ciphers, configurations and their namespaces'>
-    <tr>
-      <th>Namespace</th>
-      <th>Type</th>
-      <th>Length (bits)</th>
-      <th>Parameters</th>
-    </tr>
-    <tr>
-      <td>urn:xmpp:ciphers:aes-128-gcm-nopadding:0</td>
-      <td>AES</td>
-      <td>Key: 128, IV: 96</td>
-      <td>GCM/NoPadding</td>
-    </tr>
-    <tr>
-      <td>urn:xmpp:ciphers:aes-256-gcm-nopadding:0</td>
-      <td>AES</td>
-      <td>Key: 256, IV: 96</td>
-      <td>GCM/NoPadding</td>
-    </tr>
-  </table>
+  <p>In order to encrypt the transported bytestream, the initiator must transmit a cipher key to the responder.</>
+  <p>Jingle Encrypted Transports leaves it open to the encryption profile to specify suitable cipher modes and key lengths.</p>
 </section1>
 
 <section1 topic='Determining Support' anchor='support'>

--- a/xep-0396.xml
+++ b/xep-0396.xml
@@ -35,6 +35,16 @@
   <discuss>jingle</discuss>
   &paulschaub;
   <revision>
+    <version>0.2.1</version>
+    <date>2019-10-04</date>
+    <initials>ps</initials>
+    <remark>
+      <p>Declare usable ciphers</p>
+      <p>Remove redundant name attribute from examples</p>
+      <p>Specify handling of AES-GCM auth tag</p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.2.0</version>
     <date>2018-12-06</date>
     <initials>XEP Editor (jsc)</initials>

--- a/xep-0396.xml
+++ b/xep-0396.xml
@@ -59,6 +59,23 @@
 <section1 topic='Mappings' anchor='mappings'>
   <p>Conveniently the OMEMO protocol already provides a way to transport key material to another entity. So called KeyTransportElements are basically normal OMEMO MessageElements, but without a payload, so the contained key can be used for something else (see Section 4.6 of <cite>XEP-0384</cite>). This extension uses the key encrypted in the KeyTransportMessages &lt;key&gt; attribute and initialization vector from the &lt;iv&gt; attribute to secure Jingle Transports. The key corresponds to the <cite>Transport Key</cite> of <cite>XEP-0391</cite>, while the iv corresponds to the <cite>Initialization Vector</cite>. The KeyTransportMessage is the equivalent to the <cite>Envelope Element</cite>. Note that within the Envelope Element, the Transport Key is encrypted with the OMEMO ratchet.</p>
 </section1>
+<section1 topic='Ciphers' anchor='ciphers'>
+  <p>In order to encrypt the transported bytestream, the initiator must transmit a cipher key to the responder.</p>
+  <table caption='Available ciphers, configurations and their namespaces'>
+    <tr>
+      <th>Namespace</th>
+      <th>Type</th>
+      <th>Length (bits)</th>
+      <th>Parameters</th>
+    </tr>
+    <tr>
+      <td>urn:xmpp:ciphers:aes-128-gcm-nopadding:0</td>
+      <td>AES</td>
+      <td>Key: 128, IV: 96</td>
+      <td>GCM/NoPadding</td>
+    </tr>
+  </table>
+</section1>
 <section1 topic='Limitations' anchor='limitations'>
   <p>Unfortunately &xep0384; determines the type of the transported key to be AES-128-GCM-NoPadding, so no other configuration can be used in the context of this extension.</p>
   <p>Since OMEMO deviceIds are not bound to XMPP resources, the initiator MUST encrypt the Transport Key for every device of the recipient.</p>

--- a/xep-0396.xml
+++ b/xep-0396.xml
@@ -116,6 +116,13 @@
 </iq>]]></example>
   <p>The recipient decrypts the OMEMO KeyTransportElement to retrieve the Transport Secret. Transport Key and Initialization Vector are later used to encrypt/decrypt data as described in &xep0391;.</p>
 </section1>
+
+<section1 topic='Transfering the file' anchor='sending'>
+  <p>Now that key material is exchanged between Romeo and Juliet, Romeo can go ahead and encrypt the file. The AES-GCM authentication tag is appended at the end of the encrypted file.</p>
+  <p>The encrypted byte stream is then exchanged as described by &xep0234;. Note that the encrypted file is larger in size than the plain original, so the value communicated in the file offers &lt;size/&gt; element cannot be used to determine how many bytes are actually being sent.</p>
+  <p>Once Juliet has received the file, she decrypts it and verifies both that the file size matches the advertised &lt;size/&gt; value, as well as the autheticity of the AES-GCM authentication tag.</p>
+</section1>
+
 <section1 topic='Determining Support' anchor='support'>
   <p>To advertise its support for JET-OMEMO, when replying to service discovery information ("disco#info") requests an entity MUST return URNs for any version of this extension, as well as of the JET extension that the entity supports -- e.g., "urn:xmpp:jingle:jet-omemo:0" for this version, or "urn:xmpp:jingle:jet:0" for &xep0391; &VNOTE;.</p>
   <example caption="Service discovery information request"><![CDATA[

--- a/xep-0396.xml
+++ b/xep-0396.xml
@@ -99,7 +99,6 @@
                    type='direct'/>
       </transport>
       <security xmlns='urn:xmpp:jingle:jet:0'
-                name='a-file-offer'
                 cipher='urn:xmpp:ciphers:aes-128-gcm-nopadding'
                 type='eu.siacs.conversations.axolotl'>
         <encrypted xmlns='eu.siacs.conversations.axolotl'>


### PR DESCRIPTION
This PR adds improvements to both XEP-0391: Jingle Encrypted Transports, as well as XEP-0396: JET-OMEMO:

* Removed redundant `name=` attribute from the security element
* Specify content of the `<size/>` element
* Move cipher list from XEP-0391 to profile XEPs to enable profiles to specify own ciphers
* Describe simple JET security element for use with SCE
* Bump XEP-0391 to 0.2.0
* Bump XEP-0396 to 0.2.1