### PR TITLE
xep-pubsub-mam: Split off from XEP-0313

### DIFF
--- a/inbox/xep-pubsub-mam.xml
+++ b/inbox/xep-pubsub-mam.xml
@@ -1,0 +1,90 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY % ents SYSTEM 'xep.ent'>
+%ents;
+]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+<header>
+  <title>Pubsub Message Archive Management</title>
+  <abstract>This document defines a protocol to query and control a pubsub node's message archive.</abstract>
+  &LEGALNOTICE;
+  <number>xxxx</number>
+  <status>Deferred</status>
+  <lastcall>2017-11-15</lastcall>
+  <type>Standards Track</type>
+  <sig>Standards</sig>
+  <dependencies>
+    <spec>XMPP Core</spec>
+    <spec>XEP-0030</spec>
+    <spec>XEP-0059</spec>
+    <spec>XEP-0060</spec>
+    <spec>XEP-0297</spec>
+    <spec>XEP-0313</spec>
+  </dependencies>
+  <supersedes/>
+  <supersededby/>
+  <shortname>pubsub-mam</shortname>
+  <schemaloc>
+    <url>http://www.xmpp.org/schemas/archive-management.xsd</url>
+  </schemaloc>
+  &mwild;
+  &ksmith;
+  <revision>
+    <version>0.1.0</version>
+    <date>2020-03-30</date>
+    <initials>mw</initials>
+    <remark>
+      <p>Split off from XEP-0313 v0.6.3 to ease advancement of that XEP and allow further clarification and expansion of pubsub use cases.</p>
+    </remark>
+  </revision>
+</header>
+
+<section1 topic='Introduction' anchor='intro'>
+  <p>This document specifies how to use &xep0313; in combination with &xep0060; to host and query archives on pubsub nodes.</p>
+</section1>
+
+<section1 topic='Querying a pubsub archive' anchor='querying'>
+  <p>When querying a pubsub node's archive, the 'node' attribute is added to the &lt;query&gt; element.</p>
+  <example caption='A user queries a pubsub node&apos;s archive for messages'><![CDATA[
+<iq to='pubsub.shakespeare.lit' type='set' id='juliet1'>
+  <query xmlns='urn:xmpp:mam:2' queryid='f28' node='fdp/submitted/capulet.lit/sonnets'/>
+</iq>]]></example>
+
+  <example caption='Server returns pubsub messages'><![CDATA[
+<message id='iasd208' to='juliet@capulet.lit/chamber'>
+  <result xmlns='urn:xmpp:mam:2' queryid='g28' id='28482-20987-73623'>
+    <forwarded xmlns='urn:xmpp:forward:0'>
+      <delay xmlns='urn:xmpp:delay' stamp='2010-07-10T23:08:25Z'/>
+      <message xmlns="jabber:client">
+		  <event xmlns='http://jabber.org/protocol/pubsub#event'>
+		    <items node='princely_musings'>
+		      <item id='ae890ac52d0df67ed7cfdf51b644e901'>
+		        <entry xmlns='http://www.w3.org/2005/Atom'>
+		          <title>Soliloquy</title>
+		          <summary>
+					To be, or not to be: that is the question:
+					Whether 'tis nobler in the mind to suffer
+					The slings and arrows of outrageous fortune,
+					Or to take arms against a sea of troubles,
+					And by opposing end them?
+		          </summary>
+		          <link rel='alternate' type='text/html'
+		                href='http://denmark.lit/2003/12/13/atom03'/>
+		          <id>tag:denmark.lit,2003:entry-32397</id>
+		          <published>2003-12-13T18:30:02Z</published>
+		          <updated>2003-12-13T18:30:02Z</updated>
+		        </entry>
+		      </item>
+		    </items>
+		  </event>
+		</message>
+    </forwarded>
+  </result>
+</message>]]></example>
+</section1>
+
+<section1 topic="Business Rules" anchor='business-rules'>
+  <p>A PubSub service offering MAM SHOULD store each of the items published to each node. When responding to MAM requests it MUST construct the message stanza within the &lt;forwarded&gt; element in the same manner as the notifications sent to subscribers for the item, except that specifying the 'from' 'to' and 'id' attributes are OPTIONAL. Pubsub items must be returned one per message stanza (i.e. there MUST NOT be multiple &lt;item&gt; elements within the &lt;items&gt; element).</p>
+</section1>
+</xep>


### PR DESCRIPTION
PR 2 of 3 for XEP-0313 0.7

This is the pubsub querying protocol, split out into a separate document per community consensus.