### PR TITLE
XEP-0401: update pre-authenticated IBR

### DIFF
--- a/xep-0401.xml
+++ b/xep-0401.xml
@@ -6,7 +6,7 @@
 <?xml-stylesheet type='text/xsl' href='xep.xsl'?>
 <xep>
 <header>
-  <title>Easy User Onboarding</title>
+  <title>Ad-hoc Account Invitation Generation</title>
   <abstract>This document defines a protocol and URI scheme for user invitation in order to allow a third party to register on a server. The goal of this is to make onboarding for XMPP IM newcomers as easy as possible.</abstract>
   &LEGALNOTICE;
   <number>0401</number>
@@ -29,6 +29,10 @@
   <author>
     <firstname>Marc</firstname>
     <surname>Schink</surname>
+  </author>
+  <author>
+    <firstname>Georg</firstname>
+    <surname>Lukas</surname>
   </author>
   <revision>
     <version>0.4.0</version>
@@ -90,8 +94,8 @@
       out-of-band link (URI) which allows Juliet to:</p>
     <ol>
       <li>Download an XMPP client (if needed).</li>
-      <li>Register an account on Romeo's server with a user name defined by
-	Romeo and a password not known to Romeo.</li>
+      <li>Register an account on Romeo's server (with a user name pre-defined
+	by Romeo or chosen by Juliet, and a password not known to Romeo).</li>
       <li>Establish a mutual presence subscription between Romeo and Juliet.</li>
     </ol>
   </section2>
@@ -111,6 +115,8 @@
     Furthermore, Romeo's server SHOULD provide a HTTPS service hosting the
     landing page.
   </p>
+  <p>Romeo's server MUST support at least one <link url="#preauth-ibr">Pre-Authenticated In-Band
+    Registration</link> mechanism.</p>
 </section1>
 <section1 topic='Discovery' anchor='discover'>
   <p>Romeo can query his server for the availability of "User Invitation" and
@@ -135,9 +141,6 @@
   </query>
 </iq>
 ]]></example>
-  <p>When performing the account creation, Juliet's client needs to ensure
-    that the server supports the extended IBR protocol with a &lt;preauth&gt;
-    token: TODO</p>
 </section1>
 <section1 topic='Glossary' anchor='glossary'>
   <p>OPTIONAL.</p>
@@ -335,88 +338,18 @@
   </section2>
   <section2 topic='Pre-Authenticated In-Band Registration' anchor='preauth-ibr'>
     <p>In order to allow invited users to register on a server, the
-      registration processs as defined in &xep0077; needs to be extended. The
-      invited user's client MUST add a &lt;preauth&gt; element in the 'TODO'
-      namespace to the 'jabber:iq:register' query in order to inform the
-      server that it wants to perform Pre-Authenticated IBR:</p>
-    <example caption="Retrieving registration fields"><![CDATA[
-<iq type='get' id='reg1' to='example.com'>
-  <query xmlns='jabber:iq:register'>
-    <preauth xmlns='urn:xmpp:invite:1'/>
-  </query>
-</iq>
-]]></example>
-    <p>If the server supports and is ready to perform Pre-Authenticated IBR,
-      it MUST add a &lt;token&gt; element to the response (TODO: 'token' or
-      'preauth'?):</p>
-    <example caption="Receiving registration form"><![CDATA[
-<iq type='result' to='romeo@example.com' from='example.com' id='reg1'>
-  <query xmlns='jabber:iq:register'>
-    <x xmlns='jabber:x:data' type='form'>
-      <field type='hidden' var='FORM_TYPE'>
-        <value>urn:xmpp:invite:1</value>
-      </field>
-      <field type='text-single' label='Username' var='username'>
-        <required/>
-      </field>
-      <field type='text-private' label='Password' var='password'>
-        <required/>
-      </field>
-      <field type='text-single' label='Invite token' var='token'>
-        <required/>
-      </field>
-    </x>
-  </query>
-</iq>
-]]></example>
-    <example caption='Receiving registration form with error (invalid token)'><![CDATA[
-<iq type='error' from='example.com' id='reg1'>
-  <query xmlns='jabber:iq:register'>
-    <x xmlns='jabber:x:data' type='form'>
-      <field type='hidden' var='FORM_TYPE'>
-        <value>urn:xmpp:invite:1</value>
-      </field>
-      <field type='text-single' var='username'>
-        <value>juliet<value/>
-      </field>
-      <field type='text-private' var='password'>
-        <value>m1cro$oft<value/>
-      </field>
-      <field type='text-single' var='token'>
-        <value>BADTOKEN<value/>
-      </field>
-    </x>
-  </query>
-  <error type='modify'>
-    <bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
-    <invalid-token xmlns='urn:xmpp:invite:1'/>
-  </error>
-</iq>
-]]></example>
-    <example caption='Receiving registration form with error (token expired)'><![CDATA[
-<iq type='error' from='example.com' id='reg1'>
-  <query xmlns='jabber:iq:register'>
-    <x xmlns='jabber:x:data' type='form'>
-      <field type='hidden' var='FORM_TYPE'>
-        <value>urn:xmpp:invite:1</value>
-      </field>
-      <field type='text-single' var='username'>
-        <value>juliet<value/>
-      </field>
-      <field type='text-private' var='password'>
-        <value>m1cro$oft<value/>
-      </field>
-      <field type='text-single' var='token'>
-        <value>OLDTOKEN<value/>
-      </field>
-    </x>
-  </query>
-  <error type='cancel'>
-    <not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
-    <token-expired xmlns='urn:xmpp:invite:1'/>
-  </error>
-</iq>
-]]></example>
+      server must support pre-authenticated in-band registration based on one
+      of the following specifications:
+    </p>
+    <ul>
+      <li><link url="inbox/ibr-token.html">Pre-Authenticated In-Band Registration</link></li>
+      <li>TODO: define a mechanism based on &xep0389;</li>
+    </ul>
+    <p>
+      The invited user's client needs to connect to the server, check which of
+      the above mechanisms are supported, and continue as specified in the
+      respective document.
+    </p>
     <p>After the invitee has successfully registered on the inviter's server
       and roster subscription is enabled for account creation, the server MUST
       use roster pushes as defined in &rfc6121; §2.1.6 in order to inform the


### PR DESCRIPTION
This is a re-submission of #870 for formal reasons:

> This is an update to 0401 that incorporates Council feedback (not to do custom IBR extensions). It is now using a separate pre-IBR IQ to transmit the token to the server.

Also Needs_Author please.