### PR TITLE
XEP-0060: Clarify unlimited behaviour for node config

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -50,6 +50,12 @@
   &stpeter;
   &ralphm;
   <revision>
+    <version>1.17.0</version>
+    <date>2019-10-06</date>
+    <initials>dg</initials>
+    <remark><p>Clarify node config behaviour with regards to unlimited behaviour for fields that specify a maximum.</p></remark>
+  </revision>
+  <revision>
     <version>1.16.0</version>
     <date>2019-09-11</date>
     <initials>edhelas</initials>
@@ -1079,7 +1085,7 @@ And by opposing end them?
       <field var='pubsub#publish_model' label='Publish model' type='list-single'>
         <value>publishers</value>
       </field>
-      <field var='pubsub#max_items' label='Max # of items to persist' type='text-single'>
+      <field var='pubsub#max_items' label='Max # of items to persist. ∞ for no specific limit other than a server imposed maximum.' type='text-single'>
         <value>120</value>
       </field>
       <field var='pubsub#owner' label='Node owners' type='jid-multi'>
@@ -3517,11 +3523,11 @@ And by opposing end them?
           <value>1</value>
         </field>
         <field var='pubsub#max_items' type='text-single'
-               label='Max # of items to persist'>
+               label='Max # of items to persist. ∞ for no specific limit other than a server imposed maximum.'>
           <value>10</value>
         </field>
         <field var='pubsub#item_expire' type='text-single'
-               label='Time after which to automatically purge items'>
+               label='Time after which to automatically purge items. ∞ for no specific limit other than a server imposed maximum.'>
           <value>604800</value>
         </field>
         <field var='pubsub#subscribe' type='boolean'
@@ -3859,11 +3865,11 @@ And by opposing end them?
           <value>1</value>
         </field>
         <field var='pubsub#max_items' type='text-single'
-               label='Max # of items to persist'>
+               label='Max # of items to persist. ∞ for no specific limit other than a server imposed maximum.'>
           <value>10</value>
         </field>
         <field var='pubsub#item_expire' type='text-single'
-               label='Time after which to automatically purge items'>
+               label='Time after which to automatically purge items. ∞ for no specific limit other than a server imposed maximum.'>
           <value>604800</value>
         </field>
         <field var='pubsub#subscribe' type='boolean'
@@ -6402,10 +6408,10 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
          label='The list of JIDs that may associate leaf nodes with a collection'/>
   <field var='pubsub#children'
          type='text-multi'
-         label='The child nodes (leaf or collection) associated with a collection'/>
+         label='The child nodes (leaf or collection) associated with a collection.'/>
   <field var='pubsub#children_max'
          type='text-single'
-         label='The maximum number of child nodes that can be associated with a collection'/>
+         label='The maximum number of child nodes that can be associated with a collection.  ∞ for no specific limit other than a server imposed maximum.'/>
   <field var='pubsub#collection'
          type='text-multi'
          label='The collection(s) with which a node is affiliated'/>
@@ -6431,7 +6437,7 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
          label='A description of the node'/>
   <field var='pubsub#item_expire'
          type='text-single'
-         label='Number of seconds after which to automatically purge items'/>
+         label='Number of seconds after which to automatically purge items. ∞ for no specific limit other than a server imposed maximum.'/>
   <field var='pubsub#itemreply'
          type='list-single'
          label='Whether owners or publisher should receive replies to items'>
@@ -6447,7 +6453,7 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
          label='The default language of the node'/>
   <field var='pubsub#max_items'
          type='text-single'
-         label='The maximum number of items to persist'/>
+         label='The maximum number of items to persist. ∞ for no specific limit other than a server imposed maximum.'/>
   <field var='pubsub#max_payload_size'
          type='text-single'
          label='The maximum payload size in bytes'/>

--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -1085,7 +1085,7 @@ And by opposing end them?
       <field var='pubsub#publish_model' label='Publish model' type='list-single'>
         <value>publishers</value>
       </field>
-      <field var='pubsub#max_items' label='Max # of items to persist. ∞ for no specific limit other than a server imposed maximum.' type='text-single'>
+      <field var='pubsub#max_items' label='Max # of items to persist. `max` for no specific limit other than a server imposed maximum.' type='text-single'>
         <value>120</value>
       </field>
       <field var='pubsub#owner' label='Node owners' type='jid-multi'>
@@ -3523,11 +3523,11 @@ And by opposing end them?
           <value>1</value>
         </field>
         <field var='pubsub#max_items' type='text-single'
-               label='Max # of items to persist. ∞ for no specific limit other than a server imposed maximum.'>
+               label='Max # of items to persist. `max` for no specific limit other than a server imposed maximum.'>
           <value>10</value>
         </field>
         <field var='pubsub#item_expire' type='text-single'
-               label='Time after which to automatically purge items. ∞ for no specific limit other than a server imposed maximum.'>
+               label='Time after which to automatically purge items. `max` for no specific limit other than a server imposed maximum.'>
           <value>604800</value>
         </field>
         <field var='pubsub#subscribe' type='boolean'
@@ -3865,11 +3865,11 @@ And by opposing end them?
           <value>1</value>
         </field>
         <field var='pubsub#max_items' type='text-single'
-               label='Max # of items to persist. ∞ for no specific limit other than a server imposed maximum.'>
+               label='Max # of items to persist. `max` for no specific limit other than a server imposed maximum.'>
           <value>10</value>
         </field>
         <field var='pubsub#item_expire' type='text-single'
-               label='Time after which to automatically purge items. ∞ for no specific limit other than a server imposed maximum.'>
+               label='Time after which to automatically purge items. `max` for no specific limit other than a server imposed maximum.'>
           <value>604800</value>
         </field>
         <field var='pubsub#subscribe' type='boolean'
@@ -6022,6 +6022,11 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
   <doc>XEP-0060</doc>
 </var>
 <var>
+  <name>http://jabber.org/protocol/pubsub#config-node-max</name>
+  <desc>Server supports `max` being set as a value for node configuration options: pubsub#max_items, pubsub#item_expire and pubsub#children_max</desc>
+  <doc>XEP-0060</doc>
+</var>
+<var>
   <name>http://jabber.org/protocol/pubsub#create-and-configure</name>
   <desc>Simultaneous creation and configuration of nodes is supported.</desc>
   <doc>XEP-0060</doc>
@@ -6411,7 +6416,7 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
          label='The child nodes (leaf or collection) associated with a collection.'/>
   <field var='pubsub#children_max'
          type='text-single'
-         label='The maximum number of child nodes that can be associated with a collection.  ∞ for no specific limit other than a server imposed maximum.'/>
+         label='The maximum number of child nodes that can be associated with a collection.  `max` for no specific limit other than a server imposed maximum.'/>
   <field var='pubsub#collection'
          type='text-multi'
          label='The collection(s) with which a node is affiliated'/>
@@ -6437,7 +6442,7 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
          label='A description of the node'/>
   <field var='pubsub#item_expire'
          type='text-single'
-         label='Number of seconds after which to automatically purge items. ∞ for no specific limit other than a server imposed maximum.'/>
+         label='Number of seconds after which to automatically purge items. `max` for no specific limit other than a server imposed maximum.'/>
   <field var='pubsub#itemreply'
          type='list-single'
          label='Whether owners or publisher should receive replies to items'>
@@ -6453,7 +6458,7 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
          label='The default language of the node'/>
   <field var='pubsub#max_items'
          type='text-single'
-         label='The maximum number of items to persist. ∞ for no specific limit other than a server imposed maximum.'/>
+         label='The maximum number of items to persist. `max` for no specific limit other than a server imposed maximum.'/>
   <field var='pubsub#max_payload_size'
          type='text-single'
          label='The maximum payload size in bytes'/>


### PR DESCRIPTION
Not being able to set max_items to 'undefined' or 'unlimited' prevents publish_options to work with Bookmarks 2.