### PR TITLE
XEP-0292: Recommend using contact bare JIDs as item IDs

### DIFF
--- a/xep-0292.xml
+++ b/xep-0292.xml
@@ -356,12 +356,12 @@
   </section2>
 
   <section2 topic='Storage' anchor='contacts-storage'>
-    <p>Because contact vCards are private information, they are best stored using &xep0223;. The canonical location is a well-known pubsub node "urn:xmpp:contacts". In accordance with <cite>XEP-0223</cite>, this node MUST have an access type of "whitelist" by default. When a client stores items at this node, it SHOULD NOT include an ItemID, so that the pubsub service can assign those identifiers.</p>
+    <p>Because contact vCards are private information, they are best stored using &xep0223;. The canonical location is a well-known pubsub node "urn:xmpp:contacts". In accordance with <cite>XEP-0223</cite>, this node MUST have an access type of "whitelist" by default. When a client stores items at this node, it MUST include an ItemID set to the bare JID of the contact.</p>
     <example caption='Storing a Contact vCard'><![CDATA[
 <iq from='stpeter@stpeter.im/squire' type='set' id='h3vs7163'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
     <publish node='urn:xmpp:contacts'>
-      <item>
+      <item id='samizzi@cisco.com'>
         <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
           <fn><text>Samantha Mizzi</text></fn>
           <n>
@@ -412,7 +412,7 @@
          id='ka92g1b5'>
   <event xmlns='http://jabber.org/protocol/pubsub#event'>
     <items node='urn:xmpp:contacts'>
-      <item id='9703CC4E-CF7E-4A86-9E61-2C670235F9CB'>
+      <item id='samizzi@cisco.com'>
         <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
           <fn><text>Samantha Mizzi</text></fn>
           <n>
@@ -448,7 +448,7 @@
          id='pty14x69'>
   <event xmlns='http://jabber.org/protocol/pubsub#event'>
     <items node='urn:xmpp:contacts'>
-      <item id='9703CC4E-CF7E-4A86-9E61-2C670235F9CB'>
+      <item id='samizzi@cisco.com'>
         <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
           <fn><text>Samantha Mizzi</text></fn>
           <n>


### PR DESCRIPTION
Similar to XEP-0402. Allows easy association between items and roster
entries.

Relevant Standards threads:
https://mail.jabber.org/pipermail/standards/2011-October/025307.html
https://mail.jabber.org/pipermail/standards/2019-January/035710.html