### PR TITLE
XEP-0335: Back to Experimental

### DIFF
--- a/xep-0335.xml
+++ b/xep-0335.xml
@@ -10,7 +10,7 @@
   <abstract>This specification defines an element to be used for encapsulating JSON data in XMPP.</abstract>
   &LEGALNOTICE;
   <number>0335</number>
-  <status>Proposed</status>
+  <status>Experimental</status>
   <lastcall>2019-02-19</lastcall>
   <type>Standards Track</type>
   <sig>Standards</sig>


### PR DESCRIPTION
The LC never ended and it was agreed by council and the author to put it
back.

> [T]here's only the last call vote for XEP-0335, which got passed. We did
> a Last Call, but I don't see any subsequent vote on advancing it to
> Draft - equally, I do see feedback and no new version, so...

> After a quick chat with Matt, I'll leave '335 for now.

https://logs.xmpp.org/council/2019-05-21?p=h#2019-05-21-49640fd1dbb137b1

Technically editor realm with that quote from Dave, but maybe @horazont has more insight?

Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>