### PR TITLE
Ensure OUTDIR exists before make preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ clean:
 	rm -rf $(OUTDIR)
 
 .PHONY: preview
-preview:
+preview: $(OUTDIR)
 	inotifywait -m -e close_write,moved_to --format '%e %w %f' $(XEPDIRS) | \
 	while read -r event dir file; do \
 		if [ "$${file: -4}" == ".xml" ]; then \


### PR DESCRIPTION
Fixes a bug that makes `make preview` fail to work unless you create the `build/` tree (or whatever `OUTDIR` is) first.