### PR TITLE
XEP-0045 v1.33.0

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -46,6 +46,12 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.33.0</version>
+    <date>2020-04-15</date>
+    <initials>mw</initials>
+    <remark><p>Clarify that the 307 status code should not be used alongside 333 for user disconnects.</p></remark>
+  </revision>
+  <revision>
     <version>1.32.0</version>
     <date>2019-05-15</date>
     <initials>gl</initials>
@@ -4930,7 +4936,8 @@
 
 <section1 topic='Service Use Cases' anchor='service'>
   <section2 topic='Service removes user because of error response' anchor='service-error-kick'>
-    <p>A MUC service MAY support adding the 333 status code to presences when a user gets removed by the service due to a technical problem (e.g. s2s link failure).</p>
+    <p>A MUC service MAY support adding the 333 status code to presences when a user gets removed by the service due to a technical problem (e.g. s2s link failure).
+       This can, for example, be used as a hint for clients to distinguish between an occupant getting disconnected and them intentionally leaving the room.</p>
     <p>If a MUC service supports this OPTIONAL feature, it MUST include the 333 status code in the resulting presence:</p>
     <example caption='MUC service removes user because of error'><![CDATA[
 <presence
@@ -4940,7 +4947,6 @@
   <x xmlns='http://jabber.org/protocol/muc#user'>
     <item affiliation='none' role='none' />
     <status code='110'/>
-    <status code='307'/>
     <status code='333'/>
   </x>
 </presence>
@@ -4953,11 +4959,14 @@
     type='unavailable'>
   <x xmlns='http://jabber.org/protocol/muc#user'>
     <item affiliation='none' role='none'/>
-    <status code='307'/>
     <status code='333'/>
   </x>
 </presence>
 ]]></example>
+  <p>Note: Some server implementations additionally include a 307 status code (signifying a 'kick', i.e. a forced ejection from the
+     room). This is generally not advisable, as these types of disconnects may be frequent in the presence of poor network conditions
+     and they are not linked to any user (e.g. moderator) action that the 307 code usually indicates. It is therefore recommended for the
+     client to ignore the 307 code if a 333 status code is present.</p>
   </section2>
 </section1>
 


### PR DESCRIPTION
Per discussion in xsf@ about the UX implications of showing user disconnects as kicks.

*Note: This is a new attempt at #926 - there is only one word changed (as Council requested).*