### PR TITLE
XEP-0191: Change service discovery flow to use account instead of server

### DIFF
--- a/xep-0191.xml
+++ b/xep-0191.xml
@@ -25,6 +25,12 @@
   <shortname>blocking</shortname>
   &stpeter;
   <revision>
+    <version>1.4.0</version>
+    <date>2020-04-13</date>
+    <initials>jsc</initials>
+    <remark><p>Change the discovery flow to discover support on the account instead of the server.</p></remark>
+  </revision>
+  <revision>
     <version>1.3</version>
     <date>2015-03-12</date>
     <initials>ssw</initials>
@@ -108,15 +114,15 @@
 <section1 topic='Use Cases' anchor='usecases'>
 
   <section2 topic='User Discovers Support' anchor='disco'>
-    <p>In order for a client to discover whether its server supports the protocol defined herein, it MUST send a &xep0030; information request to the server:</p>
+    <p>In order for a client to discover whether the protocol defined herein is supported on the account, it MUST send a &xep0030; information request to the server addressed to its own account (e.g. via empty to attribute):</p>
     <example caption='Service discovery request'><![CDATA[
-<iq from='juliet@capulet.com/chamber' to='capulet.com' type='get' id='disco1'>
+<iq from='juliet@capulet.com/chamber' type='get' id='disco1'>
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>
 ]]></example>
-    <p>If the server supports the protocol defined herein, it MUST return a feature of "urn:xmpp:blocking":</p>
+    <p>If the server supports the protocol defined herein and offers it on the account of the client, it MUST return a feature of "urn:xmpp:blocking":</p>
     <example caption='Service discovery response'><![CDATA[
-<iq from='capulet.com' to='juliet@capulet.com/chamber' type='result' id='disco1'>
+<iq to='juliet@capulet.com/chamber' type='result' id='disco1'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     ...
     <feature var='urn:xmpp:blocking'/>
@@ -124,6 +130,7 @@
   </query>
 </iq>
 ]]></example>
+    <p><strong>Note:</strong> Before version 1.4.0 of this specification, the discovery flow used the server domain instead of the user account as the endpoint for the disco#info request. This was suboptimal since the feature may not be offered to all users and support on the server level may also indicate something else (e.g. server-wide blocking for admin users).</p>
   </section2>
 
   <section2 topic='User Retrieves Block List' anchor='blocklist'>


### PR DESCRIPTION
The rationale for this is that blocking is an account-level
feature. It may not be offered for all accounts, even if the server
supports it.