### PR TITLE
protoXEP Quick Response: Remove some outdated information

### DIFF
--- a/inbox/quick-response.xml
+++ b/inbox/quick-response.xml
@@ -5,7 +5,6 @@
   <!ENTITY xepname "Quick Response">
 %ents;
 ]>
-<!-- TODO: put text content into text nodes and not into attribute -->
 <?xml-stylesheet type='text/xsl' href='xep.xsl'?>
 <xep>
 <header>
@@ -23,38 +22,14 @@
   <supersededby/>
   <shortname>NOT_YET_ASSIGNED</shortname>
   <author>
-    <firstname>Kim</firstname>
-    <surname>Alvefur</surname>
-    <email>zash@zash.se</email>
-    <jid>zash@zash.se</jid>
-  </author>
-  <author>
     <firstname>Tim</firstname>
     <surname>Henkes</surname>
     <email>me@syndace.dev</email>
   </author>
   <revision>
-    <version>0.1.0</version>
+    <version>0.0.1</version>
     <date>2020-04-20</date>
     <initials>th</initials>
-    <remark>
-      <ul>
-        <li>Renamed to better reflect the use-case</li>
-        <li>Split into two use-cases, one for textual responses and one for quick access to actions</li>
-        <li>Clarified i18n and general behavioral details</li>
-      </ul>
-    </remark>
-  </revision>
-  <revision>
-    <version>0.0.2</version>
-    <date>2018-09-30</date>
-    <initials>ka</initials>
-    <remark>Polishing preparing for submission</remark>
-  </revision>
-  <revision>
-    <version>0.0.1</version>
-    <date>2018-09-02</date>
-    <initials>ka</initials>
     <remark>Initial version</remark>
   </revision>
 </header>


### PR DESCRIPTION
This PR removes @Zash from the list of authors and deletes a few version blocks. These two pieces of information were in the protoXEP for "historical reasons": I started writing this protoXEP by modifying an existing one, but later I rewrote it completely, so the version blocks and the author information is false/outdated. This PR clarifies the state of this protoXEP being a new specification and not a modified one.

I'm not sure whether changes like these are possible in experimental, that's why I'd like to get this in before the council meeting next Wednesday.