### PR TITLE
XEP-0384: Weaken links to SignalProtocol

### DIFF
--- a/xep-0384.xml
+++ b/xep-0384.xml
@@ -28,6 +28,12 @@
     <jid>andy@strb.org</jid>
   </author>
   <revision>
+    <version>0.3.1</version>
+    <date>2020-01-15</date>
+    <initials>ap</initials>
+    <remark>Weaken links to SignalProtocol</remark>
+  </revision>
+  <revision>
     <version>0.3.0</version>
     <date>2018-07-31</date>
     <initials>egp</initials>
@@ -90,15 +96,17 @@
       external complexity.
     </p>
     <p>
-      This XEP defines a protocol that leverages the SignalProtocol encryption to provide
-      multi-end to multi-end encryption, allowing messages to be synchronized
-      securely across multiple clients, even if some of them are offline. The SignalProtocol
-      is a cryptographic double ratched protocol based on work by Trevor Perrin
-      and Moxie Marlinspike first published as the Axolotl protocol. While the
-      protocol itself has specifications in the public domain, the
-      protobuf-based wire format of the signal protocol is not fully
-      documented. The signal protocol currently only exists in GPLv3-licensed
-      implementations maintained by OpenWhisperSystems.
+      This XEP defines a protocol that leverages a double ratchet "SignalProtocol"
+      encryption to provide multi-end to multi-end encryption, allowing messages
+      to be synchronized securely across multiple clients, even if some of them
+      are offline. The terms "Signal" or "SignalProtocol" when used in this
+      document, must not be construed as a reference to the SignalProtocol by
+      Trevor Perrin and Moxie Marlinspike first published as the Axolotl protocol
+      that (to date) only exists in GPLv3-licensed implementations maintained by
+      OpenWhisperSystems. The exact protocol to be used is left open for further
+      specification, however experimental implementations of this XEP may make
+      use of such implementations by OpenWhisperSystems as they implement a
+      protocol compatible with this XEP.
     </p>
   </section2>
   <section2 topic='Overview' anchor='intro-overview'>


### PR DESCRIPTION
- Clarify that use of SignalProtocol is not final
- Only experimental implementations use SignalProtocol
- Lower risk of IPR issues by not explicitly saying that SignalProtocol shall be used