### PR TITLE
XEP-0384 clarify server side requirements

### DIFF
--- a/xep-0384.xml
+++ b/xep-0384.xml
@@ -651,9 +651,9 @@
   <section2 topic='Server side requirements' anchor='server-side'>
     <p>While OMEMO uses a Pubsub Service (&xep0060;) on the user’s account it has more requirments than those defined in &xep0163;. The requirements are:</p>
     <ul>
-      <li>The pubsub service MUST persist node items.</li>
+      <li>The pubsub service MUST support persistent node items via 'pubsub#persist_items' node configuration and 'pubsub#persist_items' as a publish option.</li>
       <li>The pubsub service MUST support publishing options as defined in <link url='https://xmpp.org/extensions/xep-0060.html#publisher-publish-options'><cite>XEP-0060</cite> §7.1.5</link>.</li>
-      <li>The pubsub service MUST support 'max' as a value for the 'pubsub#persist_items' node configuration.</li>
+      <li>The pubsub service MUST support 'max' as a value for the 'pubsub#max_items' node configuration and support 'pubsub#max_items' as a publish option.</li>
       <li>The pubsub service MUST support the 'open' access model for node configuration and 'pubsub#access_model' as a publish option.</li>
     </ul>
   </section2>


### PR DESCRIPTION
As clarified on the list PEP service must _support_ persistance, not must _persist_ (unconditionally).
Also fix a typo in max value for max_items.