### PR TITLE
XEP-0277: Add atom:generator element in examples to encourage its use

### DIFF
--- a/xep-0277.xml
+++ b/xep-0277.xml
@@ -167,6 +167,7 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
           <id>tag:montague.lit,2008-05-08:posts-1cb57d9c-1c46-11dd-838c-001143d5d5db</id>
           <published>2008-05-08T18:30:02Z</published>
           <updated>2008-05-08T18:30:02Z</updated>
+          <generator uri='https://capu.chat' version='42'>CapuChat</generator>
         </entry>
       </item>
     </publish>
@@ -195,6 +196,7 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
           <id>tag:montague.lit,2008-05-08:posts-1cb57d9c-1c46-11dd-838c-001143d5d5db</id>
           <published>2008-05-08T18:30:02Z</published>
           <updated>2008-05-08T18:30:02Z</updated>
+          <generator uri='https://capu.chat' version='42'>CapuChat</generator>
         </entry>
       </item>
     </items>


### PR DESCRIPTION
As the title says, I'd like to encourage the use of the [`atom:generator`](https://tools.ietf.org/html/rfc4287#section-4.2.4) element, at least make developers aware of it. Just adding it there as we all know copying examples is how things work. No need for keywords I think.

I haven't added a version block in case #986 would get in at the same time.

Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>