### PR TITLE
XEP-0001: Replace Organizational type with Procedural

### DIFF
--- a/xep-0001.xml
+++ b/xep-0001.xml
@@ -549,7 +549,7 @@ THE SOFTWARE.
         <xs:enumeration value='Historical'/>
         <xs:enumeration value='Humorous'/>
         <xs:enumeration value='Informational'/>
-        <xs:enumeration value='Organizational'/>
+        <xs:enumeration value='Procedural'/>
         <xs:enumeration value='Standards Track'/>
       </xs:restriction>
     </xs:simpleType>

--- a/xep-0001.xml
+++ b/xep-0001.xml
@@ -23,6 +23,12 @@
   &dcridland;
   &ralphm;
   <revision>
+    <version>1.23.1</version>
+    <date>2019-10-19</date>
+    <initials>mb</initials>
+    <remark><p>Change Organizational type in schema for Procedural</p></remark>
+  </revision>
+  <revision>
     <version>1.23.0</version>
     <date>2019-01-17</date>
     <initials>rm</initials>


### PR DESCRIPTION
There's no "Procedural" type where there should be, and "Organizational" doesn't
seem to be used anywhere. Probably because historical reasons.

Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>