### PR TITLE
Add a Design Considerations section to the template

### DIFF
--- a/xep-template.xml
+++ b/xep-template.xml
@@ -68,6 +68,13 @@
 <section1 topic='XMPP Registrar Considerations' anchor='registrar'>
   <p>REQUIRED.</p>
 </section1>
+<section1 topic='Design Considerations' anchor='design'>
+  <!-- Use this section to describe other approaches which have been considered
+  during the design of this protocol and why they have been rejected. Having
+  the result and a summary of long or complicated discussions in the document
+  itself instead of list or chat archives serves future readers. -->
+  <p>RECOMMENDED.</p>
+</section1>
 <section1 topic='XML Schema' anchor='schema'>
   <p>REQUIRED for protocol specifications.</p>
 </section1>


### PR DESCRIPTION
Having the result and a summary of long or complicated discussions in the document itself instead of list or chat archives serves future readers.