### PR TITLE
HTML fixes

### DIFF
--- a/xep.xsl
+++ b/xep.xsl
@@ -34,7 +34,7 @@ OR OTHER DEALINGS IN THE SOFTWARE.
 
 <xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='1.0'>
 
-  <xsl:output doctype-public='-//W3C//DTD XHTML 1.0 Transitional//EN' doctype-system='http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd' method='html' indent='no'/>
+  <xsl:output method='html' encoding='utf-8' omit-xml-declaration='yes' indent='no'/>
 
   <xsl:template name="status-notice">
     <xsl:param name="thestatus"/>
@@ -170,6 +170,8 @@ OR OTHER DEALINGS IN THE SOFTWARE.
   </xsl:template>
 
   <xsl:template match='/'>
+    <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;
+</xsl:text>
     <html>
       <head>
         <title>XEP-<xsl:value-of select='/xep/header/number'/>:<xsl:text> </xsl:text><xsl:value-of select='/xep/header/title' /></title>

--- a/xep.xsl
+++ b/xep.xsl
@@ -34,7 +34,7 @@ OR OTHER DEALINGS IN THE SOFTWARE.
 
 <xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='1.0'>
 
-  <xsl:output doctype-public='-//W3C//DTD XHTML 1.0 Transitional//EN' doctype-system='http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd' method='html'/>
+  <xsl:output doctype-public='-//W3C//DTD XHTML 1.0 Transitional//EN' doctype-system='http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd' method='html' indent='no'/>
 
   <xsl:template name="status-notice">
     <xsl:param name="thestatus"/>


### PR DESCRIPTION
This PR introduces two changes to the HTML generation:

1. Use a proper HTML5 doctype (instead of an XHTML 1.0 doctype on HTML5 output served with text/html content type).

2. Fix the ghost whitespaces sometimes found in XEPs, for example in author lists.

Thanks to @Flowdalic for reporting the second issue which made me look into this.