### PR TITLE
docker: Switch to 2-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Builds all XEPs by default, HTML & PDF
 # docker build . --build-arg NCORES=X --build-arg TARGETS="html pdf"
 # from Dockerfile.base
-FROM xmppxsf/xeps-base:latest
+FROM xmppxsf/xeps-base:latest AS builder
 
 ARG NCORES=1
 ARG TARGETS="html inbox-html inbox-xml pdf xeplist refs xml"
@@ -13,8 +13,8 @@ COPY inbox/*.xml inbox/*.ent inbox/*.dtd /src/inbox/
 COPY texml-xsl/*.xsl /src/texml-xsl/
 
 WORKDIR /src
-RUN OUTDIR=/var/www/html/extensions/ make -j$NCORES $TARGETS
+RUN make -j$NCORES $TARGETS
 
-EXPOSE 80
-
-CMD /usr/sbin/nginx -g 'daemon off;'
+FROM nginx
+COPY --from=builder /src/build/ /usr/share/nginx/html/extensions/
+RUN chmod a+rX /usr/share/nginx/html/extensions/ -R


### PR DESCRIPTION
No build dependencies in final image. Order of magnitude reduction in image size. Less bandwidth usage.