### PR TITLE
DNM: XEP-0393: updates based on LC feedback

### DIFF
--- a/xep-0393.xml
+++ b/xep-0393.xml
@@ -27,6 +27,18 @@
   <shortname>styling</shortname>
   &sam;
   <revision>
+    <version>0.3.0</version>
+    <date>2020-06-01</date>
+    <initials>ssw</initials>
+    <remark>
+      <p>
+        Add ability to disable styling for a single message, further clarify
+        accessibility considerations, and mention that Styling is not Markdown
+        in the security considerations section.
+      </p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.2.2</version>
     <date>2020-05-20</date>
     <initials>ssw</initials>
@@ -441,6 +453,22 @@
     </section3>
   </section2>
 </section1>
+<section1 topic='Disabling Styling' anchor='disable'>
+  <p>
+    On rare occasions styling hints may conflict with the contents of a message.
+    For example, if the user sends the emoji "&gt; _ &lt;" it would be
+    interpreted as a block quote.
+    To fix this, senders may indicate to the receiver that a particular message
+    SHOULD NOT be styled by adding an empty &lt;unstyled&gt; element qualified
+    by the "urn:xmpp:styling:0" namespace.
+  </p>
+  <example caption='Sender indicates that styling is disabled'><![CDATA[
+<message>
+  <body>&gt; _ &lt;</body>
+  <unstyled xmlns="urn:xmpp:styling:0"/>
+</message>
+]]></example>
+</section1>
 <section1 topic='Implementation Notes' anchor='impl'>
   <p>
     This document does not define a regular grammar and thus styling cannot be
@@ -467,15 +495,25 @@
     text more difficult to read for visually impaired users.
   </p>
   <p>
-    Styled text may also be rendered poorly by screen readers.
+    Styled text may be rendered poorly by screen readers.
     When applying formatting it may be desirable to include directives to
-    exclude styling directives from being read.
+    exclude styling directives from being read, or to add markers to the final
+    output that have semantic meaning for screen readers.
+    For example, in an web based client an emphasis span might be converted to
+    an HTML &lt;emph&gt; element.
   </p>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
   <p>
     Authors of message styling parsers should take care that improperly
     formatted messages cannot lead to buffer overruns or code execution.
+  </p>
+  <p>
+    Though message styling is not compatible with Markdown, some of its styles
+    are similar.
+    Markdown parsers often allow arbitrary HTML to be inserted into documents
+    and therefore MUST NOT be used to parse the format defined in this document
+    even if they are flexible enough to do so.
   </p>
 </section1>
 <section1 topic='IANA Considerations' anchor='iana'>


### PR DESCRIPTION
## DO NOT MERGE

This updates XEP-0393 based on LC feedback. In particular it attempts to further clarify how accessibility might be handled (without imposing requirements which will depend on the system in which the spec is being implemented), mention security concerns people had around Markdown parsers, and add an `unstyled` hint.