### PR TITLE
ecaps2: mention xml:lang inheritance from <stream>

### DIFF
--- a/xep-0390.xml
+++ b/xep-0390.xml
@@ -130,7 +130,7 @@
     <div class="box"><p>General remarks:</p>
     <ul>
       <li><p>The algorithm strongly distinguishes between character data (sequences of Unicode code points) and octet strings (sequences of 8-bit bytes). Whenever character data is encoded to octet strings in the following algorithm, the UTF-8 as specified in &rfc3629; encoding is used. Whenever octet strings are sorted in the following algorithm, the i;octet collation as specified in &rfc4790; is used.</p></li>
-      <li><p>The algorithm uses the <tt>xml:lang</tt> attribute. Implementations must take implicit values for the <tt>xml:lang</tt> attribute into account, for example those inherited from the disco#info or the IQ element.</p></li>
+      <li><p>The algorithm uses the <tt>xml:lang</tt> attribute. Implementations must take implicit values for the <tt>xml:lang</tt> attribute into account, for example those inherited from the disco#info, the IQ element, or from the root &lt;stream&gt; tag.</p></li>
     </ul></div>
     <ol>
       <li>If the &lt;query/&gt; element contains any elements except &lt;identity/&gt;, &lt;feature/&gt; (both from the &xep0030; disco#info namespace) or &xep0128; data forms, abort with an error.</li>


### PR DESCRIPTION
The remark already talks about the outer elements as potential source
of xml:lang, but it does not explicitly mention the root <stream> open
element as further source. Better to spell this out explicitly to hint
implementors towards it.