### PR TITLE
XEP-0393: make span rules match examples

### DIFF
--- a/xep-0393.xml
+++ b/xep-0393.xml
@@ -26,6 +26,17 @@
   <shortname>styling</shortname>
   &sam;
   <revision>
+    <version>0.2.1</version>
+    <date>2020-01-02</date>
+    <initials>ssw</initials>
+    <remark>
+      <p>
+        Make rules consistent with examples that show multiple styling
+        directives being applied to the same text.
+      </p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.2.0</version>
     <date>2019-09-02</date>
     <initials>ssw</initials>
@@ -315,8 +326,9 @@
   <section2 topic='Spans' anchor='span'>
     <p>
       Matches of spans between two styling directives MUST contain some text
-      between the two styling directives and the opening styling directive MUST
-      be located at the beginning of the line, or after a whitespace character.
+      between the two styling directives and the opening styling directive
+      MUST be located at the beginning of the line, after a whitespace
+      character, or after a different opening styling directive.
       The opening styling directive MUST NOT be followed by a whitespace
       character and the closing styling directive MUST NOT be preceeded by a
       whitespace character.


### PR DESCRIPTION
Previously the styling directive rules indicated that the opening
styling directive must be preceded by whitespace or be the beginning of
the line, however, this meant that a later example was incorrect as it
showed bold and monospace text starting with *` (the second styling
directive is preceded by the first, not whitespace). Allowing styling
directives to immediately follow other styling directives fixes this
oversight.

See siacs/Conversations#3605