### PR TITLE
XEP-0167: Add namespace to potentially misleading example

### DIFF
--- a/xep-0167.xml
+++ b/xep-0167.xml
@@ -43,6 +43,12 @@
   &robmcqueen;
   &diana;
   <revision>
+    <version>1.1.2</version>
+    <date>2020-03-19</date>
+    <initials>egp</initials>
+    <remark><p>Add missing namespace in an example.</p></remark>
+  </revision>
+  <revision>
     <version>1.1.1</version>
     <date>2016-07-08</date>
     <initials>XEP Editor: ssw</initials>
@@ -604,7 +610,8 @@ delivery-method=inline; configuration=somebase16string;
   </ul>
   <p>An example follows.</p>
   <code><![CDATA[
-<encryption required='1'>
+<encryption xmlns='urn:xmpp:jingle:apps:rtp:1'
+            required='1'>
   <crypto
       crypto-suite='AES_CM_128_HMAC_SHA1_80'
       key-params='inline:WVNfX19zZW1jdGwgKCkgewkyMjA7fQp9CnVubGVz|2^20|1:32'


### PR DESCRIPTION
This could cause people to think it isn’t useful to validate the namespace here.