### PR TITLE
XEP-0060: Specify that empty <item/> are invalid on publish

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -50,6 +50,12 @@
   &stpeter;
   &ralphm;
   <revision>
+    <version>1.18.0</version>
+    <date>2020-02-27</date>
+    <initials>jsc</initials>
+    <remark><p>Properly specifiy that an empty &lt;item/&gt; is invalid on publish.</p></remark>
+  </revision>
+  <revision>
     <version>1.17.0</version>
     <date>2019-10-06</date>
     <initials>dg</initials>
@@ -2975,7 +2981,7 @@ And by opposing end them?
 ]]></example>
       </section4>
       <section4 topic='Bad Payload' anchor='publisher-publish-error-badpayload'>
-        <p>If the &ITEM; element contains more than one payload element or the namespace of the root payload element does not match the configured namespace for the node, the service MUST bounce the request with a &badrequest; error, which SHOULD also include a pubsub-specific error condition of &lt;invalid-payload/&gt;.</p>
+        <p>If the &ITEM; element does not contain exactly one payload element or the namespace of the root payload element does not match the configured namespace for the node, the service MUST bounce the request with a &badrequest; error, which SHOULD also include a pubsub-specific error condition of &lt;invalid-payload/&gt;.</p>
         <example caption='Entity attempts to publish item with multiple payload elements or namespace does not match'><![CDATA[
 <iq type='error'
     from='pubsub.shakespeare.lit'


### PR DESCRIPTION
Note that to trigger a notify-only publish, the ``<item/>`` must not
be included at all (as said at the beginning of #publisher-publish-request).