### PR TITLE
XEP-0329: Fix example 7, remove superfluous 'node' attribute

### DIFF
--- a/xep-0329.xml
+++ b/xep-0329.xml
@@ -153,7 +153,7 @@
     from='romeo@montague.net/home'
     to='juliet@capulet.com/chamber'
     id='1236'>
-  <query xmlns="urn:xmpp:fis:0" node="test2.txt">
+  <query xmlns="urn:xmpp:fis:0">
     <file xmlns='urn:xmpp:jingle:apps:file-transfer:4'>
       <name>test2.txt</name>
       <size>1000</size>

--- a/xep-0329.xml
+++ b/xep-0329.xml
@@ -33,6 +33,12 @@
   </author>
   &lance;
   <revision>
+    <version>0.4.1</version>
+    <date>2020-06-14</date>
+    <initials>fs</initials>
+    <remark>Fix example 7, remove superfluous 'node' attribute</remark>
+  </revision>
+  <revision>
     <version>0.4</version>
     <date>2017-09-11</date>
     <initials>XEP Editor (jwi)</initials>


### PR DESCRIPTION
The result IQ's <query/> child element does not need to carry the node
information. And in this case the node information was actually wrong,
since "documents/test2.txt" was queried, and not "test2.txt".