### PR TITLE
tools: be more specific about XEP filenames

### DIFF
--- a/tools/extract-metadata.py
+++ b/tools/extract-metadata.py
@@ -202,7 +202,7 @@ def main():
 
     has_error = False
 
-    for xepfile in args.xepdir.glob("xep-*.xml"):
+    for xepfile in args.xepdir.glob("xep-[0-9][0-9][0-9][0-9].xml"):
         number = xepfile.name.split("-", 1)[1].split(".", 1)[0]
         try:
             number = str(int(number))


### PR DESCRIPTION
Sometimes the main working directory may have other XML files such as
the temporary files generated by TeXML (xep-*.tex.xml) which may be
picked up by the metadata script. Use a more specific pattern so that it
only extracts metadata from real XEP files.