### PR TITLE
SIG-E2EE: Only elected XSF members may act as embassadors

### DIFF
--- a/inbox/sige2ee.xml
+++ b/inbox/sige2ee.xml
@@ -34,14 +34,14 @@
   <p>The role of the SIG shall be as follows:</p>
   <ul>
     <li>Produce, or coordinate the production and maintenance of relevant XMPP Extension Protocol (XEP) documents as described below under Deliverables.</li>
-    <li>Represent the interests and requirements of the XMPP community during the development of end-to-end encryption protocols that are non-exclusive to XMPP.</li>
+    <li>Represent the interests and requirements of the XMPP community during the development of end-to-end encryption protocols that are non-exclusive to XMPP. Note: Only elected members of the XSF may act as ambassadors.</li>
     <li>Provide recommendations for implementers.</li>
   </ul>
   <p>The SIG-E2EE shall not itself approve XMPP extension protocols (XEPs), which tasks shall remain under the purview of the XMPP Council.</p>
   <p>The scope of the SIG is limited to end-to-end encryption in contexts which are useful for instant messaging.</p>
 </section1>
 <section1 topic='Membership' anchor='membership'>
-  <p>The SIG-E2EE shall be open to the public and shall not be limited to elected members of the XMPP Standards Foundation. Anyone who works with, or is interested in encryption protocols is invited to take part.</p>
+  <p>The SIG-E2EE shall be open to the public and shall not be limited to elected members of the XMPP Standards Foundation. Anyone who works with, or is interested in encryption protocols is invited to take part. Only elected members of the XSF however may act as ambassadors.</p>
   <p>Discussions shall be conducted in a dedicated openly accessible mailing list.</p>
 </section1>
 <section1 topic='Lifetime' anchor='lifetime'>


### PR DESCRIPTION
As requested by Council, only elected members of the XSF are now able to represent the XSF to external entities.