### PR TITLE
XEP-0393: fix example to follow span rules

### DIFF
--- a/xep-0393.xml
+++ b/xep-0393.xml
@@ -402,6 +402,7 @@
       <li><strong>*strong*</strong> plain <strong>*strong*</strong></li>
       <li><strong>*strong*</strong>plain*</li>
       <li>* plain <strong>*strong*</strong></li>
+      <li><strong>***</strong>*</li>
     </ul>
     <p>
       Nothing would be styled in the following messages (where "\n" represents a
@@ -413,7 +414,6 @@
       <li>*not \n strong*</li>
       <li>*not *strong</li>
       <li>**</li>
-      <li>****</li>
     </ul>
     <section3 topic='Plain' anchor='plain'>
       <p>


### PR DESCRIPTION
I could use a good code review on this one; I think I messed up this example and it should have been styled per the span rules, but I also feel like I used this example specifically to clarify this confusion (though it's possible that I was just myself confused).

This does not change any normative behavior, just an example that I believe was incorrect.