### PR TITLE
XEP-0060: Add missing querytype 'retrieve' action and 'item' key to registry submission

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -50,6 +50,12 @@
   &stpeter;
   &ralphm;
   <revision>
+    <version>1.19.0</version>
+    <date>2020-08-16</date>
+    <initials>ps</initials>
+    <remark><p>Add missing 'item' key and 'retrieve' action to query type registry.</p></remark>
+  </revision>
+  <revision>
     <version>1.18.1</version>
     <date>2020-08-25</date>
     <initials>lnjx</initials>
@@ -6630,11 +6636,19 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings
 	  <name>unsubscribe</name>
           <desc>enables unsubscribing from a pubsub node</desc>
         </value>
+        <value>
+          <name>retrieve</name>
+          <desc>enables retrieving a specific item from a pubsub node</desc>
+        </value>
       </values>
     </key>
     <key>
       <name>node</name>
       <desc>the pubsub node</desc>
+    </key>
+    <key>
+      <name>item</name>
+      <desc>the pubsub item</desc>
     </key>
   </keys>
 </querytype>

--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -50,6 +50,12 @@
   &stpeter;
   &ralphm;
   <revision>
+    <version>1.18.1</version>
+    <date>2020-08-25</date>
+    <initials>lnjx</initials>
+    <remark><p>Fix trivial typo</p></remark>
+  </revision>
+  <revision>
     <version>1.18.0</version>
     <date>2020-02-27</date>
     <initials>jsc</initials>

--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -4188,7 +4188,7 @@ And by opposing end them?
     <field var='pubsub#node' type='text-single' label='Node ID'>
       <value>princely_musings</value>
     </field>
-    <field var='pusub#subscriber_jid' type='jid-single' label='Subscriber Address'>
+    <field var='pubsub#subscriber_jid' type='jid-single' label='Subscriber Address'>
       <value>horatio@denmark.lit</value>
     </field>
     <field var='pubsub#allow' type='boolean'


### PR DESCRIPTION
As discussed [in this mailing list thread](https://mail.jabber.org/pipermail/standards/2020-August/037679.html) the PubSub specification is missing registry entries for the 'retrieve' action and the 'item' key.
This PR adds those to the query type registry submission.