### PR TITLE
Fix some references in Password Storage ProtoXEP

### DIFF
--- a/inbox/password-storage.xml
+++ b/inbox/password-storage.xml
@@ -5,7 +5,7 @@
   <!ENTITY rfc2195 "<span class='ref'><link url='http://tools.ietf.org/html/rfc2195'>RFC 2195</link></span> <note>RFC 2195: IMAP/POP AUTHorize Extension for Simple Challenge/Response &lt;<link url='http://tools.ietf.org/html/rfc2195'>http://tools.ietf.org/html/rfc2195</link>&gt;.</note>" >
   <!ENTITY rfc7677 "<span class='ref'><link url='http://tools.ietf.org/html/rfc7677'>RFC 7677</link></span> <note>RFC 7677: SCRAM-SHA-256 and SCRAM-SHA-256-PLUS Simple Authentication and Security Layer (SASL) Mechanisms &lt;<link url='http://tools.ietf.org/html/rfc7677'>http://tools.ietf.org/html/rfc7677</link>&gt;.</note>" >
   <!ENTITY rfc8018 "<span class='ref'><link url='http://tools.ietf.org/html/rfc8018'>RFC 8018</link></span> <note>RFC 8018: PKCS #5: Password-Based Cryptography Specification Version 2.1 &lt;<link url='http://tools.ietf.org/html/rfc8018'>http://tools.ietf.org/html/rfc8018</link>&gt;.</note>" >
-  <!ENTITY rfc8265 "<span class='ref'><link url='http://tools.ietf.org/html/rfc8265'>RFC 8265</link></span> <note>RFC 8265: PRECIS Framework: Preparation, Enforcement, and Comparison of Internationalized Strings in Application ProtocolePRECIS Framework: Preparation, Enforcement, and Comparison of Internationalized Strings in Application Protocolsration, Enforcement, and Comparison of Internationalized Strings Representing Usernames and Passwords &lt;<link url='http://tools.ietf.org/html/rfc8265'>http://tools.ietf.org/html/rfc8265</link>&gt;.</note>" >
+  <!ENTITY rfc8265 "<span class='ref'><link url='http://tools.ietf.org/html/rfc8265'>RFC 8265</link></span> <note>RFC 8265: Preparation, Enforcement, and Comparison of Internationalized Strings Representing Usernames and Passwords &lt;<link url='http://tools.ietf.org/html/rfc8265'>http://tools.ietf.org/html/rfc8265</link>&gt;.</note>" >
   <!ENTITY nistsp800-63-3 "<span class='ref'><link url='https://doi.org/10.6028/NIST.SP.800-63-3'>Digital Identity Guidelines</link></span> <note>Digital Identity Guidelines, NIST Special Publication 800-63-3 &lt;<link url='https://doi.org/10.6028/NIST.SP.800-63-3'>https://doi.org/10.6028/NIST.SP.800-63-3</link>&gt;.</note>" >
   <!ENTITY nistsp800-63b "<span class='ref'><link url='https://doi.org/10.6028/NIST.SP.800-63b'>Digital Identity Guidelines: Authentication and Lifecycle Management</link></span> <note>Digital Identity Guidelines: Authentication and Lifecycle Management, NIST Special Publication 800-63B &lt;<link url='https://doi.org/10.6028/NIST.SP.800-63b'>https://doi.org/10.6028/NIST.SP.800-63b</link>&gt;.</note>" >
   <!ENTITY nistsp800-132 "<span class='ref'><link url='https://doi.org/10.6028/NIST.SP.800-132'>Recommendation for Password-Based Key Derivation, Part 1: Storage Applications</link></span> <note>Recommendation for Password-Based Key Derivation, Part 1: Storage Applications, NIST Special Publication 800-132 &lt;<link url='https://doi.org/10.6028/NIST.SP.800-132'>https://doi.org/10.6028/NIST.SP.800-132</link>&gt;.</note>" >
@@ -130,7 +130,7 @@
   <section2 topic='Mechanism Pinning' anchor='pinning'>
     <p>
       Clients maintain a list of preferred SASL mechanisms, generally ordered by
-      perceived strength to enable strong authentication (RFC 6120 §6.3.3
+      perceived strength to enable strong authentication (&rfc6120; §6.3.3
       Mechanism Preferences).
       To prevent downgrade attacks by a malicious actor that has successfully
       man in the middled a connection, or compromised a trusted server's


### PR DESCRIPTION
This fixes some broken reference text that should have no bearing on the council voting. It would be nice if it could be merged before a number gets assigned (assuming the council votes to do so, if not naturally this PR doesn't matter), but if not feel free to close this and I'll incorporate it into a v0.0.2 or similar of this document.