### PR TITLE
XEP-0045: Direct messages SHOULD be used over PMs in non-anonymous rooms

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -46,6 +46,12 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.33.0</version>
+    <date>2019-11-12</date>
+    <initials>gl</initials>
+    <remark><p>Direct messages SHOULD be used over PMs in non-anonymous rooms.</p></remark>
+  </revision>
+  <revision>
     <version>1.32.0</version>
     <date>2019-05-15</date>
     <initials>gl</initials>
@@ -1979,6 +1985,7 @@
     <p>Since each occupant has its own occupant JID, an occupant can send a "private message" to a selected occupant via the service by sending a message to the intended recipient's occupant JID. The message type SHOULD be "chat" and MUST NOT be "groupchat", but MAY be left unspecified (i.e., a normal message). This privilege is controlled by the "muc#roomconfig_allowpm" room configuration option.</p>
     <p>To allow for proper synchronization of these messages to the user's other clients by &xep0280;, the sending client SHOULD add an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace to the message.</p>
     <p><strong>Note:</strong> because this requirement was only added in revision 1.28 of this XEP, receiving entities MUST NOT rely on the existence of the &lt;x/&gt; element on private messages for proper processing.</p>
+    <p>Private messages are meant to hide a user's real JID from occupants they are talking to. In <link url='#enter-nonanon'>non-anonymous rooms</link>, a client SHOULD NOT resort to private messages, but instead make use of direct messages to the other occupant's real bare JID. However, if the user knows the other JID for other reasons, e.g. because they are a room admin, private messages SHOULD be used anyway.</p>
     <example caption='Occupant Sends Private Message'><![CDATA[
 <message
     from='wiccarocks@shakespeare.lit/laptop'


### PR DESCRIPTION
I'm the last person to get rid of PMs, but I think they have no place in non-anon MUCs. Needs Council, obviously.