### PR TITLE
caps: fix complex generation example by adding missing form field type

### DIFF
--- a/xep-0115.xml
+++ b/xep-0115.xml
@@ -345,7 +345,7 @@
       &lt;field var='FORM_TYPE' type='hidden'&gt;
         &lt;value&gt;urn:xmpp:dataforms:softwareinfo&lt;/value&gt;
       &lt;/field&gt;
-      &lt;field var='ip_version'&gt;
+      &lt;field var='ip_version' type='text-multi' &gt;
         &lt;value&gt;ipv4&lt;/value&gt;
         &lt;value&gt;ipv6&lt;/value&gt;
       &lt;/field&gt;


### PR DESCRIPTION
The default form field type is text-single, but the hyptothetical
field ip_version has multiple values and hence can not be of type
text-single.