### PR TITLE
XEP-0004: clarify that the submitting entity may omit optional fields

### DIFF
--- a/xep-0004.xml
+++ b/xep-0004.xml
@@ -191,7 +191,7 @@
       </tr>
       <tr>
         <td>submit</td>
-        <td>The form-submitting entity is submitting data to the form-processing entity. The submission MAY include fields that were not provided in the empty form, but the form-processing entity MUST ignore any fields that it does not understand.</td>
+        <td>The form-submitting entity is submitting data to the form-processing entity. The submission MAY include fields that were not provided in the empty form, but the form-processing entity MUST ignore any fields that it does not understand. Furthermore, the submission MAY omit fields not marked with &gt;required/&lt; by the form-processing entity.</td>
       </tr>
       <tr>
         <td>cancel</td>


### PR DESCRIPTION
It is not really spelled out that the submitting entity may omit
fields not mark as required by the processing entity. Even though the
existence of the <required/> flag on form fields is a strong hint
towards this, it is worth to explicitly state that.