### PR TITLE
Add XEP proposals for file sharing and stickers

### DIFF
--- a/inbox/esfs.xml
+++ b/inbox/esfs.xml
@@ -1,0 +1,160 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Note to editor: Remove xep-sfs entity declared below and change all references from &xep-sfs; to respective &xepXXXX; to refeence sfs when moving to experimental.
+-->
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY xep-sfs "<span class='ref'><link url='./sfs.html'>Stateless file sharing (XEP-xxxx)</link></span> <note>XEP-xxxx: Stateless file sharing &lt;<link url='./sfs.html'>https://xmpp.org/extensions/inbox/sfs.html</link>&gt;.</note>" >
+  <!ENTITY % ents SYSTEM 'xep.ent'>
+%ents;
+]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+<header>
+  <title>Encryption for stateless file sharing</title>
+  <abstract>This specification provides a protocol for sharing encrypted files using the stateless file sharing protocol (XEP-xxxx).</abstract>
+  &LEGALNOTICE;
+  <number>xxxx</number>
+  <status>ProtoXEP</status>
+  <type>Standards Track</type>
+  <sig>Standards</sig>
+  <approver>Council</approver>
+  <dependencies>
+    <spec>XMPP Core</spec>
+    <spec>XEP-0001</spec>
+    <spec>XEP-xxxx</spec>
+  </dependencies>
+  <supersedes/>
+  <supersededby/>
+  <shortname>esfs</shortname>
+  &larma;
+  <revision>
+    <version>0.0.1</version>
+    <date>2020-11-10</date>
+    <initials>lmw</initials>
+    <remark><p>First draft.</p></remark>
+  </revision>
+</header>
+<section1 topic='Introduction' anchor='intro'>
+  <p>
+    End-to-end encrypted messaging is a popular feature within the community.
+    Various protocols like &xep0373; or &xep0384; have been proposed to allow sending encrypted messages.
+    &xep0343; and &xep0391; specify protocols for establishing an encrypted transport using Jingle to share files using &xep0234;.
+  </p>
+  <p>
+    &xep-sfs; describes a protocol that can be used to share files, previously uploaded using &xep0363;, but lacks means of encrypting files.
+    This leaves files uploaded using &xep0363; without any standardized means of encrypting them.
+  </p>
+  <p>This XEP describes a protocol building on top of &xep-sfs; to allow encrypting files.</p>
+</section1>
+<section1 topic='Requirements' anchor='reqs'>
+  <ul>
+    <li>Make use of existing protocols for end-to-end encryption (&xep0373; and &xep0420;)</li>
+    <li>Reuse existing protocols for the actual transport of the data</li>
+    <li>Allow caching and forwarding without being required to decrypt the file</li>
+    <li>Backwards compatibility with existing, widely-deployed protocols<note>There is a widely-deployed protocol for encrypted file sharing known as "OMEMO media sharing" or "aesgcm-links" that was never accepted as a XEP. While backwards compatibility with such non-standard is not a maxime of the XSF, it was still considered during the design of this protocol.</note></li>
+  </ul>
+</section1>
+<section1 topic='Use Cases' anchor='usecases'>
+  <p>
+    This protocol is only meaningful for end-to-end encrypted file sharing when transported as end-to-end encrypted XML, like it's possible using &xep0420;.
+    However, usage without such end-to-end encryption still has its usecase, as it allows sharing files through untrusted intermediaries for as long as the intermediary XMPP servers, if any, are trusted.
+  </p>
+  <p class='box'>Note: To make the examples in this document more readable, no end-to-end encryption is used.</p>
+  <section2 topic='Sharing a file' anchor='file-sharing'>
+    <p>
+      Before sharing the file, the sending entity MUST create random symmetric private key and initialization vector (IV) as required by the selected encryption cipher (see <link url='#ciphers'>Ciphers</link>). The file is then encrypted using selected encryption cipher and the generated key and IV. After this it can be uploaded using &xep0363; or prepared for any other means of file sharing.
+    </p>
+    <p>
+      The file is then shared using the protocol described in &xep-sfs;.
+      The <tt>&lt;file/&gt;</tt> metadata element still refers to the original file, i.e. it describes the original file name, size and hashes. The <tt>&lt;size/&gt;</tt> element and one or multiple <tt>&lt;hash/&gt;</tt> elements are REQUIRED when sending encrypted files.
+    </p>
+    <p>
+      For the encrypted file, a source is added as an <tt>&lt;encrypted/&gt;</tt> element to the <tt>&lt;sources/&gt;</tt>. It carries an attribute <tt>cipher</tt> with the namespace of the encryption cipher being used. The <tt>&lt;encrypted/&gt;</tt> element contains a <tt>&lt;key/&gt;</tt> and an <tt>&lt;iv/&gt;</tt> element, containing both values as Base64-encoded strings. The <tt>&lt;encrypted/&gt;</tt> element MAY also include <tt>&lt;hash/&gt;</tt> elements as described in &xep0300;, referring to the hash of the encrypted file. At last, the <tt>&lt;encrypted/&gt;</tt> element also includes another <tt>&lt;sources/&gt;</tt> element as described in &xep-sfs;, specifying sources to obtain the encrypted file.
+      The outer <tt>&lt;sources/&gt;</tt> may contain additional sources that directly allow for end-to-end encrypted file transfers, for example &xep0234; using &xep0391;.
+    </p>
+    <example caption='Sharing summit.jpg with juliet@shakespeare.lit using encryption'><![CDATA[
+<message to='juliet@shakespeare.lit' from='romeo@montague.lit/resource' id='sharing-a-file'>
+  <file-sharing xmlns='urn:xmpp:sfs:0'>
+    <file xmlns='urn:xmpp:file:metadata:0'>
+      <media-type>image/jpeg</media-type>
+      <name>summit.jpg</name>
+      <size>3032449</size>
+      <dimension>4096x2160</dimension>
+      <hash xmlns='urn:xmpp:hashes:2' algo='sha3-256'>2XarmwTlNxDAMkvymloX3S5+VbylNrJt/l5QyPa+YoU=</hash>
+      <hash xmlns='urn:xmpp:hashes:2' algo='id-blake2b256'>2AfMGH8O7UNPTvUVAM9aK13mpCY=</hash>
+      <desc>Photo from the summit.</desc>
+      <thumbnail xmlns='urn:xmpp:thumbs:1' uri='cid:sha1+ffd7c8d28e9c5e82afea41f97108c6b4@bob.xmpp.org' media-type='image/png' width='128' height='96'/>
+    </file>
+    <sources>
+      <encrypted xmlns='urn:xmpp:esfs:0' cipher='urn:xmpp:ciphers:aes-256-gcm-nopadding:0'>
+        <key>SuRJ2agVm/pQbJQlPq/B23Xt1YOOJCcEGJA5HrcYOGQ=</key>
+        <iv>T8RDMBaiqn6Ci4Nw</iv>
+        <hash xmlns='urn:xmpp:hashes:2' algo='sha3-256'>BgKI2gp2kNCRsARNvhFmw5kFf9BBo2pTbV2D8XHTMWI=</hash>
+        <hash xmlns='urn:xmpp:hashes:2' algo='id-blake2b256'>id4cnqqy9/ssfCkM4vYSkiXXrlE=</hash>
+        <sources xmlns='urn:xmpp:sfs:0'>
+          <url-data xmlns='http://jabber.org/protocol/url-data' target='https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/encrypted.jpg' />
+        </sources>
+      </encrypted>
+      <jinglepub xmlns='urn:xmpp:jinglepub:1' from='romeo@montague.lit/resource' id='9559976B-3FBF-4E7E-B457-2DAA225972BB'>
+        <description xmlns='urn:xmpp:jingle:apps:file-transfer:5' />
+      </jinglepub>
+    </sources>
+  </file-sharing>
+</message>
+]]></example>
+  </section2>
+  <section2 topic='Receiving a file' anchor='file-receive'>
+    <p>On receive of a message including a <tt>&lt;file-sharing/&gt;</tt> element, that has an <tt>&lt;encrypted/&gt;</tt> element in its sources, normal processing as described in &xep-sfs; applies.</p>
+    <p>
+      When the receiving entity tries to obtain the file from the source described by the <tt>&lt;encrypted/&gt;</tt> element, it will try to obtain any of its inner sources instead.
+      On success, it decrypts the obtained file using the encryption cipher, private key and IV provided.
+      If the resulting file is larger than the number of bytes specified in the <tt>&lt;size/&gt;</tt> metadata element, the additional bytes are cut off.
+    </p>
+  </section2>
+  <section2 topic='Attaching a source' anchor='attach-source'>
+    <p>
+      The protocol to attach a source described in &xep-sfs; can also be used to attach encrypted sources.
+      After receiving a file using encrypted means, it is RECOMMENDED to only attach additional sources that support encryption.
+    </p>
+  </section2>
+</section1>
+<section1 topic='Ciphers' anchor='ciphers'>
+  <p class='box'>Note The following table was copied from &xep0391;.</p>
+  <p>In order to encrypt the file, the sending entity must transmit a cipher key to the responder. There are multiple options available:</p>
+  <table caption='Available ciphers, configurations and their namespaces'>
+    <tr>
+      <th>Namespace</th>
+      <th>Type</th>
+      <th>Length (bits)</th>
+      <th>Parameters</th>
+    </tr>
+    <tr>
+      <td>urn:xmpp:ciphers:aes-128-gcm-nopadding:0</td>
+      <td>AES</td>
+      <td>Key: 128, IV: 96</td>
+      <td>GCM/NoPadding</td>
+    </tr>
+    <tr>
+      <td>urn:xmpp:ciphers:aes-256-gcm-nopadding:0</td>
+      <td>AES</td>
+      <td>Key: 256, IV: 96</td>
+      <td>GCM/NoPadding</td>
+    </tr>
+  </table>
+  <p>For compatibility reasons, it is RECOMMENDED to append the GCM authentication tag to the uploaded file when using any AES cipher with GCM. The GCM authentication tag is not needed when using the protocol described in this document as a hash of the resulting file is transported independently.</p>
+</section1>
+<section1 topic='Security Considerations' anchor='security'>
+  <p>Yes.</p>
+</section1>
+<section1 topic='IANA Considerations' anchor='iana'>
+  <p>This document requires no interaction with &IANA;.</p>
+</section1>
+<section1 topic='XMPP Registrar Considerations' anchor='registrar'>
+  <section2 topic='Protocol Namespaces' anchor='ns'>
+    <p>The &REGISTRAR; includes 'urn:xmpp:esfs:0' in its registry of protocol namespaces (see &NAMESPACES;).</p>
+    <ul>
+      <li>urn:xmpp:esfs:0</li>
+    </ul>
+  </section2>
+</section1>
+</xep>

--- a/inbox/file-metadata.xml
+++ b/inbox/file-metadata.xml
@@ -1,0 +1,146 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+        <!ENTITY % ents SYSTEM 'xep.ent'>
+        %ents;
+        ]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+<header>
+  <title>File metadata element</title>
+  <abstract>This specification defines a generic file metadata element to be used in other specifications.</abstract>
+  &LEGALNOTICE;
+  <number>xxxx</number>
+  <status>ProtoXEP</status>
+  <type>Standards Track</type>
+  <sig>Standards</sig>
+  <approver>Council</approver>
+  <dependencies>
+    <spec>XMPP Core</spec>
+    <spec>XEP-0001</spec>
+    <spec>XEP-0082</spec>
+    <spec>XEP-0264</spec>
+    <spec>XEP-0300</spec>
+  </dependencies>
+  <supersedes/>
+  <supersededby/>
+  <shortname>file-metadata</shortname>
+  &larma;
+  <revision>
+    <version>0.0.1</version>
+    <date>2020-11-03</date>
+    <initials>lmw</initials>
+    <remark><p>First draft.</p></remark>
+  </revision>
+</header>
+<section1 topic='Introduction' anchor='intro'>
+  <p>
+    Several existing specification have the need to provide metadata on a file.
+    The only specification of an element that contains file metadata so far is
+    provided as part of &xep0234;. This resulted in the situation that XEPs like
+    &xep0385; depend on the mostly unrelated &xep0166; just for the metadata
+    element. The motiviation of this XEP is to get rid of such dependencies and
+    have a dedicated place to define a file metadata element.
+  </p>
+</section1>
+<section1 topic='Element format' anchor='format'>
+  <code><![CDATA[
+<file xmlns='urn:xmpp:file:metadata:0'>
+    <media-type>text/plain</media-type>
+    <name>test.txt</name>
+    <date>2015-07-26T21:46:00+01:00</date>
+    <size>6144</size>
+    <hash xmlns='urn:xmpp:hashes:2'
+          algo='sha-1'>w0mcJylzCn+AfvuGdqkty2+KP48=</hash>
+</file>]]></code>
+  <p>The child elements of the &lt;file/&gt; element are as follows:</p>
+  <table caption='File Description Elements'>
+    <tr>
+      <th>Element Name</th>
+      <th>Description</th>
+      <th>Example</th>
+    </tr>
+    <tr>
+      <td>date</td>
+      <td>Timestamp specifying the last modified time of the file (which MUST conform to the DateTime profile of &xep0082;).</td>
+      <td><tt>2015-07-26T21:46:00+01:00</tt></td>
+    </tr>
+    <tr>
+      <td>dimensions</td>
+      <td>Horizontal and vertical dimensions of image or video files, in pixels.</td>
+      <td><tt>1920x1080</tt></td>
+    </tr>
+    <tr>
+      <td>desc</td>
+      <td>A human readable description of the file. Multiple <tt>&lt;desc/&gt;</tt> elements MAY be included if different xml:lang values are specified.</td>
+      <td><tt>Picture of 24th XSF Summit</tt></td>
+    </tr>
+    <tr>
+      <td>hash</td>
+      <td>A hash of the file content, using the <tt>&lt;hash/&gt;</tt> element defined in &xep0300; and qualifed by the 'urn:xmpp:hashes:2' namespace. Multiple hashes MAY be included for hash agility.</td>
+      <td><em>see specification</em></td>
+    </tr>
+    <tr>
+      <td>length</td>
+      <td>Length of an audio or video file, in milliseconds.</td>
+      <td><tt>63000</tt></td>
+    </tr>
+    <tr>
+      <td>media-type</td>
+      <td>The media type of the file content, which SHOULD be a valid MIME-TYPE as registered with &IANA; (specifically, as listed at &lt;<link url='http://www.iana.org/assignments/media-types'>http://www.iana.org/assignments/media-types</link>&gt;). If not specified, the content is assumed to be "application/octet-stream".</td>
+      <td><tt>text/plain</tt></td>
+    </tr>
+    <tr>
+      <td>name</td>
+      <td>The name of the file. The name SHOULD NOT contain characters or character sequences that would be interpreted as a directory structure by the local file system (e.g. "/", "\", "../", etc.). If any such characters or character sequences are present (possibly because the local and remote file systems use different syntax for directory structure), they SHOULD be escaped (e.g., via percent-encoding) before using the name as part of any file system operation. See <link url='#security'>Security Considerations</link>.</td>
+      <td><tt>text.txt</tt></td>
+    </tr>
+    <tr>
+      <td>size</td>
+      <td>The length of the file's content, in bytes.</td>
+      <td><tt>6144</tt></td>
+    </tr>
+    <tr>
+      <td>thumbnail</td>
+      <td>A thumbnail element of the file, using the &lt;thumbnail/&gt; element defined in &xep0264; and qualified by the 'urn:xmpp:thumbs:1' namespace. Multiple thumbnails MAY be included for media type and size agility.</td>
+      <td><em>see specification</em></td>
+    </tr>
+  </table>
+  <p>
+    All child elements are OPTIONAL, however, specifications making use of the
+    file metadata object MAY require providing some of these elements as part
+    of their specification.
+  </p>
+</section1>
+<section1 topic='Security Considerations' anchor='security'>
+  <p>
+    Caution needs to be exercised when using the <tt>&lt;name/&gt;</tt> of the metadata
+    to control any interaction with a file system. For example, a malicious
+    user could request a file with <tt>&lt;name&gt;/etc/passwd&lt;/name&gt;</tt> or
+    include file system specific control patterns such as
+    <tt>&lt;name&gt;../../private.txt&lt;/name&gt;</tt> to try and access a sensitive
+    file outside of the set of files intended to be shared. Or a malicious user
+    could offer a file named <tt>/etc/passwd</tt> to try and trick the receiver into
+    overwriting that or other sensitive files. Therefore, implementations
+    SHOULD escape any file system path separators in the <tt>&lt;name/&gt;</tt> before
+    using that value in any file system calls.
+  </p>
+  <p>
+    It is RECOMMENDED for implementations to use the strongest hashing
+    algorithm available to both parties. See &xep0300; for further discussion.
+  </p>
+</section1>
+<section1 topic='IANA Considerations' anchor='iana'>
+  <p>This document requires no interaction with &IANA;.</p>
+</section1>
+<section1 topic='XMPP Registrar Considerations' anchor='registrar'>
+  <section2 topic='Protocol Namespaces' anchor='ns'>
+    <p>The &REGISTRAR; includes 'urn:xmpp:file:metadata:0' in its registry of protocol namespaces (see &NAMESPACES;).</p>
+    <ul>
+      <li>urn:xmpp:file:metadata:0</li>
+    </ul>
+  </section2>
+</section1>
+<section1 topic='Acknowledgements' anchor='ack'>
+  <p>Thanks to the authors of &xep0234; which heavily inspired this XEP.</p>
+</section1>
+</xep>

--- a/inbox/sfs.xml
+++ b/inbox/sfs.xml
@@ -1,0 +1,202 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Note to editor: Remove xep-file-metadata entity declared below and change all references from &xep-file-metadata; to respective &xepXXXX; to refeence file metadata element when moving to experimental.
+-->
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY xep-file-metadata "<span class='ref'><link url='./file-metadata.html'>File metadata element (XEP-xxxx)</link></span> <note>XEP-xxxx: File metadata element &lt;<link url='./file-metadata.html'>https://xmpp.org/extensions/inbox/file-metadata.html</link>&gt;.</note>" >
+  <!ENTITY % ents SYSTEM 'xep.ent'>
+%ents;
+]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+<header>
+  <title>Stateless file sharing</title>
+  <abstract>This specification describes a protocol for stateless asynchronous file sharing with integrity and transport flexibility. It allows clients to provide a good interoperable user experience in combination with Carbons and MAM.</abstract>
+  &LEGALNOTICE;
+  <number>xxxx</number>
+  <status>ProtoXEP</status>
+  <type>Standards Track</type>
+  <sig>Standards</sig>
+  <approver>Council</approver>
+  <dependencies>
+    <spec>XMPP Core</spec>
+    <spec>XEP-0001</spec>
+    <spec>XEP-xxxx</spec>
+  </dependencies>
+  <supersedes/>
+  <supersededby/>
+  <shortname>sfs</shortname>
+  &larma;
+  <revision>
+    <version>0.0.1</version>
+    <date>2020-11-10</date>
+    <initials>lmw</initials>
+    <remark><p>First draft.</p></remark>
+  </revision>
+</header>
+<section1 topic='Introduction' anchor='intro'>
+  <p>
+    This is a reiteration on &xep0385; with some significant changes:
+  </p>
+  <ul>
+    <li>No focus on media, generic for every file type.</li>
+    <li>No mixed content, body is used for fallback only and not to transmit additional information.</li>
+    <li>Using &xep-file-metadata;.</li>
+    <li>Using XML for structured data instead of URIs when possible, adding further extensibility (like providing proper means of sharing encrypted files on http servers).</li>
+    <li>Not relying on underspecified usage of &xep0372;.</li>
+  </ul>
+</section1>
+<section1 topic='Requirements' anchor='reqs'>
+  <ul>
+    <li>Do not require any server components for easier deployment</li>
+    <li>Should work and enable a good UX in multi-user chats like &xep0045; and &xep0369;</li>
+    <li>Should work great together with conversation synchronization protocols like &xep0280; and &xep0313;</li>
+    <li>Reuse existing protocols for the actual transport of the data, i.e. &xep0234; or &xep0363;</li>
+    <li>Guarantee file integrity</li>
+    <li>Enable aggresive caching</li>
+    <li>Provide users with metadata, e.g. file size, file type or thumbnail, to help them decide whether or not they want to load the file</li>
+    <li>Support referring to third party hosting services</li>
+    <li>Backwards compatibility with existing, widely-deployed protocols</li>
+  </ul>
+</section1>
+<section1 topic='Use cases' anchor='usecases'>
+  <section2 topic='Sharing a file' anchor='file-sharing'>
+    <p>
+      To share a file, a user sends a message stanza including <tt>&lt;file-sharing/&gt;</tt> to the inteded recipient contact or group.
+      The <tt>&lt;file-sharing/&gt;</tt> element includes a <tt>&lt;file/&gt;</tt> metadata element as described in &xep-file-metadata; as well as a <tt>&lt;sources/&gt;</tt> element.
+      The <tt>&lt;sources/&gt;</tt> element provides one or multiple sources that the receiving client may use to obtain the file.
+    </p>
+    <example caption='Sharing summit.jpg with juliet@shakespeare.lit'><![CDATA[
+<message to='juliet@shakespeare.lit' from='romeo@montague.lit/resource' id='sharing-a-file'>
+  <file-sharing xmlns='urn:xmpp:sfs:0'>
+    <file xmlns='urn:xmpp:file:metadata:0'>
+      <media-type>image/jpeg</media-type>
+      <name>summit.jpg</name>
+      <size>3032449</size>
+      <dimension>4096x2160</dimension>
+      <hash xmlns='urn:xmpp:hashes:2' algo='sha3-256'>2XarmwTlNxDAMkvymloX3S5+VbylNrJt/l5QyPa+YoU=</hash>
+      <hash xmlns='urn:xmpp:hashes:2' algo='id-blake2b256'>2AfMGH8O7UNPTvUVAM9aK13mpCY=</hash>
+      <desc>Photo from the summit.</desc>
+      <thumbnail xmlns='urn:xmpp:thumbs:1' uri='cid:sha1+ffd7c8d28e9c5e82afea41f97108c6b4@bob.xmpp.org' media-type='image/png' width='128' height='96'/>
+    </file>
+    <sources>
+      <url-data xmlns='http://jabber.org/protocol/url-data' target='https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/summit.jpg' />
+      <jinglepub xmlns='urn:xmpp:jinglepub:1' from='romeo@montague.lit/resource' id='9559976B-3FBF-4E7E-B457-2DAA225972BB'>
+        <description xmlns='urn:xmpp:jingle:apps:file-transfer:5' />
+      </jinglepub>
+    </sources>
+  </file-sharing>
+</message>
+]]></example>
+    <p>
+      It is RECOMMENDED that the file metadata specifies name, media-type, size and one or multiple hash elements as described in &xep0300;.
+      The hash elements provide end-to-end file integrity and allow efficient caching and flexible retrieval methods.
+    </p>
+    <p>
+      The message MAY include a suitable fallback body.
+      The fallback body MUST NOT include any information that is not also represented in <tt>&lt;file-sharing/&gt;</tt>.
+      If the <tt>&lt;sources/&gt;</tt> element includes an <tt>&lt;url-data/&gt;</tt> element that can be represented as a single URL, adding a &xep0066; x-oob reference is RECOMMENDED for compatibility.
+    </p>
+    <example caption='Sharing summit.jpg with juliet@shakespeare.lit with fallback'><![CDATA[
+<message to='juliet@shakespeare.lit' from='romeo@montague.lit/resource' id='sharing-a-file'>
+  <file-sharing xmlns='urn:xmpp:sfs:0'>
+    <!-- ... -->
+  </file-sharing>
+  <body>Photo from the summit: https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/summit.jpg</body>
+  <x xmlns='jabber:x:oob'><url>https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/summit.jpg</url></x>
+</message>
+]]></example>
+    <p>If the message has an empty body, it is RECOMMENDED to add a message processing hint, see &xep0334;, to indicate the message to be stored in message stores like &xep0313;.</p>
+    <example caption='Sharing summit.jpg with juliet@shakespeare.lit without fallback'><![CDATA[
+<message to='juliet@shakespeare.lit' from='romeo@montague.lit/resource' id='sharing-a-file'>
+  <file-sharing xmlns='urn:xmpp:sfs:0'>
+    <!-- ... -->
+  </file-sharing>
+  <store xmlns='urn:xmpp:hints' />
+</message>
+]]></example>
+  </section2>
+  <section2 topic='Receiving a file' anchor='file-receive'>
+    <p>
+      On receive of a message including a <tt>&lt;file-sharing/&gt;</tt> element, the receiving entity SHOULD lookup in a local storage, whether the file with any of the proivded hashes has already been retrieved and is available.
+      In that case no transfer needs to be initated and the cached file can be used instead.
+    </p>
+    <p>
+      If the file is not available locally, the file can be obtained by one of the sources listed in the <tt>&lt;sources/&gt;</tt> element.
+      If further sources have been attached (as described in <link url="#attach-source">Attaching a source</link>), the receiving entity may also try to obtain the file from any of those.
+    </p>
+    <p>
+      When the source is an <tt>&lt;url-data/&gt;</tt> element as described in &xep0103;, the receiving entity MAY obtain the file by downloading it from the specified URL.
+      If the URL uses HTTP or HTTPS and additional HTTP request information as specified in &xep0104; is provided, the receiving entity SHOULD use such information when obtaining the file.
+      When sending and receiving files using <tt>&lt;url-data/&gt;</tt>, it is RECOMMENDED to prefer secure protocols (e.g. HTTPS, FTPS).
+      Please read <link url="#security">security considerations</link> when implementing support for insecure URLs.
+    </p>
+    <p>
+      When the source is a <tt>&lt;jingle-pub/&gt;</tt> element as described in &xep0358;, the receiving entity MAY obtain the file using the protocol described in &xep0358;.
+      If a <tt>&lt;hash/&gt;</tt> is provided, the receiving entity MAY obtain the file by requesting it as described in &xep0234;.
+    </p>
+    <p>
+      If sources of any other type are provided, clients MAY attempt to obtain the files from such sources.
+      The details of obtaining such file are out of scope of this document.
+    </p>
+    <p>
+      If the <tt>&lt;media-type/&gt;</tt> of the shared file is such that it can be displayed inline, the receiving entity MAY display the file inline.
+      If no <tt>&lt;media-type/&gt;</tt> is provided or the <tt>&lt;media-type/&gt;</tt> indicates that the file can not be displayed inline, i.e. when the media type is <tt>application/octet-stream</tt>, the receiving entity SHOULD NOT display the file inline and instead offer to download it or save it on the users file system.
+    </p>
+  </section2>
+  <section2 topic='Attaching a source' anchor='attach-source'>
+    <p class='box'>TODO: The following section relies on &xep0367;, however other methods to attach information to another message like the recently proposed &xep0422; might be suitable here as well. This is to be clarified before advancing to Draft.</p>
+    <p>
+      After a user shared a file using one entity and another entity in the conversation obtained it or found it in its local storage, that entity MAY announce that the file is now available with an additional source.
+      This increases availability of the file in case the sender goes offline before all the intended recipients were able to fetch the file. It also allows for peer-to-peer file distribution in group chats.
+    </p>
+    <p>
+      The entity MUST NOT announce itself as an additional source before verifying that <em>all</em> hashes provided match the hash of the file.
+      If no hashes are provided, the entity SHOULD NOT announce itself as an additional source.
+    </p>
+    <p>The attaching itself is performed by sending a message including a <tt>&lt;sources&gt;</tt> element with further sources using the protocol described in &xep0367;.</p>
+    <p>Depending on the lifetime of the newly attached source, it may be useful to add a message processing hint, see &xep0334;, to indicate the message to be stored in message stores like &xep0313;.</p>
+    <example caption='romeo@montague.lit/resource2 attaches itself as an additional source for the file'><![CDATA[
+<message to='juliet@shakespeare.lit' from='romeo@montague.lit/resource2'>
+  <attach-to id='sharing-a-file' xmlns='urn:xmpp:message-attaching:1'/>
+  <sources xmlns='urn:xmpp:sfs:0'>
+    <jinglepub xmlns='urn:xmpp:jinglepub:1' from='romeo@montague.lit/resource2' id='9559976B-3FBF-4E7E-B457-2DAA225972BB'>
+      <description xmlns='urn:xmpp:jingle:apps:file-transfer:5' />
+    </jinglepub>
+  </sources>
+  <store xmlns='urn:xmpp:hints' />
+</message>
+]]></example>
+  </section2>
+</section1>
+<section1 topic='Security Considerations' anchor='security'>
+  <p>
+    If a <tt>&lt;hash/&gt;</tt> using any supported algorithm is provided, the receiving client SHOULD verify that the <tt>&lt;hash/&gt;</tt> of the announced file matches the obained file before presenting it to the user.
+    If no <tt>&lt;hash/&gt;</tt> is provided or the <tt>&lt;hash/&gt;</tt> elements provided use unsupported algorithms, receiving clients MUST ignore any attached sources from other senders and only obtain the file from the sources announced by the original sender.
+    If no <tt>&lt;hash/&gt;</tt> is provided or the <tt>&lt;hash/&gt;</tt> elements provided use unsupported algorithms, receiving clients MUST ignore any sources that use unsecure protocols (e.g. HTTP without TLS).
+  </p>
+  <p>
+    For most methods of transferring a file proposed through the <tt>&lt;sources/&gt;</tt> element, obtaining files requires revealing private information like IP addresses to the sending user or third-parties.
+    Sources that do not require revealing private information to untrusted entities SHOULD be preferred by receiving entitites.
+    Receiving entities SHOULD ask users for confirmation before obtaining a file, if doing so would require revealing private information to untrusted entities.
+    If the protocol that is used when obtaining the file is not secure (e.g. HTTP without TLS), this SHOULD be considered as if the protocol reveals private information.
+  </p>
+  <p>
+    The security considerations of &xep-file-metadata; apply.
+  </p>
+</section1>
+<section1 topic='IANA Considerations' anchor='iana'>
+  <p>This document requires no interaction with &IANA;.</p>
+</section1>
+<section1 topic='XMPP Registrar Considerations' anchor='registrar'>
+  <section2 topic='Protocol Namespaces' anchor='ns'>
+    <p>The &REGISTRAR; includes 'urn:xmpp:sfs:0' in its registry of protocol namespaces (see &NAMESPACES;).</p>
+    <ul>
+      <li>urn:xmpp:sfs:0</li>
+    </ul>
+  </section2>
+</section1>
+<section1 topic='Acknowledgements' anchor='ack'>
+  <p>Thanks to the authors of &xep0385; which heavily inspired this XEP.</p>
+</section1>
+</xep>

--- a/inbox/stickers.xml
+++ b/inbox/stickers.xml
@@ -1,0 +1,232 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Note to editor: 
+- Remove xep-sfs entity declared below and change all references from &xep-sfs; to respective &xepXXXX; to refeence sfs when moving to experimental.
+- Remove xep-file-metadata entity declared below and change all references from &xep-file-metadata; to respective &xepXXXX; to refeence file metadata when moving to experimental.
+-->
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY xep-file-metadata "<span class='ref'><link url='./file-metadata.html'>File metadata element (XEP-xxxx)</link></span> <note>XEP-xxxx: File metadata element &lt;<link url='./file-metadata.html'>https://xmpp.org/extensions/inbox/file-metadata.html</link>&gt;.</note>" >
+  <!ENTITY xep-sfs "<span class='ref'><link url='./sfs.html'>Stateless file sharing (XEP-xxxx)</link></span> <note>XEP-xxxx: Stateless file sharing &lt;<link url='./sfs.html'>https://xmpp.org/extensions/inbox/sfs.html</link>&gt;.</note>" >
+  <!ENTITY % ents SYSTEM 'xep.ent'>
+%ents;
+  <!ENTITY sepl4 "0x1f (ASCII Unit Separator)">
+  <!ENTITY sepl3 "0x1e (ASCII Record Separator)">
+  <!ENTITY sepl2 "0x1d (ASCII Group Separator)">
+  <!ENTITY sepl1 "0x1c (ASCII File Separator)">
+]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+<header>
+  <title>Stickers</title>
+  <abstract>This specification provides a protocol to send stickers and to create and share sticker packs.</abstract>
+  &LEGALNOTICE;
+  <number>xxxx</number>
+  <status>ProtoXEP</status>
+  <type>Standards Track</type>
+  <sig>Standards</sig>
+  <approver>Council</approver>
+  <dependencies>
+    <spec>XMPP Core</spec>
+    <spec>XEP-0001</spec>
+  </dependencies>
+  <supersedes/>
+  <supersededby/>
+  <shortname>stickers</shortname>
+  &larma;
+  <revision>
+    <version>0.0.1</version>
+    <date>2020-11-03</date>
+    <initials>lmw</initials>
+    <remark><p>First draft.</p></remark>
+  </revision>
+</header>
+<section1 topic='Introduction' anchor='intro'>
+  <p>Stickers<note><em>Sticker (messaging)</em> on Wikipedia &lt;<link url='https://en.wikipedia.org/wiki/Sticker_(messaging)'>https://en.wikipedia.org/wiki/Sticker_(messaging)</link>&gt;.</note> are images or short animations that often represent an emoticon or an action. They are increasingly used in private messaging in the last years, especially on mobile phone apps. Stickers can be more nuanced and expressive than emoticons. They can be used to convey emotions or tell stories in a fun and easy way.</p>
+  <p>Recently, demand to implement stickers, including their social feature of sharing sticker packs arised within the XMPP community. This specification is to fulfill this demand.</p>
+</section1>
+<section1 topic='Requirements' anchor='reqs'>
+  <ul>
+    <li>Do not require additional server components for easier deployment</li>
+    <li>Compatibility with non-graphical user interfaces (terminals, etc)</li>
+  </ul>
+</section1>
+<section1 topic='Glossary' anchor='glossary'>
+  <dl>
+    <di><dt>Sticker</dt><dd>Emoticon-like picture</dd></di>
+    <di><dt>Sticker pack</dt><dd>Collection of stickers, typically devoted to a specific theme or with all stickers created by the same author</dd></di>
+  </dl>
+</section1>
+<section1 topic='Use Cases' anchor='usecases'>
+  <section2 topic='Creating a sticker pack' anchor='create'>
+    <p>
+      Sticker packs are stored on pubsub nodes.
+      They SHOULD be located at a personal eventing (PEP) node named "urn:xmpp:stickers:0" but MAY be located at a generic publish-subscribe node that is not attached to a user's IM account.
+      The pubsub node's access model SHOULD be set to 'open', so that other users can fetch sticker packs.
+    </p>
+    <section3 topic='Sticker pack pubsub item' anchor='pubsub-item'>
+      <p>
+        Each sticker pack is one item on the pubsub node consisting of a <tt>&lt;pack/&gt;</tt> element.
+      </p>
+      <p>
+        The <tt>&lt;pack/&gt;</tt> element includes elements <tt>&lt;name/&gt;</tt> and <tt>&lt;summary/&gt;</tt> to announce a name and summary of the sticker pack that can be displayed to users, respectively.
+        The summary MAY contain copyright and license information in user-readable format.
+        Multiple <tt>&lt;name/&gt;</tt> and <tt>&lt;summary/&gt;</tt> elements MAY be included given that no two elements of same name specify the same <tt>xml:lang</tt>.
+      </p>
+      <p>
+        The <tt>&lt;pack/&gt;</tt> element MAY include a <tt>&lt;restricted/&gt;</tt> element to indicate that this sticker pack may not be used or imported by other users.
+      </p>
+      <p>
+        The <tt>&lt;pack/&gt;</tt> element contains one or more <tt>&lt;item/&gt;</tt> elements that include details on the stickers in the pack. Each <tt>&lt;item/&gt;</tt> element has <tt>&lt;file/&gt;</tt> element as described in &xep-file-metadata;. The metadata MUST include one or multiple <tt>&lt;hash/&gt;</tt> elements as described in &xep0300;. All stickers in a pack MUST use the same algorithm for their <tt>&lt;hash/&gt;</tt> elements. The metadata MUST include one <tt>&lt;desc/&gt;</tt> element that is not qualified by a <tt>xml:lang</tt> attribute and describes the textual fallback (often an emoji or a sequence of emojis) of the sticker. Each <tt>&lt;item/&gt;</tt> element further has a <tt>&lt;sources/&gt;</tt> element as described in &xep-sfs; describing how to retrieve the image file of the sticker. Each <tt>&lt;item/&gt;</tt> element MAY include one or more <tt>&lt;suggest/&gt;</tt> elements that include a text that clients may replace with the sticker. <tt>&lt;suggest/&gt;</tt> elements MAY have an <tt>xml:lang</tt> attribute.
+      </p>
+      <p>
+        Finally, the <tt>&lt;pack/&gt;</tt> element includes a single <tt>&lt;hash/&gt;</tt> element as described in &xep0300;, specifying the hash of the sticker pack. See <link url='#pack-hash'>next section</link> on how such hash is generated.
+      </p>
+    </section3>
+    <section3 topic='Sticker pack hash calculation' anchor='pack-hash'>
+      <p>Each sticker pack has a unique ID, which is used as the pubsub item's id. This ID is derived from a hash of significant information from a <tt>&lt;pack/&gt;</tt> element as outlined in this section.</p>
+      <ol>
+        <li><p>Processing <tt>&lt;name/&gt;</tt> and <tt>&lt;summary/&gt;</tt> elements:</p>
+          <ol>
+            <li><p>For each <tt>&lt;name/&gt;</tt> or <tt>&lt;summary/&gt;</tt> element:</p>
+              <ol>
+                <li>Encode the character data of element name (<tt>name</tt> or <tt>summary</tt>), <tt>xml:lang</tt> attribute value and content.</li>
+                <li>Append an octet of value &sepl4; to each resulting octet string.</li>
+                <li>Join the resulting octet strings together, in the order of element name, <tt>xml:lang</tt> attribute and content, resulting in a single octet string for the <tt>&lt;name/&gt;</tt> or <tt>&lt;summary/&gt;</tt> element.</li>
+                <li>Append an octet of value &sepl3;.</li>
+              </ol>
+            </li>
+            <li>Join the resulting octet strings together, ordered from lesser to greater.</li>
+            <li>Append an octet of value &sepl1;.</li>
+          </ol>
+          <p>The result of this step is referenced as <em>Meta string</em> later.</p>
+        </li>
+        <li><p>Processing <tt>&lt;item/&gt;</tt> elements:</p>
+          <ol>
+            <li><p>For each <tt>&lt;item/&gt;</tt> element:</p>
+              <ol>
+                <li>Encode the character data of <tt>&lt;file/&gt;</tt>'s <tt>&lt;desc/&gt;</tt> content.</li>
+                <li>Append an octet of value &sepl3; to the resulting octet string.</li>
+                <li><p>For each of <tt>&lt;hash/&gt;</tt> element in <tt>&lt;file/&gt;</tt>:</p>
+                  <ol>
+                    <li>Encode the character data of <tt>algo</tt> attribute and content.</li>
+                    <li>Append an octet of value &sepl4; to the resulting octet strings.</li>
+                    <li>Join the resulting octet strings together, in the order of <tt>algo</tt> attribute and content, resulting in a single octet string for the <tt>&lt;hash/&gt;</tt> element.</li>
+                    <li>Append an octet of value &sepl3;.</li>
+                  </ol>
+                </li>
+                <li>Join the resulting octet strings together, in the order of <tt>&lt;file/&gt;</tt>'s <tt>&lt;desc/&gt;</tt> content first and then all <tt>&lt;hash/&gt;</tt> elements ordered from lesser to greater.</li>
+                <li>Append an octet of value &sepl2;.</li>
+              </ol>
+            </li>
+            <li>Join the resulting octet strings together, ordered from lesser to greater.</li>
+            <li>Append an octet of value &sepl1;.</li>
+          </ol>
+          <p>The result of this step is referenced as <em>Stickers string</em> later.</p>
+        </li>
+        <li>Join the <em>Meta String</em> and <em>Stickers String</em> together, in this order.</li>
+        <li>Hash the resulting string using the algorithm choosen for the sticker pack.</li>
+      </ol>
+      <p>The ID of the sticker pack is dervied by taking the first 144 bit of the hash and encode it using Base64. This is equivalent to the first 24 characters of the Base64 encoded content of the <tt>&lt;hash/&gt;</tt> element.</p>
+    </section3>
+    <example caption='Publish a new sticker pack'><![CDATA[
+<iq from='romeo@montague.lit/pda'
+    id='pub1'
+    to='romeo@montague.lit'
+    type='set'>
+  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+    <publish node='urn:xmpp:stickers:0'>
+      <item id='EpRv28DHHzFrE4zd+xaNpVb4'>
+        <pack xmlns='urn:xmpp:stickers:0'>
+          <name>Marsey the Cat</name>
+          <summary>Be cute or be cynical, this little kitten works both ways.</summary>
+          <item>
+            <file xmlns='urn:xmpp:file:metadata:0'>
+              <media-type>image/png</media-type>
+              <desc>👍</desc>
+              <size>71045</size>
+              <dimension>512x512</dimension>
+              <hash xmlns='urn:xmpp:hashes:2' algo='sha-256'>0AdP8lJOWJrugSKOIAqfEKqFatIpG5JBCjjxY253ojQ=</hash>
+            </file>
+            <sources xmlns='urn:xmpp:sfs:0'>
+              <url-data xmlns='http://jabber.org/protocol/url-data' target='https://download.montague.lit/51078299-d071-46e1-b6d3-3de4a8ab67d6/sticker_marsey_thumbs_up.png' />
+            </sources>
+            <suggest>+1</suggest>
+          </item>
+          <item>
+            <file xmlns='urn:xmpp:file:metadata:0'>
+              <media-type>image/png</media-type>
+              <desc>😘</desc>
+              <size>67016</size>
+              <dimension>512x512</dimension>
+              <hash xmlns='urn:xmpp:hashes:2' algo='sha-256'>gw+6xdCgOcvCYSKuQNrXH33lV9NMzuDf/s0huByCDsY=</hash>
+            </file>
+            <sources xmlns='urn:xmpp:sfs:0'>
+              <url-data xmlns='http://jabber.org/protocol/url-data' target='https://download.montague.lit/51078299-d071-46e1-b6d3-3de4a8ab67d6/sticker_marsey_kiss.png' />
+            </sources>
+          </item>
+          <!-- ... -->
+          <hash xmlns='urn:xmpp:hashes:2' algo='sha-256'>EpRv28DHHzFrE4zd+xaNpVb4jbu4s74XtioExNjQzZ0=</hash>
+        </pack>
+      </item>
+    </publish>
+  </pubsub>
+</iq>
+]]></example>    
+  </section2>
+  <section2 topic='Sending a sticker' anchor='send'>
+    <p>The sending entity uses &xep-sfs; to send the image file from the sticker pack. The <tt>&lt;item/&gt;</tt>'s <tt>&lt;file/&gt;</tt> and <tt>&lt;sources/&gt;</tt> elements from the sticker pack are used as a template. The sending entity MAY add additional <tt>&lt;hash/&gt;</tt> elements or sources.</p>
+    <p>Additionally, the sending entity adds an element <tt>&lt;sticker/&gt;</tt> to the message. This element carries an attribute <tt>pack</tt> referring to the id of the pubsub item carrying the sticker pack. If the sticker pack resides on a pubsub item other than the senders personal eventing (PEP) node named "urn:xmpp:stickers:0", the sending entity must add additional attributes <tt>jid</tt> and <tt>node</tt>, referring to the jid of the pubsub node and the name of the node, respectively.</p>
+    <p>The sending entity SHOULD use the <tt>&lt;file/&gt;</tt>'s <tt>&lt;desc/&gt;</tt> content as the message body, except if the sticker was selected based on a suggestion, in which case the content of the corresponding <tt>&lt;suggest/&gt;</tt> SHOULD be used.</p>
+    <example caption='Sending a sticker'><![CDATA[
+<message to='juliet@shakespeare.lit' from='romeo@montague.lit/pda' id='sharing-a-file'>
+  <body>😘</body>
+  <sticker xmlns='urn:xmpp:stickers:0' pack='EpRv28DHHzFrE4zd+xaNpVb4' />
+  <file-sharing xmlns='urn:xmpp:sfs:0'>
+    <file xmlns='urn:xmpp:file:metadata:0'>
+      <media-type>image/png</media-type>
+      <desc>😘</desc>
+      <size>67016</size>
+      <dimension>512x512</dimension>
+      <hash xmlns='urn:xmpp:hashes:2' algo='sha-256'>gw+6xdCgOcvCYSKuQNrXH33lV9NMzuDf/s0huByCDsY=</hash>
+    </file>
+    <sources>
+      <url-data xmlns='http://jabber.org/protocol/url-data' target='https://download.montague.lit/51078299-d071-46e1-b6d3-3de4a8ab67d6/sticker_marsey_kiss.png' />
+    </sources>
+  </file-sharing>
+</message>
+]]></example>
+  </section2>
+  <section2 topic='Receiving a sticker' anchor='receive'>
+    <p>When receiving a message with a <tt>&lt;sticker/&gt;</tt> element, the receiving entity SHOULD consider the message and the <tt>&lt;file-sharing/&gt;</tt> element as a sticker.</p>
+    <p>When receiving a sticker, the receiving entity may display the stickers image file inline or display the textual representation in the <tt>&lt;desc/&gt;</tt> element. The receiving entity SHOULD NOT display the received sticker only as a downloadable file.</p>
+  </section2>
+  <section2 topic='Importing a sticker pack' anchor='import'>
+    <p>When receiving a sticker or any other reference to a sticker pack, the receiving entity may allow the user to import such sticker pack. The receiving entity SHOULD NOT offer to import a sticker pack that has a <tt>&lt;restricted/&gt;</tt> element.</p>
+    <p>When importing a sticker pack, the entity SHOULD make all files that are part of the sticker pack locally available. The entity SHOULD duplicate the pubsub item from its original source to the users personal eventing (PEP) node named "urn:xmpp:stickers:0", preserving the pack id. The entity MAY remove any of the sources provided, and MAY make an effort to make the files available at additional sources, e.g. by using &xep0363;.</p>
+  </section2>
+  <section2 topic='Sharing a sticker pack' anchor='share'>
+    <p>After creating or importing a sticker pack, it can be shared using an <tt>xmpp:</tt>-uri as described in &xep0060;.</p>
+    <p>When handling this URI, the entity SHOULD display a preview of the sticker pack and allow importing it as described above.</p>
+    <example caption='Sticker pack URI'>xmpp:romeo@montague.lit?pubsub;action=retrieve;node=urn:xmpp:stickers:0;item=EpRv28DHHzFrE4zd%2BxaNpVb4</example>
+  </section2>
+</section1>
+<section1 topic='Accessibility Considerations' anchor='access'>
+  <p>Flickering, flashing or blinking stickers can induce seizures or other incapacitating physical reactions. It is RECOMMENDED that clients that support stickers have an option to disable animations and/or stickers entirely.</p>
+</section1>
+<section1 topic='Security Considerations' anchor='security'>
+  <p>
+    The security considerations of &xep-sfs; apply.
+  </p>
+</section1>
+<section1 topic='IANA Considerations' anchor='iana'>
+  <p>This document requires no interaction with &IANA;.</p>
+</section1>
+<section1 topic='XMPP Registrar Considerations' anchor='registrar'>
+  <section2 topic='Protocol Namespaces' anchor='ns'>
+    <p>The &REGISTRAR; includes 'urn:xmpp:stickers:0' in its registry of protocol namespaces (see &NAMESPACES;).</p>
+    <ul>
+      <li>urn:xmpp:stickers:0</li>
+    </ul>
+  </section2>
+</section1>
+</xep>

--- a/xep.ent
+++ b/xep.ent
@@ -1115,6 +1115,14 @@ IANA Service Location Protocol, Version 2 (SLPv2) Templates</link></span> <note>
     <jid>jc@opkode.com</jid>
   </author>
 " >
+<!ENTITY larma "
+  <author>
+    <firstname>Marvin</firstname>
+    <surname>Wißfeld</surname>
+    <email>xmpp@larma.de</email>
+    <jid>jabber@larma.de</jid>
+  </author>
+">
 
 <!-- XMPP Extension Protocols -->
 


### PR DESCRIPTION
This pull requests adds four XEP proposals:
- [File metadata element](https://larma.de/xeps/file-metadata.html). This specification defines a generic file metadata element to be used in other specifications.
- [Stateless file sharing](https://larma.de/xeps/sfs.html). This specification describes a protocol for stateless asynchronous file sharing with integrity and transport flexibility. It allows clients to provide a good interoperable user experience in combination with Carbons and MAM.
- [Encryption for stateless file sharing](https://larma.de/xeps/esfs.html). This specification provides a protocol for sharing encrypted files using the stateless file sharing protocol.
- [Stickers](https://larma.de/xeps/stickers.html). This specification provides a protocol to send stickers and to create and share sticker packs.