### PR TITLE
Move ref target attribute to root node

### DIFF
--- a/ref.xsl
+++ b/ref.xsl
@@ -35,6 +35,7 @@ THE SOFTWARE.
   <xsl:template match='/'>
     <reference>
       <xsl:attribute name='anchor'><xsl:text>XEP-</xsl:text><xsl:value-of select='/xep/header/number'/></xsl:attribute>
+      <xsl:attribute name='target'><xsl:text>http://xmpp.org/extensions/xep-</xsl:text><xsl:value-of select='/xep/header/number'/><xsl:text>.html</xsl:text></xsl:attribute>
       <front>
         <title><xsl:value-of select='/xep/header/title' /></title>
         <xsl:apply-templates select='/xep/header/author'/>


### PR DESCRIPTION
XEPs are currently rendered without the URL when referenced from an RFC because target is on a list of formats and not on the root node. This copies the attribute to the root node.

For an example reference see https://xml2rfc.tools.ietf.org/public/rfc/bibxml2/reference.NIST.SP.800-185.xml