### PR TITLE
XEP-0167: Add missing required attribute in schema for encryption element

### DIFF
--- a/xep-0167.xml
+++ b/xep-0167.xml
@@ -1816,6 +1816,7 @@ Romeo                         Juliet
                   minOccurs='0'
                   maxOccurs='unbounded'/>
     </xs:sequence>
+    <xs:attribute name='required' type='xs:boolean' use='optional'/>
   </xs:complexType>
 
   <xs:complexType name='payloadElementType'>


### PR DESCRIPTION
This was apparently missing in the schema, but is described in the normative part and appears in examples.