### PR TITLE
XEP-0389: new revision

### DIFF
--- a/xep-0389.xml
+++ b/xep-0389.xml
@@ -166,8 +166,8 @@
   </p>
   <p>
     For recovery or registration, the server MUST include a list of all
-    challenge types which the client may receive during the course of
-    registering or recovering an account.
+    challenges which the client may receive during the course of registering or
+    recovering an account.
     These are grouped into "flows" and let the client pick a registration
     workflow that only contains challenges which the client supports.
     Each &lt;flow/&gt; element MUST have a unique "id" attribute which is used
@@ -182,7 +182,7 @@
     representing the various challenges that must be completed to complete the
     registration or recovery flow.
     Each &lt;challenge/&gt; element contains a string that uniquely (within the
-    given parent element) identifies the type of challenge that will be offered.
+    given parent element) identifies the challenge that will be offered.
     If a flow would offer the same challenge twice (eg. two dataforms asking for
     different data), the challenge SHOULD only be listed once in the flow
     element.
@@ -264,12 +264,10 @@
     If replying to an IQ, the challenge must be wrapped in an IQ of type
     "result".
     Challenges take the form of a &lt;challenge/&gt; element qualified by the
-    'urn:xmpp:register:0' namespace with a 'type' attribute containing the
-    challenge type and containing a challenge data payload.
+    'urn:xmpp:register:0' namespace with a 'type' attribute that uniquely
+    identifies the type of payload a client might expect the element to contain.
   </p>
   <p>
-    Type type of a challenge is a value which identifes what sort of payload a
-    client might expect.
     This document defines a type of 'jabber:x:data' which MUST always contain a
     data form (an 'x' element with type 'form') as defined by &xep0004;.
     Other types may be defined in the future.
@@ -304,8 +302,8 @@
     sending a &lt;response/&gt; element qualified by the 'urn:xmpp:register:0'
     namespace or a cancellation as defined later in this document.
     If the client sends a response, it MUST also include a payload defined by
-    the specific challenge type.
-    In the case of a jabber:x:data challenge, the payload should be a form
+    the challenges 'type' element.
+    In the case of a "jabber:x:data" challenge, the payload should be a form
     submission as defined by &xep0004; (an 'x' element of type 'submit').
     For instance, to reply to the data form challenge from the previous example
     a client might send:
@@ -438,16 +436,16 @@
   <status>provisional</status>
 </ns>]]></code>
   </section2>
-  <section2 topic='IBR Challenge Types Registry' anchor='registrar-challenges'>
+  <section2 topic='IBR Challenges Registry' anchor='registrar-challenges'>
     <p>
-      The XMPP Registrar shall maintain a registry of IBR challenge types.
-      Challenge types defined within the XEP series MUST be registered with the
-      XMPP Registrar.
+      The XMPP Registrar shall maintain a registry of IBR challenges.
+      Challenges defined within the XEP series MUST be registered with the XMPP
+      Registrar.
     </p>
     &REGPROCESS;
     <code><![CDATA[
 <challenge>
-  <name>The name of the challenge (from the initial <challenge/> listing).</name>
+  <type>A name that uniquely identifies the challenge.</type>
   <desc>A natural-language summary of the challenge.</desc>
   <doc>
     The doucment (or documents) in which the IBR challenge and its paylaod are
@@ -459,18 +457,18 @@
   </p>
   </section2>
   <section2 topic='Challenge Types' anchor='registrar-ibrchallenges'>
-    <p>This specification defines the following IBR challenge types:</p>
+    <p>This specification defines the following IBR challenge:</p>
     <ul>
       <li>jabber:x:data</li>
     </ul>
     <p>
       Upon advancement of this specification from a status of Experimental to a
       status of Draft, the &REGISTRAR; shall add the following definition to the
-      IBR challenge types registry, as described in this document:
+      IBR challenges registry, as described in this document:
     </p>
-    <code caption='Challenge Type Registry Submission for Data Forms'><![CDATA[
+    <code caption='IBR Challenges Registry Submission for Data Forms'><![CDATA[
 <challenge>
-  <name>jabber:x:data</name>
+  <type>jabber:x:data</type>
   <desc>Requests that the client fill out an XEP-0004 data form.</desc>
   <doc>&xep0389;, &xep0004;</doc>
 </challenge>]]></code>

--- a/xep-0389.xml
+++ b/xep-0389.xml
@@ -32,6 +32,21 @@
   <shortname>ibr2</shortname>
   &sam;
   <revision>
+    <version>0.4.0</version>
+    <date>2020-04-22</date>
+    <initials>ssw</initials>
+    <remark>
+      <ul>
+        <li>Add OOB challenge type.</li>
+        <li>Add IQ query for flows.</li>
+        <li>Add a glossary.</li>
+        <li>Make challenge listings more consistent.</li>
+        <li>Cleanup and expand the registrar considerations section.</li>
+        <li>Clarifications and typo fixes throughout the text.</li>
+      </ul>
+    </remark>
+  </revision>
+  <revision>
     <version>0.3.0</version>
     <date>2020-04-19</date>
     <initials>ssw</initials>
@@ -216,14 +231,14 @@
     registration or recovery flow.
     Each &lt;challenge/&gt; element contains a "type" attribute that uniquely
     identifies the challenge for the purpose of determining if it is supported.
-    If a flow would offer the same challenge twice (eg. two dataforms asking for
-    different data), the challenge SHOULD only be listed once in the flow
+    If a flow would offer the same challenge twice (eg. two data forms asking
+    for different data), the challenge SHOULD only be listed once in the flow
     element.
   </p>
   <p>
     For example, a server may advertise a "Verify with SMS" flow and a "Verify
-    by Phone Call" flow that both show a dataform asking for a phone number
-    and then a second dataform asking for a token provided to the user in a
+    by Phone Call" flow that both show a data form asking for a phone number
+    and then a second data form asking for a token provided to the user in a
     text message or phone call depending on which flow the user selects.
   </p>
   <example caption='Host Advertises Stream Features'><![CDATA[
@@ -332,7 +347,7 @@
     If the client is initiating registration or recovery after a stream has
     already been initiated it uses the same registration element wrapped in an
     IQ of type "set".
-  </p>
+    </p>
   <example caption='Client selects a recovery flow after stream negotiation'><![CDATA[
 <iq type='set' id='foo'>
   <recovery xmlns='urn:xmpp:register:0'>
@@ -347,14 +362,28 @@
     'urn:xmpp:register:0' namespace with a 'type' attribute that uniquely
     identifies the type of payload a client might expect the element to contain.
   </p>
+    <example caption='Server issues a challenge'><![CDATA[
+<challenge xmlns='urn:xmpp:register:0'
+           type='urn:example:challenge'>
+  <example xmlns='urn:example:challenge'>Payload</example>
+</challenge>]]></example>
   <p>
-    This document defines a type of 'jabber:x:data' which MUST always contain a
-    data form (an 'x' element with type 'form') as defined by &xep0004;.
-    Other types may be defined in the future.
-    For example, a challenge containing a data form might look like the
-    following:
+    After a challenge is received, the client replies to the challenge by
+    sending a &lt;response/&gt; element qualified by the 'urn:xmpp:register:0'
+    namespace or a cancellation as defined later in this document.
+    If the client sends a response, it MUST also include the payload
+    corresponding to the challenges 'type' element (which may be empty).
   </p>
-  <example caption='Host Returns Registration Form to Entity'><![CDATA[
+    <example caption='Client responds to a challenge'><![CDATA[
+<response xmlns='urn:xmpp:register:0'>
+  <result xmlns='urn:example:challenge'>Example Response</result>
+</response>]]></example>
+  <section2 topic='Data Form' anchor='dataform'>
+    <p>
+      This document defines a type of 'jabber:x:data' which MUST always contain a
+      data form (an 'x' element with type 'form') as defined by &xep0004;.
+    </p>
+    <example caption='Server issues a data form challenge'><![CDATA[
 <challenge xmlns='urn:xmpp:register:0'
            type='jabber:x:data'>
   <x xmlns='jabber:x:data' type='form'>
@@ -375,20 +404,14 @@
       <required/>
     </field>
   </x>
-</challenge>
-]]></example>
+</challenge>]]></example>
   <p>
-    After a challenge is received, the client replies to the challenge by
-    sending a &lt;response/&gt; element qualified by the 'urn:xmpp:register:0'
-    namespace or a cancellation as defined later in this document.
-    If the client sends a response, it MUST also include a payload defined by
-    the challenges 'type' element.
-    In the case of a "jabber:x:data" challenge, the payload should be a form
-    submission as defined by &xep0004; (an 'x' element of type 'submit').
+    The response to a "jabber:x:data" challenge MUST be a form submission (an
+    'x' element of type 'submit').
     For instance, to reply to the data form challenge from the previous example
     a client might send:
   </p>
-  <example caption='User Submits Registration Form'><![CDATA[
+  <example caption='Client submits a data form in response to the challenge'><![CDATA[
 <response xmlns='urn:xmpp:register:0'>
   <x xmlns='jabber:x:data' type='submit'>
     <field type='hidden' var='FORM_TYPE'>
@@ -407,8 +430,26 @@
       <value>juliet@capulet.com</value>
     </field>
   </x>
-</response>
-]]></example>
+</response>]]></example>
+  </section2>
+  <section2 topic='Out of Band Data' anchor='oob'>
+    <p>
+      Challenges of the type "jabber:x:oob" MUST contain an &lt;x/&gt; element
+      qualified by the "jabber:x:oob" namespace as defined in &xep0066;.
+    </p>
+    <example caption='Server issues an OOB challenge'><![CDATA[
+<challenge xmlns='urn:xmpp:register:0'
+           type='jabber:x:oob'>
+  <x xmlns='jabber:x:oob'>
+    <url>http://example.net/login?token=foo</url>
+  </x>
+</challenge>]]></example>
+    <p>
+      If the client sends a response to the OOB challenge it MUST be empty.
+    </p>
+    <example caption='Client acknowledges the OOB challenge'><![CDATA[
+<response xmlns='urn:xmpp:register:0'/>]]></example>
+  </section2>
 </section1>
 <section1 topic='Completing Registration or Recovery' anchor='completion'>
   <p>
@@ -528,7 +569,7 @@
   <type>A name that uniquely identifies the challenge.</type>
   <desc>A natural-language summary of the challenge.</desc>
   <doc>
-    The doucment (or documents) in which the IBR challenge and its paylaod are
+    The document (or documents) in which the IBR challenge and its payload are
     defined.
   </doc>
 </challenge>]]></code>
@@ -540,17 +581,24 @@
     <p>This specification defines the following IBR challenge:</p>
     <ul>
       <li>jabber:x:data</li>
+      <li>jabber:x:oob</li>
     </ul>
     <p>
       Upon advancement of this specification from a status of Experimental to a
-      status of Draft, the &REGISTRAR; shall add the following definition to the
-      IBR challenges registry, as described in this document:
+      status of Draft, the &REGISTRAR; shall add the following definitions to
+      the IBR challenges registry, as described in this document:
     </p>
     <code caption='IBR Challenges Registry Submission for Data Forms'><![CDATA[
 <challenge>
   <type>jabber:x:data</type>
   <desc>Requests that the client fill out an XEP-0004 data form.</desc>
   <doc>&xep0389;, &xep0004;</doc>
+</challenge>]]></code>
+    <code caption='IBR Challenges Registry Submission for OOB Data'><![CDATA[
+<challenge>
+  <type>jabber:x:oob</type>
+  <desc>Requests that the client execute a URI.</desc>
+  <doc>&xep0066;</doc>
 </challenge>]]></code>
   </section2>
   <section2 topic='Namespace Versioning' anchor='registrar-versioning'>

--- a/xep-0389.xml
+++ b/xep-0389.xml
@@ -407,9 +407,36 @@
     <p>
       Upon advancement of this specification from a status of Experimental to a
       status of Draft, the &REGISTRAR; shall add the foregoing namespace to the
-      registry located at &STREAMFEATURES;, as described in Section 4 of
-      &xep0053;.
+      registries located at &STREAMFEATURES;, and &DISCOFEATURES; as described
+      in Section 4 of &xep0053;.
     </p>
+    <code caption='Service Discovery Features Registry Submission'><![CDATA[
+<var>
+  <name>urn:xmpp:register:0</name>
+  <desc>Support for in band registration and password reset.</desc>
+  <doc>&xep0389;</doc>
+</var>]]></code>
+    <code caption='Stream Features Registry Submission'><![CDATA[
+<feature>
+  <ns>urn:xmpp:register:0</ns>
+  <name>Extensible In-Band Registration</name>
+  <element>register</element>
+  <desc>Support for in band registration and password reset.</desc>
+  <doc>&xep0389;</doc>
+</feature>]]></code>
+    <p>
+      The &REGISTRAR; shall also add the foregoing namespace to the Jabber/XMPP
+      Protocol Namespaces Registry located at &NAMESPACES;.
+      Upon advancement of this specification from a status of Experimental to a
+      status of Draft, the &REGISTRAR; shall remove the provisional status from
+      this registry entry.
+    </p>
+    <code caption='Jabber/XMPP Protocol Namespaces Registry Submission'><![CDATA[
+<ns>
+  <name>urn:xmpp:register:0</name>
+  <doc>&xep0389;</doc>
+  <status>provisional</status>
+</ns>]]></code>
   </section2>
   <section2 topic='IBR Challenge Types Registry' anchor='registrar-challenges'>
     <p>
@@ -420,14 +447,11 @@
     &REGPROCESS;
     <code><![CDATA[
 <challenge>
-  <name>The name of the challenge type.</name>
+  <name>The name of the challenge (from the initial <challenge/> listing).</name>
   <desc>A natural-language summary of the challenge.</desc>
-  <payloaddoc>
-    The document in which the IBR challenge payload is specified.
-  </payloaddoc>
   <doc>
-    The doucment in which the IBR challenge itself is specified (may be the same
-    as <payloaddoc/>).
+    The doucment (or documents) in which the IBR challenge and its paylaod are
+    defined.
   </doc>
 </challenge>]]></code>
   <p>
@@ -444,13 +468,12 @@
       status of Draft, the &REGISTRAR; shall add the following definition to the
       IBR challenge types registry, as described in this document:
     </p>
-    <code><![CDATA[
+    <code caption='Challenge Type Registry Submission for Data Forms'><![CDATA[
 <challenge>
-  <name>Data Forms Challenge</name>
+  <name>jabber:x:data</name>
   <desc>Requests that the client fill out an XEP-0004 data form.</desc>
-  <payloaddoc>XEP-0004</payloaddoc>
-  <doc>TODO: Insert this document once it is assigned a number</doc>
-</profile>]]></code>
+  <doc>&xep0389;, &xep0004;</doc>
+</challenge>]]></code>
   </section2>
   <section2 topic='Namespace Versioning' anchor='registrar-versioning'>
     &NSVER;

--- a/xep-0389.xml
+++ b/xep-0389.xml
@@ -117,6 +117,38 @@
     </li>
   </ul>
 </section1>
+<section1 topic='Glossary' anchor='glossary'>
+  <dl>
+    <di>
+      <dt>Challenge</dt>
+      <dd>
+        A challenge is an action taken during account registration or recovery
+        that requires a response.
+        For example, displaying a form to a user or asking for a token.
+      </dd>
+    </di>
+    <di>
+      <dt>Challenge Type</dt>
+      <dd>
+        The type of a challenge is a unique string that identifies the type of
+        payload that can be expected.
+        For example, a challenge element with type "jabber:x:data" can be
+        expected to contain a data form.
+        Challenge types must be defined and registered in the challenge types
+        registry.
+        When defining a challenge it is often convenient to reuse an XML
+        namespace from the document defining the challenge.
+      </dd>
+    </di>
+    <di>
+      <dt>Flow</dt>
+      <dd>
+        A flow, or more specifically a "registration flow" or "recovery flow",
+        is an ordered collection of challenges.
+      </dd>
+    </di>
+  </dl>
+</section1>
 <section1 topic='Use Cases' anchor='usecases'>
   <ul>
     <li>

--- a/xep-0389.xml
+++ b/xep-0389.xml
@@ -193,7 +193,7 @@
     and then a second dataform asking for a token provided to the user in a
     text message or phone call depending on which flow the user selects.
   </p>
-  <example caption="Host Advertises Stream Features"><![CDATA[
+  <example caption='Host Advertises Stream Features'><![CDATA[
 <stream:features>
   <mechanisms xmlns='urn:xmpp:sasl:0'>
     <mechanism>EXTERNAL</mechanism>
@@ -202,28 +202,28 @@
     <mechanism>PLAIN</mechanism>
   </mechanisms>
   <register xmlns='urn:xmpp:register:0'>
-    <flow id="0">
+    <flow id='0'>
       <name>Verify with SMS</name>
       <challenge>jabber:x:data</challenge>
     </flow>
-    <flow id="1">
+    <flow id='1'>
       <name>Verify by Phone Call</name>
       <challenge>jabber:x:data</challenge>
     </flow>
-    <flow id="2">
+    <flow id='2'>
       <name>Verify with the web</name>
       <challenge>jabber:x:data</challenge>
       <challenge>jabber:x:oob</challenge>
     </flow>
   </register>
   <recovery xmlns='urn:xmpp:register:0'>
-    <flow id="0">
+    <flow id='0'>
       <name>Visit Password Recovery Site</name>
       <challenge>jabber:x:oob</challenge>
     </flow>
   </recovery>
 </stream:features>]]></example>
-</section2>
+  </section2>
   <section2 topic='Service Discovery'>
     <p>
       Clients, servers, and other services such as components that support
@@ -244,19 +244,19 @@
     For example, to select the "Verify by Phone Call" registration flow from
     the previous example, the client would reply with:
   </p>
-  <example caption="Client selects a recovery flow"><![CDATA[
+  <example caption='Client selects a recovery flow'><![CDATA[
 <register xmlns='urn:xmpp:register:0'>
-  <flow id="1"/>
+  <flow id='1'/>
 </register>]]></example>
   <p>
     If the client is initiating registration or recovery after a stream has
     already been initiated it uses the same registration element wrapped in an
     IQ of type "set".
   </p>
-  <example caption="Client selects a recovery flow after stream negotiation"><![CDATA[
-<iq type="set" id="foo">
+  <example caption='Client selects a recovery flow after stream negotiation'><![CDATA[
+<iq type='set' id='foo'>
   <recovery xmlns='urn:xmpp:register:0'>
-    <flow id="0"/>
+    <flow id='0'/>
   </recovery>
 </iq>]]></example>
   <p>

--- a/xep-0389.xml
+++ b/xep-0389.xml
@@ -264,8 +264,55 @@
       fact by including a feature of "urn::xmpp:register:0" in response to
       &xep0030; information requests and in their &xep0115; profiles.
     </p>
-    <example caption='Disco response'><![CDATA[
-<feature var='urn:xmpp:register:0' />]]></example>
+    <example caption='Disco info response'><![CDATA[
+<query xmlns='http://jabber.org/protocol/disco#info'>
+  …
+  <feature var='urn:xmpp:register:0' />
+  …
+</query>]]></example>
+  </section2>
+  <section2 topic='Retrieving the Flows'>
+    <p>
+      To find what flows an entity provides (if any) after stream negotiation is
+      complete the requester can send an IQ of type "get" containing a
+      &lt;register&gt; or &lt;recovery&gt; element qualified by the
+      "urn:xmpp:register:0" namespace.
+    </p>
+    <p>
+      When responding to a query for registration or recovery flows the list of
+      challenges should be included just as it would be if during stream feature
+      negotiation.
+      That is, a "register" or "recovery" element containing a list of flows,
+      each with an id, containing a name and a list of challenges.
+      If an entity supports this specification but does not provide any flows
+      after stream negotiation it MUST respond with an empty list.
+    </p>
+    <example caption='Registration flows query'><![CDATA[
+<iq type='get'>
+  <register xmlns='urn:xmpp:register:0'/>
+</iq>]]></example>
+    <example caption='Registration flows results'><![CDATA[
+<iq type='result'>
+  <register xmlns='urn:xmpp:register:0'>
+    <flow id='0'>
+      <name>Verify with SMS</name>
+      <challenge type='jabber:x:data'/>
+    </flow>
+    <flow id='1'>
+      <name>Verify by Phone Call</name>
+      <challenge type='jabber:x:data'/>
+    </flow>
+    <flow id='2'>
+      <name>Verify with the web</name>
+      <challenge type='jabber:x:data'/>
+      <challenge type='jabber:x:oob'/>
+    </flow>
+  </register>
+</iq>]]></example>
+    <example caption='Empty registration flows results'><![CDATA[
+<iq type='result'>
+  <register xmlns='urn:xmpp:register:0'/>
+</iq>]]></example>
   </section2>
 </section1>
 <section1 topic='Challenges' anchor='challenge'>

--- a/xep-0389.xml
+++ b/xep-0389.xml
@@ -87,7 +87,7 @@
     To solve these issues this specification provides a new in-band registration
     protocol that allows servers to present the user with a series of
     "challenges".
-    This allows for both multi-stage proof-of-posession registration flows and
+    This allows for both multi-stage proof-of-possession registration flows and
     spam prevention mechanisms such as proof-of-work functions.
   </p>
 </section1>
@@ -140,7 +140,7 @@
       continue.
     </li>
     <li>
-      As a server operator I want to prevent SPIM using a proof-of-posession
+      As a server operator I want to prevent SPIM using a proof-of-possession
       protocol so I present the user with a form asking for a mobile phone
       number and then send a verification code to that number via SMS and show
       another form requesting the verification code.
@@ -302,7 +302,7 @@
   <p>
     After a challenge is received, the client replies to the challenge by
     sending a &lt;response/&gt; element qualified by the 'urn:xmpp:register:0'
-    namespace or a cancelation as defined later in this document.
+    namespace or a cancellation as defined later in this document.
     If the client sends a response, it MUST also include a payload defined by
     the specific challenge type.
     In the case of a jabber:x:data challenge, the payload should be a form
@@ -348,8 +348,8 @@
     wishes to cancel the flow, it MAY respond to any IQ from the client with the
     cancel element and type "result".
   </p>
-  <example caption='Server cancels rquest'><![CDATA[
-<iq type="result" id="bar">
+  <example caption='Server cancels request'><![CDATA[
+<iq type='result' id='bar'>
   <cancel xmlns='urn:xmpp:register:0'/>
 </iq>]]></example>
   <p>
@@ -367,8 +367,8 @@
     If the IQ based flow is being used and the server wishes to indicate success
     it sends an empty IQ response of type "result".
   </p>
-  <example caption='Server indicates success after stream negotation'><![CDATA[
-<iq type="result" id="bar" />]]></example>
+  <example caption='Server indicates success after stream negotiation'><![CDATA[
+<iq type='result' id='bar' />]]></example>
 </section1>
 <section1 topic='Internationalization Considerations' anchor='i18n'>
   <p>
@@ -387,7 +387,7 @@
     Servers that allow in-band registration need to take measures to prevent
     abuse.
     Common techniques to prevent spam registrations include displaying CAPTCHAs
-    or requiring proof-of-posession of a valid email address or telephone number
+    or requiring proof-of-possession of a valid email address or telephone number
     by sending a unique code (e.g. an HMAC that can later be verified as having
     originated at the server) to the users email and requiring that they enter
     the code before continuing.

--- a/xep-0389.xml
+++ b/xep-0389.xml
@@ -144,7 +144,8 @@
       <dt>Flow</dt>
       <dd>
         A flow, or more specifically a "registration flow" or "recovery flow",
-        is an ordered collection of challenges.
+        is a collection of challenges that together can be used to gather enough
+        information to register a new account or recover an existing account.
       </dd>
     </di>
   </dl>
@@ -210,11 +211,11 @@
     for the "xml:lang" attribute.
     Clients MAY use the name element to show the different flows to the user and
     ask them to pick between them.
-    Each flow must also contain a list of &lt;challenge/&gt; elements
+    Each flow must also contain an unordered set of &lt;challenge/&gt; elements
     representing the various challenges that must be completed to complete the
     registration or recovery flow.
-    Each &lt;challenge/&gt; element contains a string that uniquely (within the
-    given parent element) identifies the challenge that will be offered.
+    Each &lt;challenge/&gt; element contains a "type" attribute that uniquely
+    identifies the challenge for the purpose of determining if it is supported.
     If a flow would offer the same challenge twice (eg. two dataforms asking for
     different data), the challenge SHOULD only be listed once in the flow
     element.
@@ -236,22 +237,22 @@
   <register xmlns='urn:xmpp:register:0'>
     <flow id='0'>
       <name>Verify with SMS</name>
-      <challenge>jabber:x:data</challenge>
+      <challenge type='jabber:x:data'/>
     </flow>
     <flow id='1'>
       <name>Verify by Phone Call</name>
-      <challenge>jabber:x:data</challenge>
+      <challenge type='jabber:x:data'/>
     </flow>
     <flow id='2'>
       <name>Verify with the web</name>
-      <challenge>jabber:x:data</challenge>
-      <challenge>jabber:x:oob</challenge>
+      <challenge type='jabber:x:data'/>
+      <challenge type='jabber:x:oob'/>
     </flow>
   </register>
   <recovery xmlns='urn:xmpp:register:0'>
     <flow id='0'>
       <name>Visit Password Recovery Site</name>
-      <challenge>jabber:x:oob</challenge>
+      <challenge type='jabber:x:oob'/>
     </flow>
   </recovery>
 </stream:features>]]></example>


### PR DESCRIPTION
Here are a handful of self-contained commits that make up a new revision of XEP-0389. These include adding a glossary, lots of typo fixes, some clarifications, adding the ability to query for registration/recovery flows after stream negotiation has been complete, the addition of an OOB challenge, and minor changes to the challenge list.