### PR TITLE
XEP-0060: Add integer-or-max datatype to use with Data Forms Validation

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -50,6 +50,12 @@
   &stpeter;
   &ralphm;
   <revision>
+    <version>1.20.0</version>
+    <date>2020-09-24</date>
+    <initials>pep</initials>
+    <remark><p>Add integer-or-max datatype to use with Data Forms Validation.</p></remark>
+  </revision>
+  <revision>
     <version>1.19.1</version>
     <date>2021-03-04</date>
     <initials>mw</initials>
@@ -5911,6 +5917,29 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=subscribe;node=princely_musings
 xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae890ac52d0df67ed7cfdf51b644e901
 ]]></example>
   </section2>
+
+  <section2 topic='Integration with Data Forms' anchor='usecase.xdata'>
+    <p>This section defines a datatype "integer-or-max" to be used with &xep0122;. An implementation may use this type to validate fields such as "pubsub#children_max", "pubsub#item_expire" or "pubsub#max_items".</p>
+    <code><![CDATA[
+<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema' targetNamespace="http://jabber.org/protocol/pubsub#integer-or-max">
+  <xs:simpleType name='integer-or-max'>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base='integer'/>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base='string'>
+          <xs:enumeration value='max'/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+</xs:schema>
+]]></code>
+    <p>The meaning of a value of this type is defined in each field named above.</p>
+    <p>When the <link url='xep-0122.html#usecases-validation.range'>&lt;range/&gt; element</link> is used in combination with this datatype, it applies to the integer value.</p>
+  </section2>
+
 </section1>
 
 <section1 topic='Internationalization Considerations' anchor='i18n'>
@@ -6658,6 +6687,20 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings
     </key>
   </keys>
 </querytype>
+]]></code>
+  </section2>
+
+  <section2 topic='Data Forms Validation Datatypes' anchor='registrar.xdata-validate'>
+    <p>The following datatype shall be registered for use with Data Forms Validation:</p>
+    <code caption='Data Forms Validation Datatypes Registry Submission'><![CDATA[
+<datatype>
+  <name>integer-or-max</name>
+    <desc>
+      Datatype used for text-single fields where the accepted value is
+      either an integer or the string "max".
+    </desc>
+    <doc>XEP-0060</doc>
+</datatype>
 ]]></code>
   </section2>
 </section1>


### PR DESCRIPTION
I'd like to have council's opinion on how to handle this.

Seems like the datatype requires a prefix, where to define it? where do I put things so that they end up in https://xmpp.org/registrar/xdv-prefixes.html ? In 0060 as well?

Should this type be its own spec? And then referred to and given meaning in 0060?

[Rendered version](https://ppjet.bouah.net/xeps/xep-0060-integer-or-max.html)

Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>