### PR TITLE
XEP-0047: fix incorrect max sequence number

### DIFF
--- a/xep-0047.xml
+++ b/xep-0047.xml
@@ -194,7 +194,7 @@
 </iq>
 ]]></example>
     <p>Each chunk of data is included as the XML character data of the &lt;data/&gt; element after being encoded as Base64 as specified in Section 4 of &rfc4648;. Each block MUST be a valid base64 block with padding at the end if needed.</p>
-    <p>The &lt;data/&gt; element MUST possess a 'seq' attribute; this is a 16-bit unsigned integer that acts as a counter for data chunks sent in a particular direction within this session. The 'seq' value starts at 0 (zero) for each sender and MUST be incremented for each packet sent by that entity. Thus, the second chunk sent has a 'seq' value of 1, the third chunk has a 'seq' value of 2, and so on. The counter loops at maximum, so that after value 65535 (2<span class='super'>15</span> - 1) the 'seq' MUST start again at 0.</p>
+    <p>The &lt;data/&gt; element MUST possess a 'seq' attribute; this is a 16-bit unsigned integer that acts as a counter for data chunks sent in a particular direction within this session. The 'seq' value starts at 0 (zero) for each sender and MUST be incremented for each packet sent by that entity. Thus, the second chunk sent has a 'seq' value of 1, the third chunk has a 'seq' value of 2, and so on. The counter loops at maximum, so that after value 65535 (2<span class='super'>16</span> - 1) the 'seq' MUST start again at 0.</p>
     <p>The &lt;data/&gt; element MUST also possess a 'sid' attribute that ties the data chunk to this particular IBB session.</p>
     <p>In the case of IQ stanzas, if the packet can be processed then the recipient MUST reply with an IQ stanza of type "result".</p>
     <example caption='Acknowledging data received via IQ'><![CDATA[


### PR DESCRIPTION
Previously the text said that the max sequence number was 65535 (max
unsigned 16 bit integer), but also said this was (1<<15)-1, which is
actually max signed 16 bit integer or 32767.

This spec is final and therefore will need council review but per [XEP-0001](https://xmpp.org/extensions/xep-0001.html#states-Final) can still be modified in small ways. I think this fits within the scope of "backwards compatible" modifications since it's effectively just a typo fix.