### PR TITLE
XEP template: add a section with various XEP XML examples

### DIFF
--- a/xep-template.xml
+++ b/xep-template.xml
@@ -75,6 +75,48 @@
   itself instead of list or chat archives serves future readers. -->
   <p>RECOMMENDED.</p>
 </section1>
+<section1 topic='XEP Styling Examples (1st Level Heading)' anchor='styling'>
+  <p>PLEASE REMOVE THIS SECTION. These are just examples for the RECOMMENDED ways to style your XEP.</p>
+  <section2 topic='2nd Level Heading' anchor='styling-examples'>
+    <p>This is regular XEP text. It can contain <strong>strong</strong> and <em>emphasized</em> markup as well as <tt>fixed-width text</tt>.</p>
+    <p>This is text with a line break.<br/>New line.</p>
+    <p>This is text with a footnote<note>This is the footnote.</note>.</p>
+    <p>This is a <link url='#styling-examples'>link to a section in this document</link>.</p>
+    <p>This is a reference to another XEP: &xep0001;, it can be re-referenced as <cite>XEP-0001</cite> later in the text.</p>
+    <code caption='Code block caption'>Code block content.</code>
+    <ol>
+      <li>This is an ordered list. First item</li>
+      <li>Second item</li>
+    </ol>
+    <ul>
+      <li>This is an unordered list. First item</li>
+      <li>Second item</li>
+    </ul>
+    <dl>
+      <di>
+	<dt>Definition List</dt>
+	<dd>
+	  A definition list contains definition items with a title and a description.
+	</dd>
+      </di>
+    </dl>
+    <p class='box'>Note: This is an informational box</p>
+    <example caption='Example of embedding XMPP XML'><![CDATA[
+<iq from='hag66@shakespeare.lit/pda'
+    id='h7ns81g'
+    to='shakespeare.lit'
+    type='get'>
+  <query xmlns='http://jabber.org/protocol/disco#items'/>
+</iq>
+]]></example>
+    <section3 topic='3rd Level Heading' anchor='syling-examples-3rd'>
+      <p>Text in a Sub-Sub-Section.</p>
+      <section4 topic='4th Level Heading' anchor='syling-examples-4th'>
+	<p>Text in a Sub-Sub-Sub-Section.</p>
+      </section4>
+    </section3>
+  </section2>
+</section1>
 <section1 topic='XML Schema' anchor='schema'>
   <p>REQUIRED for protocol specifications.</p>
 </section1>


### PR DESCRIPTION
When writing a XEP, you sometimes need to use various styling elements and it is hard to decide which one to take.

Therefore, I've added most of the possible XEP XML elements as examples into the template.

[Rendered version](https://op-co.de/tmp/xep-template.html#styling)