### PR TITLE
XEP-0176: Improve compatibility with WebRTC clients

### DIFF
--- a/xep-0176.xml
+++ b/xep-0176.xml
@@ -34,6 +34,17 @@
   &seanegan;
   &robmcqueen;
   <revision>
+    <version>1.1</version>
+    <date>2020-11-27</date>
+    <initials>egp</initials>
+    <remark>
+      <ul>
+        <li>Make the 'foundation' attribute a string instead of an unsignedByte, in accordance with &rfc8445;.</li>
+        <li>Make the 'network' attribute optional, and add a mapping to SDP.</li>
+      </ul>
+    </remark>
+  </revision>
+  <revision>
     <version>1.0</version>
     <date>2009-06-10</date>
     <initials>psa</initials>
@@ -383,8 +394,8 @@ INITIATOR                              RESPONDER
       <tr>
         <td>network</td>
         <td>An index, starting at 0, referencing which network this candidate is on for a given peer (used for diagnostic purposes if the calling hardware has more than one Network Interface Card).</td>
-        <td>N/A</td>
-          <td>0</td>
+        <td>"extension-att-name network extension-att-value &lt;the network&gt;" in a=candidate line</td>
+        <td>0</td>
       </tr>
       <tr>
         <td>port</td>
@@ -1012,16 +1023,16 @@ Romeo                    Gateway                    Juliet
     <xs:simpleContent>
       <xs:extension base='empty'>
         <xs:attribute name='component' type='xs:unsignedByte' use='required'/>
-        <xs:attribute name='foundation' type='xs:unsignedByte' use='required'/>
+        <xs:attribute name='foundation' type='xs:string' use='required'/>
         <xs:attribute name='generation' type='xs:unsignedByte' use='required'/>
         <xs:attribute name='id' type='xs:NCName' use='required'/>
         <xs:attribute name='ip' type='xs:string' use='required'/>
-        <xs:attribute name='network' type='xs:unsignedByte' use='required'/>
         <xs:attribute name='port' type='xs:unsignedShort' use='required'/>
         <xs:attribute name='priority' type='xs:positiveInteger' use='required'/>
         <xs:attribute name='protocol' type='xs:NCName' use='required'/>
         <xs:attribute name='rel-addr' type='xs:string' use='optional'/>
         <xs:attribute name='rel-port' type='xs:unsignedShort' use='optional'/>
+        <xs:attribute name='network' type='xs:unsignedByte' use='optional'/>
         <xs:attribute name='type' use='required'>
           <xs:simpleType>
             <xs:restriction base='xs:NCName'>


### PR DESCRIPTION
Ping @iNPUTmice on this one.

An alternative would be to describe a way to make up 'id' and 'network' when working with WebRTC.

Foundation is actually described as “[a] sequence of up to 32 characters” [in RFC 8445](https://tools.ietf.org/html/rfc8445#section-5.3), but it is still described as a number elsewhere so not sure which one would be correct, maybe we’d like to take it up to the IETF?