### PR TITLE
add defined IV size for GCM.  clarified text

### DIFF
--- a/xep-0384.xml
+++ b/xep-0384.xml
@@ -28,6 +28,12 @@
     <jid>andy@strb.org</jid>
   </author>
   <revision>
+    <version>0.4.0</version>
+    <date>2020-03-05</date>
+    <initials>ap</initials>
+    <remark>Specify the size of the GCM iv to be 12 bytes.</remark>
+  </revision>
+  <revision>
     <version>0.3.0</version>
     <date>2018-07-31</date>
     <initials>egp</initials>
@@ -256,12 +262,11 @@
   <section2 topic='Sending a message' anchor='usecases-messagesend'>
     <p>
       In order to send a chat message, its &lt;body&gt; first has to be
-      encrypted. The client MUST use fresh, randomly generated key/IV pairs with
-      AES-128 in Galois/Counter Mode (GCM).
-      The 16 bytes key and the GCM authentication tag (The tag SHOULD have at least
-      128 bit) are concatenated and for each intended recipient device,
-      i.e. both own devices as well as devices associated with the contact, the
-      result of this concatenation is encrypted using the corresponding
+      encrypted. The client MUST use a fresh, randomly generated 16 byte key (i.e. AES GCM 128) and 12 byte
+      initialization vector (IV).
+      The GCM authentication tag SHOULD be at least 16 bytes. The key and the tag are
+      then concatenated. For each of the recipient's trusted devices as well as each of your own
+      trusted devices, the result of this concatenation is encrypted using the corresponding
       long-standing SignalProtocol session. Each encrypted payload key/authentication tag
       tuple is tagged with the recipient device's ID. The key element MUST be
       tagged with a prekey attribute set to true if a PreKeySignalMessage is being
@@ -285,8 +290,9 @@
   <section2 topic='Sending a key' anchor='usecases-keysend'>
     <p>
       The client may wish to transmit keying material to the contact. This first
-      has to be generated. The client MUST generate a fresh, randomly generated
-      key/IV pair. The 16 bytes key and the GCM authentication tag (The tag
+      has to be generated. The client MUST use a fresh, randomly generated 16 byte key
+      (i.e. AES GCM 128) and 12 byte initialization vector (IV). The 16 byte key and the
+      GCM authentication tag (The tag
       SHOULD have at least 128 bit) are concatenated and for each intended
       recipient device, i.e. both own devices as well as devices associated
       with the contact, this key is encrypted using the corresponding


### PR DESCRIPTION
OMEMO media sharing specifies the size of the iv to 12 but this XEP does not. In the absence of a recommended size, the only way for someone to implement OMEMO is to reach out to an exiting developer of a client and ask them what size they use. At the moment it is not possible to implement OMEMO based on this XEP alone. 