### PR TITLE
XEP-0420: Release version 0.4.0

### DIFF
--- a/xep-0420.xml
+++ b/xep-0420.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE xep SYSTEM 'xep.dtd' [
   <!ENTITY content "&lt;content/&gt;">
   <!ENTITY envelope "&lt;envelope/&gt;">
-  <!ENTITY payload "&lt;payload/&gt;">
   <!ENTITY time "&lt;time/&gt;">
   <!ENTITY rpad "&lt;rpad/&gt;">
   <!ENTITY to "&lt;to/&gt;">
@@ -31,6 +30,15 @@
   <shortname>SCE</shortname>
   &paulschaub;
   <revision>
+    <version>0.4.0</version>
+    <date>2021-04-07</date>
+    <initials>melvo</initials>
+    <remark>
+      <p>Use 'envelope' and 'content' consistently by renaming elements</p>
+      <p>Update namespace to <tt>urn:xmpp:sce:1</tt></p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.3.2</version>
     <date>2021-03-04</date>
     <initials>mw</initials>
@@ -39,7 +47,7 @@
   <revision>
     <version>0.3.1</version>
     <date>2020-11-03</date>
-    <initials>gh/@melvo</initials>
+    <initials>melvo</initials>
     <remark><p>Fix misspelling of 'whose'</p></remark>
   </revision>
   <revision>
@@ -87,7 +95,7 @@
 </section1>
 
 <section1 topic='Requirements' anchor='reqs'>
-  <p>This proposal widens the scope of the security guarantees given by the used encryption mechanism from just the body of the message to all contents of the &content; element. It is intended to serve as a "one size fits all" solution for extension element encryption in XMPP.</p>
+  <p>This proposal widens the scope of the security guarantees given by the used encryption mechanism from just the body of the message to various extension elements. It is intended to serve as a "one size fits all" solution for extension element encryption in XMPP.</p>
 
   <p>In order to achieve its goal, Stanza Content Encryption does the following:</p>
   <ul>
@@ -99,14 +107,14 @@
 
 <section1 topic='Glossary' anchor='glossary'>
   <dl>
-    <di><dt>Envelope Element &envelope;</dt><dd>An XMPP extension element which is used to hold the encrypted &content; element.</dd></di>
-    <di><dt>Content Element &content;</dt><dd>An element which is used to contain all of those extension elements that need to be encrypted.
-            The XML representation of this element is encrypted and then embedded into the &envelope; element.</dd></di>
+    <di><dt>Envelope Element &envelope;</dt><dd>An XMPP extension element which is used to hold the &content; element and the affix elements.
+            The XML representation of this element is encrypted and then embedded as the payload of the message being sent.</dd></di>
+    <di><dt>Content Element &content;</dt><dd>An element which is used to contain all extension elements which need to be encrypted.</dd></di>
   </dl>
 </section1>
 
 <section1 topic='Affix Elements' anchor='affix_elements'>
-  <p>In order to prevent certain attacks, different affix elements MAY be added into the &content; element.</p>
+  <p>In order to prevent certain attacks, different affix elements MAY be added as direct child elements of the &envelope; element.</p>
 
   <table caption='Overview about different crypto property elements'>
     <tr>
@@ -219,21 +227,21 @@
 
     <p>This applies to many extension elements that add additional information to &lt;message/&gt; stanzas, such as those of &xep0066;.</p>
 
-    <example caption='Content element containing the messages body and the OBB element.'><![CDATA[
-<content xmlns='urn:xmpp:sce:0'>
-  <payload>
+    <example caption='Envelope element containing the messages body and the OBB element.'><![CDATA[
+<envelope xmlns='urn:xmpp:sce:1'>
+  <content>
     <body xmlns='jabber:client'>[...]</body>
     <x xmlns='jabber:x:oob'>
       <url>https://en.wikipedia.org/wiki/Fight_Club#Plot</url>
     </x>
-  </payload>
-</content>]]>
+  </content>
+</envelope>]]>
     </example>
 
-    <example caption='Finished message stanza containing the &lt;content/&gt; element from the previous example encrypted using a hypothetical encryption protocol and SCE.'><![CDATA[
+    <example caption='Finished message stanza containing the &lt;envelope/&gt; element from the previous example, inside of its payload element, encrypted using a hypothetical encryption protocol and SCE.'><![CDATA[
 <message from='narrator@jabber.org'
          to='viewer@jabber.org'>
-  <encrypted xmlns='urn:xmpp:encryption:stub:sce:0'>
+  <encrypted xmlns='urn:xmpp:encryption:stub:sce:1'>
     <payload>
       PGNvbnRlbnQgeG1sbnM9J3Vybjp4bXBwOnNjZTowJz48cGF5bG9hZD48Ym9keSB4bWxucz0namFi
       YmVyOmNsaWVudCc+SSBnb3QgaW4gZXZlcnlvbmUncyBob3N0aWxlIGxpdHRsZSBmYWNlLiBZZXMs
@@ -251,23 +259,23 @@
     <p>Stanza Content Encryption thrives not only to allow for rich content encryption in &lt;message/&gt; stanzas, but is also applicable to &lt;iq/&gt; queries. A resource might want to query sensitive information from another resource capable of Stanza Content Encryption.</p>
 
     <example caption='Sender prepares a &content; element containing the query subject.'><![CDATA[
-<content xmlns='urn:xmpp:sce:0'>
-  <payload>
+<envelope xmlns='urn:xmpp:sce:1'>
+  <content>
     <data xmlns='urn:xmpp:bob'
         cid='sha1+8f35fef110ffc5df08d579a50083ff9308fb6242@bob.xmpp.org'/>
-  </payload>
+  </content>
   <from jid='doctor@shakespeare.lit/pda'/>
   <to jid='ladymacbeth@shakespear.lit/castle'/>
-</content>
+</envelope>
 ]]>
     </example>
 
-    <example caption='The sender then encrypts the &content; element for the recipient and sends the &lt;iq/&gt; containing the result of the encryption.'><![CDATA[
+    <example caption='The sender then encrypts the &envelope; element for the recipient and sends the &lt;iq/&gt; containing the result of the encryption.'><![CDATA[
 <iq from='doctor@shakespeare.lit/pda'
     id='get-data-1'
     to='ladymacbeth@shakespeare.lit/castle'
     type='get'>
-  <encrypted xmlns='urn:xmpp:encryption:stub:sce:0'>
+  <encrypted xmlns='urn:xmpp:encryption:stub:sce:1'>
     <payload>
       V2FpdCwgd2hhdD8gQXJlIHlvdSBzZXJpb3VzPyBEaWQgeW91IHJlYWxseSBqdXN0IGdyYWIgeW91
       ciBmYXZvdXJpdGUgYmFzZTY0IGRlY29kZXIganVzdCB0byBjaGVjayB0aGlzIGRvY3VtZW50IGZv
@@ -278,9 +286,9 @@
 </iq>]]>
     </example>
 
-    <example caption='The recipient prepares the reply to the request by assembling the &content; element.'><![CDATA[
-<content xmlns='urn:xmpp:sce:0'>
-  <payload>
+    <example caption='The recipient prepares the reply to the request by assembling the &envelope; element.'><![CDATA[
+<envelope xmlns='urn:xmpp:sce:1'>
+  <content>
     <data xmlns='urn:xmpp:bob'
         cid='sha1+8f35fef110ffc5df08d579a50083ff9308fb6242@bob.xmpp.org'
         max-age='86400'
@@ -291,18 +299,18 @@
     Rw6EMBTAUP8kJKENnaF37n9FQPLCekAgzklhgCwfrlNHEXhrvCsxaU/SwLGAFuIWZFpBERtKm9Xf
     JqH+vVWh4POqgHrsAtht095b+geYRSl57QHSPgP3+CwvAAAAAABJRU5ErkJggg==
     </data>
-  </payload>
+  </content>
   <from jid='ladymacbeth@shakespear.lit/castle'/>
   <to jid='doctor@shakespeare.lit/pda'/>
-</content>]]>
+</envelope>]]>
     </example>
 
-    <example caption='The &content; element is then encrypted and sent as a reply to the initiator of the request.'><![CDATA[
+    <example caption='The &envelope; element is then encrypted and sent as a reply to the initiator of the request.'><![CDATA[
 <iq from='ladymacbeth@shakespeare.lit/castle'
     id='get-data-1'
     to='doctor@shakespeare.lit/pda'
     type='result'>
-  <encrypted xmlns='urn:xmpp:encryption:stub:sce:0'>
+  <encrypted xmlns='urn:xmpp:encryption:stub:sce:1'>
     <payload>
       PGNvbnRlbnQgeG1sbnM9J3Vybjp4bXBwOnNjZTowJz4KICA8cGF5bG9hZD4KICAgIDxkYXRhIHht
       bG5zPSd1cm46eG1wcDpib2InCiAgICAgICAgY2lkPSdzaGExKzhmMzVmZWYxMTBmZmM1ZGYwOGQ1
@@ -326,39 +334,39 @@
 
 <section1 topic='Sending an encrypted stanza' anchor='sending'>
 
-  <p>In order to send an encrypted message without leaking extension elements the sender prepares the message by placing the sensitive extension elements inside a &payload; element inside a &content; element.</p>
-  <p>Depending on the encryption-specific SCE-profile, some affix elements are added as child elements of the &content; element.</p>
-  <p>The &content; element is then serialized into XML and encrypted using the SCE-specific profile of the encryption mechanism in place. The result is appended to the message.</p>
+  <p>In order to send an encrypted message without leaking extension elements, the sender prepares the message by placing the sensitive extension elements inside a &content; element and that inside an &envelope; element.</p>
+  <p>Depending on the encryption-specific SCE-profile, some affix elements are added as child elements of the &envelope; element.</p>
+  <p>The &envelope; element is then serialized into XML and encrypted using the SCE-specific profile of the encryption mechanism in place. The result is appended to the message.</p>
   <p>Since the outer message element does not contain a &lt;body/&gt; element the sender appends an unencrypted &lt;store/&gt; hint as specified in &xep0334;.</p>
   <p>The message can then be sent to the recipient.</p>
 </section1>
 
 <section1 topic='Receiving an encrypted stanza' anchor='receiving'>
-  <p>The recipient of the message decrypts the content of the &envelope; element to retrieve the &content; element. Depending on the affix profiles specified by the used encryption protocol, the affix elements are verified to prevent certain attacks from taking place.</p>
-  <p>Next the extension elements of the &content; elements &payload; element are checked against the permitted list and any disallowed elements are discarded.</p>
-  <p>As a last step, the original unencrypted stanza is recreated by replacing the &envelope; element of the stanza with the contents of the &payload; element.</p>
+  <p>The recipient of the message decrypts its encrypted payload. The result is the &envelope; element containing the &content; element and the affix elements as direct child elements. Depending on the affix profiles specified by the used encryption protocol, the affix elements are verified to prevent certain attacks from taking place.</p>
+  <p>Afterwards, the extension elements inside the &content; element are checked against the permitted list and any disallowed elements are discarded.</p>
+  <p>As a last step, the original unencrypted stanza is recreated by replacing the &envelope; element of the stanza with the elements inside of the &content; element.</p>
 </section1>
 
 <section1 topic='Server-processed Elements' anchor='server-processed'>
   <p>There are certain extension elements which are required to be available to the server in order to do message routing and processing.
      Additionally there are some elements that MUST be filtered by the server.
      Allowing for those elements to be included in, and parsed from the encrypted payload would allow a malicious client to perform a number of attacks.</p>
-  <p>Contrary to this, other elements are considered sensitive and MUST NOT be available in plaintext outside the &content; element.</p>
+  <p>Contrary to this, other elements are considered sensitive and MUST NOT be available in plaintext outside the &envelope; element.</p>
   <p>It is hard to come up with a complete list of exceptional elements at this point, as there is no practical implementation experience.</p>
-  <p>Below is a non-exhaustive list of elements that are definitely forbidden inside the &content; element and permitted as direct child elements of the message.</p>
-  <table caption='Examples for exceptional elements that MUST NOT be included in, or read from the &content; element and MUST instead be sent traditionally as direct child elements of the stanza.'>
+  <p>Below is a non-exhaustive list of elements that are definitely forbidden inside the &envelope; element and permitted as direct child elements of the message.</p>
+  <table caption='Examples for exceptional elements that MUST NOT be included in, or read from the &envelope; element and MUST instead be sent traditionally as direct child elements of the stanza.'>
     <tr>
       <th>Element</th>
       <th>Reason</th>
     </tr>
     <tr>
       <td>Elements of &xep0334;</td>
-      <td>Message Processing Hints are addressed to the server and MUST therefore be accessible in plaintext. A receiving client MUST ignore any message processing hints encountered inside the encrypted &content; element</td>
+      <td>Message Processing Hints are addressed to the server and MUST therefore be accessible in plaintext. A receiving client MUST ignore any message processing hints encountered inside the encrypted &envelope; element</td>
     </tr>
     <tr>
       <td>Stanza-ID elements of &xep0359;</td>
-      <td>Sending clients MUST NOT include Stanza-ID elements inside the &content; element, as this would prevent the server from filtering it.
-          A client MUST ignore Stanza-ID elements encountered inside &content; element</td>
+      <td>Sending clients MUST NOT include Stanza-ID elements inside the &envelope; element, as this would prevent the server from filtering it.
+          A client MUST ignore Stanza-ID elements encountered inside the &envelope; element</td>
     </tr>
     <tr>
       <td>Elements of &xep0033;</td>
@@ -373,13 +381,13 @@
 </section1>
 
 <section1 topic='Business Rules' anchor='rules'>
-  <p>Unencrypted &content; elements are NOT ALLOWED as child elements of the stanza and MUST be dropped.</p>
-  <p>Elements in the &content; elements &payload; element MUST be identified using an element name and namespace.
+  <p>Unencrypted &envelope; elements are NOT ALLOWED as child elements of the stanza and MUST be dropped.</p>
+  <p>Elements in the &content; element MUST be identified using an element name and namespace.
      Notably the &lt;body/&gt; element MUST contain a valid namespace (i.e. "jabber:client").</p>
-  <p>The recipient must verify that the decrypted &content; element contains valid XML before processing it any further. Invalid XML must be rejected.</p>
-  <p>After verifying the integrity of the &content; element, the recipient needs to make sure that no server-processed elements are found within the payload.
+  <p>The recipient MUST verify that the decrypted &envelope; element contains valid XML before processing it any further. Invalid XML must be rejected.</p>
+  <p>After verifying the integrity of the &envelope; element, the recipient needs to make sure that no server-processed elements are found inside of it.
      Any forbidden elements MUST be dropped before the message is processed any further.</p>
-  <p>Furthermore the receiving client MUST ignore any extension elements considered as sensitive which are found outside of the &content; element,
+  <p>Furthermore the receiving client MUST ignore any extension elements considered as sensitive which are found outside of the &envelope; element,
      especially as direct unencrypted child elements of the enclosing stanza.</p>
   <p>Since a chat message encrypted with SCE MUST NOT contain a &lt;body/&gt; element, it is not eligible for MAM message storage (&xep0313;).
      Therefore sending entities MUST append an unencrypted &xep0334; &lt;store/&gt; hint as a direct child element to the message.</p>


### PR DESCRIPTION
* Use 'envelope' and 'content' consistently by renaming elements
* Update namespace to 'urn:xmpp:sce:1'

@vanitasvitae Here is the outcome of our discussion.