### PR TITLE
XEP-0393: clarify rules for span directives

### DIFF
--- a/xep-0393.xml
+++ b/xep-0393.xml
@@ -381,9 +381,10 @@
   <section2 topic='Spans' anchor='span'>
     <p>
       Matches of spans between two styling directives MUST contain some text
-      between the two styling directives and the opening styling directive
-      MUST be located at the beginning of the line, after a whitespace
-      character, or after a different opening styling directive.
+      between the two styling directives, otherwise neither directive is valid.
+      The opening styling directive MUST be located at the beginning of the
+      line, after a whitespace character, or after a different opening styling
+      directive.
       The opening styling directive MUST NOT be followed by a whitespace
       character and the closing styling directive MUST NOT be preceeded by a
       whitespace character.
@@ -413,6 +414,7 @@
       <li>*not \n strong*</li>
       <li>*not *strong</li>
       <li>**</li>
+      <li>***</li>
       <li>****</li>
     </ul>
     <section3 topic='Plain' anchor='plain'>


### PR DESCRIPTION
Previously I believe the styling of `***` in the examples was incorrect. After discussing the matter on the mailing list we came to the conclusion that the actual rules were ambiguous and therefore `***` could be styled either way.

To fix this I have clarified the rules to match the existing example on the theory that this is the minimal change that is least likely to break someone who was following the spec as closely as possible and is the most likely to be allowed in a draft PR.
I also added some similar examples. 