### PR TITLE
XEP-0068: Clarify that FORM_TYPE does not need to be type='hidden' in submission forms

### DIFF
--- a/xep-0068.xml
+++ b/xep-0068.xml
@@ -24,6 +24,12 @@
   &hildjj;
   &stpeter;
   <revision>
+    <version>1.2.1</version>
+    <date>2020-03-25</date>
+    <initials>mw</initials>
+    <remark>Clarify that FORM_TYPE does not need to be type=&quot;hidden&quot; in submission forms.</remark>
+  </revision>
+  <revision>
     <version>1.2</version>
     <date>2012-05-28</date>
     <initials>psa/jjh</initials>
@@ -115,7 +121,7 @@
 
 <section1 topic='Use Cases' anchor='usecases'>
     <section2 topic='Unspecified Form' anchor='usecases-unspecified'>
-      <p>These are forms that do not have a hidden field of name FORM_TYPE.
+      <p>These are forms with type=&quot;form&quot; or type=&quot;result&quot; that do not have a hidden field of name FORM_TYPE or forms with type=&quot;submit&quot; that do not have any field of name FORM_TYPE.
         Existing processing rules still apply.</p>
       <example caption='Message with no FORM_TYPE'><![CDATA[
 <message
@@ -171,7 +177,7 @@
     </section2>
     <section2 topic='Incorrectly Specified FORM_TYPE' anchor='usecases-incorrect'>
 
-    <p>If the FORM_TYPE field is not hidden, it MUST be ignored as a context indicator.</p>
+    <p>If the FORM_TYPE field is not hidden in a form with type=&quot;form&quot; or type=&quot;result&quot;, it MUST be ignored as a context indicator.</p>
 
       <example caption='Message with bad FORM_TYPE'><![CDATA[
 <message to="juliet@capulet.com" from="romeo@montague.net/garden">
@@ -192,7 +198,7 @@
 ]]></example>
   </section2>
   <section2 topic='IQ Example' anchor='usecases-IQ'>
-    <p>The following example shows a user's interaction with a Multi-User Chat room in order to register with the room.</p>
+    <p>The following example shows a user's interaction with a Multi-User Chat room in order to register with the room. Note that during submission of the form, the FORM_TYPE field does not need to include the type=&quot;hidden&quot; attribute.</p>
     <example caption='User Requests Registration Requirements'><![CDATA[
 <iq
     from='hag66@shakespeare.lit/pda'
@@ -294,7 +300,7 @@
 </section1>
 
 <section1 topic='Implementation Notes' anchor='impl'>
-    <p>If the FORM_TYPE field is not type=&quot;hidden&quot;, it does not have the special meaning defined herein.</p>
+    <p>If the FORM_TYPE field is not type=&quot;hidden&quot; in a form with type=&quot;form&quot; or type=&quot;result&quot;, it does not have the special meaning defined herein.</p>
     <p>If the form is used in an IQ, the namespace of the &lt;query/&gt; element SHOULD match the base namespace of the FORM_TYPE. (One possible way of solving this problem would have been to reuse the &lt;query/&gt; tag from the IQ form of jabber:x:data within messages, but that would have meant that existing clients would not have been able to participate in these exchanges.)</p>
 </section1>
 


### PR DESCRIPTION
The specification did not match actual usage and examples in this and other XEPs for submission forms.

Rendered diff: http://www.aptest.com/standards/htmldiff/htmldiff.pl?oldfile=https://xmpp.org/extensions/xep-0068.html&newfile=https://larma.de/xeps/xep-0068.html