### PR TITLE
XEP "Malicous Stanzas" (XEP-0076): Fix IQ example

### DIFF
--- a/xep-0076.xml
+++ b/xep-0076.xml
@@ -23,6 +23,12 @@
   &stpeter;
   &hildjj;
   <revision>
+    <version>1.0.1</version>
+    <date>2019-10-09</date>
+    <initials>fs</initials>
+    <remark><p>Fix &IQ; example.</p></remark>
+  </revision>
+  <revision>
     <version>1.0</version>
     <date>2003-04-01</date>
     <initials>psa</initials>
@@ -71,13 +77,14 @@
     <example caption='Evil Entity Sends Evil Message'><![CDATA[
 <iq from='iago@shakespeare.lit/pda'
     id='evil1'
+    type='result'
     to='emilia@shakespeare.lit/mobile'>
   <query xmlns='jabber:iq:version'>
     <name>Stabber</name>
     <version>666</version>
     <os>FiendOS</os>
+    <evil xmlns='http://jabber.org/protocol/evil'/>
   </query>
-  <evil xmlns='http://jabber.org/protocol/evil'/>
 </iq>
 ]]></example>
   </section2>


### PR DESCRIPTION
Extensions elements in IQ go as sub-child element into the direct IQ
child element (of which IQs usually can only have at most one).