### PR TITLE
XEP-0178: Clarify SASL-EXTERNAL specification when s2s auth fails

### DIFF
--- a/xep-0178.xml
+++ b/xep-0178.xml
@@ -379,7 +379,7 @@
           <p>Implementation Note: If Server2 needs to assign an authorization identity during SASL negotiation, it SHOULD use the value of the 'from' attribute of the stream header sent by Server1.</p>
         </li>
         <li>
-          <p>Else Server2 SHOULD return a &notauthorized; stream error and close the stream.</p>
+          <p>Else Server2 SHOULD return a &notauthorized; error and either close Server1's TCP connection or continue with a Server Dialback (XEP-0220) [8] negotiation.</p>
           <example><![CDATA[
 <failure xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>
   <not-authorized/>


### PR DESCRIPTION
A while back it was discussed that XEP-0178 (SASL-EXTERNAL) for s2s was kinda misleading - it says that server should close connection if authentication fails but it seems that "everyone" (at least Prosody[0] and ejabberd) actually fallbacks to dialback in that case.

This PR changes the specification to reflect status quo.

[0] https://issues.prosody.im/1006