### PR TITLE
XEP-0156: Mention Web Host Metadata Link format in abstract

### DIFF
--- a/xep-0156.xml
+++ b/xep-0156.xml
@@ -7,7 +7,7 @@
 <xep>
 <header>
   <title>Discovering Alternative XMPP Connection Methods</title>
-  <abstract>This document defines a DNS TXT Resource Record format for use in discovering alternative methods of connecting to an XMPP server.</abstract>
+  <abstract>This document defines an XMPP Extension Protocol for discovering alternative methods of connecting to an XMPP server using two ways: (1) DNS TXT Resource Record format; and (2) Web Host Metadata Link format.</abstract>
   &LEGALNOTICE;
   <number>0156</number>
   <status>Draft</status>


### PR DESCRIPTION
The XEP-0156 abstract suggests that it defines only one format for use in discovering alternative methods to connect to an XMPP server. However, the XEP clearly describes two ways for the same.