### PR TITLE
XEP-OMEMO (384): add hint to PubSub 'persistent-items' feature

### DIFF
--- a/xep-0384.xml
+++ b/xep-0384.xml
@@ -640,7 +640,7 @@
   <section2 topic='Server side requirements' anchor='server-side'>
     <p>While OMEMO uses a Pubsub Service (&xep0060;) on the user’s account it has more requirments than those defined in &xep0163;. The requirements are:</p>
     <ul>
-      <li>The pubsub service MUST persist node items.</li>
+      <li>The pubsub service MUST persist node items, i.e., the <link url='https://xmpp.org/extensions/xep-0060.html#features'>feature 'persistent-items'</link> is announced by the service.</li>
       <li>The pubsub service MUST support publishing options as defined in <link url='https://xmpp.org/extensions/xep-0060.html#publisher-publish-options'><cite>XEP-0060</cite> §7.1.5</link>.</li>
       <li>The pubsub service MUST support 'max' as a value for the 'pubsub#persist_items' node configuration.</li>
       <li>The pubsub service MUST support the 'open' access model for node configuration and 'pubsub#access_model' as a publish option.</li>


### PR DESCRIPTION
OMEMO implementations ideally want to determine if the PEP service is
suitable for OMEMO. This includes a xep30 feature discovery. This
change makes it easier for implementors to determine the features to
look out for by explicitly mention and linking to the
'persistent-items' feature