### PR TITLE
XEP-0393: remove disabling individual spans/blocks

### DIFF
--- a/xep-0393.xml
+++ b/xep-0393.xml
@@ -27,6 +27,18 @@
   <shortname>styling</shortname>
   &sam;
   <revision>
+    <version>0.4.0</version>
+    <date>2020-06-02</date>
+    <initials>ssw</initials>
+    <remark>
+      <p>
+        Remove description of mechanism for disabling styling on individual
+        spans and blocks, users can do this themselves without us documenting
+        the use of a codepoint that's not specifically for this purpose.
+      </p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.3.0</version>
     <date>2020-06-02</date>
     <initials>ssw</initials>
@@ -471,33 +483,16 @@
     On rare occasions styling hints may conflict with the contents of a message.
     For example, if the user sends the emoji "&gt; _ &lt;" it would be
     interpreted as a block quote.
+    Senders may indicate to the receiver that a particular message SHOULD NOT be
+    styled by adding an empty &lt;unstyled&gt; element qualified by the
+    "urn:xmpp:styling:0" namespace.
   </p>
-
-  <section2 topic='Individual Directives'>
-    <p>
-      To remove styling without removing the styling directives, a whitespace
-      character can be inserted after the opening styling directive and before
-      the closing styling directive (if applicable).
-      This whitespace character SHOULD be U+2060 WORD JOINER to prevent line
-      breaks between the character that was misinterpreted as a styling
-      directive and the text that it would otherwise style.
-    </p>
-  </section2>
-  <section2 topic='Entire Messages'>
-    <p>
-      An entire message may also have styling disabled to remove the need to
-      parse the message for styling in the first place.
-      Senders may indicate to the receiver that a particular message SHOULD NOT
-      be styled by adding an empty &lt;unstyled&gt; element qualified by the
-      "urn:xmpp:styling:0" namespace.
-    </p>
   <example caption='Sender indicates that styling is disabled'><![CDATA[
 <message>
   <body>&gt; _ &lt;</body>
   <unstyled xmlns="urn:xmpp:styling:0"/>
 </message>
 ]]></example>
-  </section2>
 </section1>
 <section1 topic='Implementation Notes' anchor='impl'>
   <p>
@@ -513,6 +508,13 @@
     same manner as the text they apply to.
     For example, the string "*emphasis*" would be rendered as
     "<strong>*emphasis*</strong>".
+  </p>
+  <p>
+    This specification does not provide a mechanism for removing styling from
+    individual spans or blocks within a styled message.
+    Implementations are free to implement their own workarounds, for example by
+    inserting Unicode non-printable characters to invalidate styling directives,
+    but no specific technique is known to be widely supported.
   </p>
 </section1>
 <section1 topic='Accessibility Considerations' anchor='access'>


### PR DESCRIPTION
This was a nice workaround, but a convenient code point that is actually
for this sort of use can't be found. While this still works and can be used in individual implementations, let's not make any specific recommendations at this time.