### PR TITLE
Fix styling on superscript elements

### DIFF
--- a/xmpp.css
+++ b/xmpp.css
@@ -942,14 +942,16 @@
   }
 
   sub,
-  sup {
+  sup,
+  .super {
     font-size: 75%;
     line-height: 0;
     position: relative;
     vertical-align: baseline;
   }
 
-  sup {
+  sup,
+  .super {
     top: -0.5em;
   }
 


### PR DESCRIPTION
Superscript elements currently aren't styled as superscript. For example, see XEP-0047 which says "65535 (215 - 1)" (which is still wrong either way, but at least the intention would be clearer with the styling).