### PR TITLE
XEP-0405: Replace jid attribute by id as described in XEP-0369

### DIFF
--- a/xep-0405.xml
+++ b/xep-0405.xml
@@ -291,7 +291,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     from='coven@mix.shakespeare.example'
     to='hag66@shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-  <join xmlns='urn:xmpp:mix:core:1' jid='123456#coven@mix.shakespeare.example'>
+  <join xmlns='urn:xmpp:mix:core:1' id='123456'>
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:presence'/>
     <subscribe node='urn:xmpp:mix:nodes:participants'/>
@@ -311,8 +311,7 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
     to='hag66@shakespeare.example/UUID-a1j/7533'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
       <client-join xmlns='urn:xmpp:mix:pam:2'>
-        <join xmlns='urn:xmpp:mix:core:1'
-              jid='123456#coven@mix.shakespeare.example'>
+        <join xmlns='urn:xmpp:mix:core:1' id='123456'>
           <subscribe node='urn:xmpp:mix:nodes:messages'/>
           <subscribe node='urn:xmpp:mix:nodes:presence'/>
           <subscribe node='urn:xmpp:mix:nodes:participants'/>


### PR DESCRIPTION
Back in 2018, MIX-CORE [was changed](https://github.com/xsf/xeps/commit/5c552188b258653bb419806aa5a367eb1c502d32#diff-46551996fe454185b68cb3f084c2e18fL947-L991) to include Stable Participant `id=` attributes instead of Proxy `jid=` attributes in the response to a join element.

This change was apparently not transferred over to MIX-PAM. This PR addresses this issue.