### PR TITLE
XEP-0060: Disallow '=' and ';' in NodeIDs to allow use in URIs and refer to PRECIS Stringprep

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -50,6 +50,15 @@
   &stpeter;
   &ralphm;
   <revision>
+    <version>1.20.0</version>
+    <date>2020-09-15</date>
+    <initials>ps</initials>
+    <remark>
+      <p>Correction: NodeIDs are stringprepped using PRECIS.</p>
+      <p>Disallow '=' and ';' in NodeIDs to allow NodeIDs to be used in URIs.</p>
+    </remark>
+  </revision>
+  <revision>
     <version>1.19.0</version>
     <date>2020-08-16</date>
     <initials>ps</initials>
@@ -895,8 +904,12 @@ And by opposing end them?
   <section2 topic='Addressing' anchor='addressing'>
     <p>If a pubsub node is addressable, it MUST be addressable either (1) as a JID or (2) as the combination of a JID and a node. <note>These nodes are equivalent to those used in <cite>XEP-0030: Service Discovery</cite>.</note></p>
     <section3 topic='JID' anchor='addressing-jid'>
-      <p>If a pubsub node is addressable as a JID, the NodeID MUST be the resource identifier, and MUST NOT be specified by the "user" portion (node identifier) of the JID (e.g. "domain.tld/NodeID" and "user@domain.tld/NodeID" are allowed; "NodeID@domain.tld" is not allowed <note>This rule does not apply to the root collection node, if any.</note>). JID addressing SHOULD be used when interacting with a pubsub node using a protocol that does not support the node attribute. For example, when a service makes it possible for entities to subscribe to nodes via presence, it would address nodes as JIDs. If a pubsub node is addressable as a JID, the pubsub service MUST ensure that the NodeID conforms to the Resourceprep profile of Stringprep as described in <cite>RFC 3920</cite>.</p>
-      <p>Consider the following example, in which the pubsub service is located at the hostname pubsub.shakespeare.lit.</p>
+      <p>If a pubsub node is addressable as a JID, the NodeID MUST be the resource identifier, and MUST NOT be specified by the "user" portion (node identifier) of the JID (e.g. "domain.tld/NodeID" and "user@domain.tld/NodeID" are allowed; "NodeID@domain.tld" is not allowed <note>This rule does not apply to the root collection node, if any.</note>).
+      JID addressing SHOULD be used when interacting with a pubsub node using a protocol that does not support the node attribute.
+      For example, when a service makes it possible for entities to subscribe to nodes via presence, it would address nodes as JIDs.
+      If a pubsub node is addressable as a JID, the pubsub service MUST ensure that the NodeID adheres to the requirements and fullfills the constraints of resourceparts as specified in <cite>RFC 7622 § 3.4</cite> with the additional constraint that the NodeID MUST NOT contain the characters '=' and ';'.
+      <note>This is to allow the NodeID to be used in URIs.</note>
+      Consider the following example, in which the pubsub service is located at the hostname pubsub.shakespeare.lit.</p>
       <example caption='Node addressed as domain.tld/NodeID'><![CDATA[
 <iq to='pubsub.shakespeare.lit/news announcements'>
   ...
@@ -910,8 +923,10 @@ And by opposing end them?
 ]]></example>
     </section3>
     <section3 topic='JID+NodeID' anchor='addressing-jidnode'>
-      <p>If a pubsub node is addressable as a JID plus node, the NodeID MUST be the value of both the Service Discovery 'node' attribute and the pubsub 'node' attribute; i.e., for discovery purposes, a pubsub node is equivalent to a Service Discovery node. If a pubsub node is addressable as a JID plus node, the pubsub service SHOULD ensure that the NodeID conforms to the Resourceprep profile of Stringprep as described in <cite>RFC 3920</cite>.</p>
-      <p>Consider the following example, in which the (virtual) pubsub service is located at hamlet@denmark.lit.</p>
+      <p>If a pubsub node is addressable as a JID plus node, the NodeID MUST be the value of both the Service Discovery 'node' attribute and the pubsub 'node' attribute; i.e., for discovery purposes, a pubsub node is equivalent to a Service Discovery node.
+      If a pubsub node is addressable as a JID plus node, the pubsub service SHOULD ensure that the NodeID adheres to the requirements and fullfills the constraints of resourceparts as specified in <cite>RFC 7622 § 3.4</cite> with the additional constraint that the NodeID MUST NOT contain the characters '=' and ';'.
+      <note>This is to allow the NodeID to be used in URIs.</note>
+      Consider the following example, in which the (virtual) pubsub service is located at hamlet@denmark.lit.</p>
       <example caption='Node addressed as JID+NodeID'><![CDATA[
 <iq to='hamlet@denmark.lit'>
   <query node='princely_musings'/>


### PR DESCRIPTION
Disclaimer: This might be a breaking change.

This PR limits node IDs by disallowing the characters '=' and ';'.
The reason is that currently it is possible to forge possibly dangerous PubSub node IDs.
Let's take a node with ID `catpictures;node=dogpictures` as an example.
The URI for subscribing to above node might be `xmpp:pubsub.example.org?pubsub;action=subscribe;node=catpictures;node=dogpictures` which a client might interpret as `xmpp:pubsub.example.org?pubsub;action=subscribe;node=dogpictures`, which would subscribe the client to a different node.

Additionally @Flowdalic noted that the sentence 
> the pubsub service MUST ensure that the NodeID conforms to the Resourceprep profile of Stringprep as described in <cite>RFC 3920</cite>

is wrong and that PRECIS is used instead. RFC 7622 §3.4 states that
> The resourcepart of a JID is an instance of the OpaqueString profile of the PRECIS FreeformClass, which is specified in [RFC7613].  The rules and considerations provided in that specification MUST be applied to XMPP resourceparts.