### PR TITLE
XEP-0158: Use the correct FORM_TYPE for extended IBR, and use a proper MUC join as an example

### DIFF
--- a/xep-0158.xml
+++ b/xep-0158.xml
@@ -405,7 +405,7 @@
   <query xmlns='jabber:iq:register'>
     <x xmlns='jabber:x:data' type='form'>
       <field type='hidden' var='FORM_TYPE'>
-        <value>urn:xmpp:captcha</value>
+        <value>jabber:iq:register</value>
       </field>
       <field type='hidden' var='challenge'><value>F3A6292C</value></field>
       <field type='hidden' var='sid'><value>reg1</value></field>
@@ -442,7 +442,7 @@
   <query xmlns='jabber:iq:register'>
     <x xmlns='jabber:x:data' type='submit'>
       <field var='FORM_TYPE'>
-        <value>urn:xmpp:captcha</value>
+        <value>jabber:iq:register</value>
       </field>
       <field var='challenge'><value>F3A6292C</value></field>
       <field var='sid'><value>reg1</value></field>

--- a/xep-0158.xml
+++ b/xep-0158.xml
@@ -460,7 +460,9 @@
   <p>A service that hosts multi-user chat rooms in accordance with <cite>XEP-0045</cite> MAY challenge unknown entities that seek to join such rooms or that send messages in such rooms.</p>
   <example caption='Sender Attempts to Join Chat Room'><![CDATA[
 <presence from='robot@abuser.com/zombie'
-          to='friendly-chat@muc.victim.com/robot101'/>
+          to='friendly-chat@muc.victim.com/robot101'>
+  <x xmlns='http://jabber.org/protocol/muc'/>
+</presence>
 ]]></example>
   <example caption='Challenger Offers a Choice of Challenges to Sender'><![CDATA[
 <message from='friendly-chat@muc.victim.com'

--- a/xep-0158.xml
+++ b/xep-0158.xml
@@ -29,6 +29,12 @@
   &ianpaterson;
   &stpeter;
   <revision>
+    <version>1.0.1</version>
+    <date>2019-11-07</date>
+    <initials>egp</initials>
+    <remark><p>Use the correct FORM_TYPE for extended IBR, and use a proper MUC join as an example.</p></remark>
+  </revision>
+  <revision>
     <version>1.0</version>
     <date>2008-09-03</date>
     <initials>psa</initials>


### PR DESCRIPTION
This was found while implementing IBR CAPTCHA in [Renga](https://github.com/HaikuArchives/Renga) at the [Stockholm sprint](https://wiki.xmpp.org/web/Sprints/2019_September_Stockholm).