### PR TITLE
XEP-0156: reorganize stating XRD/JRD requirements

### DIFF
--- a/xep-0156.xml
+++ b/xep-0156.xml
@@ -200,6 +200,7 @@ _xmppconnect IN TXT "_xmpp-client-websocket=wss://web.example.com:443/ws"
   <section2 topic='Business Rules' anchor='httpbizrules'>
     <p>The following business rules apply:</p>
     <ol start='1'>
+      <li>Services implementing this XEP MUST offer the information in the Extensible Resource Descriptor (XRD) format and SHOULD additionally provide the JRD format (both formats are specified in &rfc6415;).</li>
       <li>HTTP queries for host-meta information MUST be used only as a fallback after the methods specified in <cite>RFC 6120</cite> have been exhausted.</li>
       <li>A domain SHOULD NOT present information in host-meta link records that is available via the DNS SRV records defined in <cite>RFC 6120</cite>.</li>
       <li>The order of XMPP related link entries in the host-meta file SHOULD NOT be interpreted as significant by the presenting domain or the receiving entity.</li>
@@ -208,7 +209,6 @@ _xmppconnect IN TXT "_xmpp-client-websocket=wss://web.example.com:443/ws"
 
   <section2 topic='Examples' anchor='httpexamples'>
     <p>The following examples show two host-meta link records: the first indicates support for the XMPP Over BOSH connection method defined in <cite>XEP-0124</cite> and <cite>XEP-0206</cite> and the second indicates support for the XMPP Over WebSocket connection method defined in &rfc7395;.</p>
-    <p>As specified in <cite>RFC 6120</cite> &sect;3, support for the XML encoding of the host-meta resource is REQUIRED while alternative representations such as JSON are OPTIONAL.</p>
     <example caption='Result for /.well-known/host-meta'><![CDATA[<?xml version='1.0' encoding='utf-8'?>
 <XRD xmlns='http://docs.oasis-open.org/ns/xri/xrd-1.0'>
   ...
@@ -219,7 +219,7 @@ _xmppconnect IN TXT "_xmpp-client-websocket=wss://web.example.com:443/ws"
   ...
 </XRD>
 ]]></example>
-    <p>It is possible to use an alternative JSON format for host-meta information, in which case the above example would be presented as:</p>
+    <p>It is possible to use an alternative JSON format for host-meta information. The JSON representation of the host metadata is named JRD and specified in Appendix A of &rfc6415;. The above XRD example would be presented in JRD as:</p>
     <example caption='Result for /.well-known/host-meta.json'><![CDATA[{
   ...
   "links": [

--- a/xep-0156.xml
+++ b/xep-0156.xml
@@ -219,7 +219,7 @@ _xmppconnect IN TXT "_xmpp-client-websocket=wss://web.example.com:443/ws"
   ...
 </XRD>
 ]]></example>
-    <p>It is possible to use an alternative JSON format for host-meta information. The JSON representation of the host metadata is named JRD and specified in Appendix A of &rfc6415;. The above XRD example would be presented in JRD as:</p>
+    <p>It is possible to use additionally a JSON-based format for host-meta information. The JSON representation of the host metadata is named JRD and specified in Appendix A of &rfc6415;. The above XRD example would be presented in JRD as:</p>
     <example caption='Result for /.well-known/host-meta.json'><![CDATA[{
   ...
   "links": [


### PR DESCRIPTION
The reference to RFC 6120 was incorrect, what this really meant is RFC
6415. But instead of simply s/RFC 6120/RFC 6415/ here, I decided to
reorganize stating the requirements of XRD and JRD a little.