### PR TITLE
XEP-0414: Reverse SHOULD/MUST for Blake2b algorithms

### DIFF
--- a/xep-0414.xml
+++ b/xep-0414.xml
@@ -21,6 +21,12 @@
   <shortname>hashrecs</shortname>
   &jonaswielicki;
   <revision>
+    <version>0.4.0</version>
+    <date>2020-05-23</date>
+    <initials>rion</initials>
+    <remark>Make Blake2b-256 SHOULD and Blake2b 512 MUST</remark>
+  </revision>
+  <revision>
     <version>0.3.0</version>
     <date>2019-08-19</date>
     <initials>jsc</initials>
@@ -151,12 +157,12 @@
     <tr>
       <td>BLAKE2b256</td>
       <td>256 bits</td>
-      <td>MUST</td>
+      <td>SHOULD</td>
     </tr>
     <tr>
       <td>BLAKE2b512</td>
       <td>512 bits</td>
-      <td>SHOULD</td>
+      <td>MUST</td>
     </tr>
   </table>
   <p>These recommendations ought to be reviewed yearly by the &COUNCIL;.</p>


### PR DESCRIPTION
While Blake2b is capable to produce digests of any size from 1 to 64 bytes, It's default mode is 64 bytes (512 bits) though.
Some libraries implement just default digest size.

* OpenSSL supports blake2s-256 and blake2b-512 (no blake2b-256)
* gcrypt supports both blake2b-256 and blake2b-512
* nss supports none of blake2b
* Botan - any digest size
* Java: https://github.com/alphazero/Blake2b - any digest size
* Go-lang: https://godoc.org/golang.org/x/crypto/blake2b - both blake2b-256 and blake2b-512
* Rust: https://docs.rs/blake2/0.8.1/blake2/ - any digest size, 512 by default
* JS: https://github.com/dcposch/blakejs - any digest size, 512 by default

Also various libraries based on openssl will provide just blake2b-512.
So it looks to be a preferable choice over blake2b-256