### PR TITLE
Fix several mistakes in MIX specs

### DIFF
--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -537,7 +537,7 @@
 </section1>
 
 <section1 topic='Concepts' anchor='concepts'>
-  <section2 topic="Comparsion to MUC" anchor="concepts-muc-comparison">
+  <section2 topic="Comparison to MUC" anchor="concepts-muc-comparison">
     <p>
       This  section is written as an introduction to MIX for those with detailed knowledge of &xep0045;, to summarize key differences and some rationale for the differences.   For those unfamiliar with MUC, this section should be ignored.
     </p>

--- a/xep-0403.xml
+++ b/xep-0403.xml
@@ -200,7 +200,7 @@
 <items node='urn:xmpp:mix:nodes:presence'>
   <item id='123456#coven@mix.shakespeare.example/UUID-x4r/2491'>
     <presence xmlns='jabber:client'>
-      <mix xmlns='urn:xmpp:presence:0'>
+      <mix xmlns='urn:xmpp:mix:presence:0'>
         <jid>hecate@shakespeare.example/UUID-x4r/2491</jid>
         <nick>thirdwitch</jid>
       </mix>
@@ -265,7 +265,7 @@ A user MAY share presence information with the channel, for one or more online c
 <![CDATA[<presence from='123435#coven@mix.shakespeare.example/UUID-a1j/7533'
           to='hag99@shakespeare.example'
           id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'>
-  <mix xmlns='urn:xmpp:presence:0'>
+  <mix xmlns='urn:xmpp:mix:presence:0'>
      <jid>hecate@shakespeare.example/UUID-x4r/2491</jid>
      <nick>thirdwitch</jid>
   </mix>
@@ -313,7 +313,7 @@ A user MAY share presence information with the channel, for one or more online c
           to='hecate@shakespeare.example'
           id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
           type='unavailable'>
-      <mix xmlns='urn:xmpp:presence:0'>
+      <mix xmlns='urn:xmpp:mix:presence:0'>
         <jid>hecate@shakespeare.example/UUID-x4r/2491</jid>
         <nick>thirdwitch</jid>
       </mix>
@@ -337,7 +337,7 @@ A user MAY share presence information with the channel, for one or more online c
           to='hecate@shakespeare.example'
           id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD'
           type='unavailable'>
-      <mix xmlns='urn:xmpp:presence:0'>
+      <mix xmlns='urn:xmpp:mix:presence:0'>
         <jid>hecate@shakespeare.example/UUID-x4r/2491</jid>
         <nick>thirdwitch</jid>
       </mix>

--- a/xep-0404.xml
+++ b/xep-0404.xml
@@ -278,21 +278,23 @@ This change means that the client will not be able to determine real JID of the 
     from='coven@mix.shakespeare.example'
     to='hag66@shakespeare.example/UUID-a1j/7533'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-    <user-preference xmlns='urn:xmpp:mix:anon:0'>
+  <user-preference xmlns='urn:xmpp:mix:anon:0'>
     <x xmlns='jabber:x:data' type='form'>
       <field var='FORM_TYPE' type='hidden'>
         <value>urn:xmpp:mix:anon:0</value>
-     </field>
-     <field type='list-single' label='Preference for JID Visibility
-            var='JID Visibility'>
+      </field>
+      <field type='list-single' label='Preference for JID Visibility
+             var='JID Visibility'>
         <option label='JID Never Shown'><value>Never</value></option>
-        <option label='Default Behaviour'
-        <value>default</value></option>
-          <option label='Try not to show JID'>
-            <value>prefer not</value></option>
-     </field>
-     <field type='list-single' label='Example Custom Preference'
-            var='Custom Preference'>
+        <option label='Default Behaviour'>
+          <value>default</value>
+        </option>
+        <option label='Try not to show JID'>
+          <value>prefer not</value>
+        </option>
+      </field>
+      <field type='list-single' label='Example Custom Preference'
+             var='Custom Preference'>
         <option label='One Option'><value>a</value></option>
         <option label='Another Option'><value>b</value></option>
       </field>
@@ -308,41 +310,42 @@ This change means that the client will not be able to determine real JID of the 
     from='hag66@shakespeare.example/UUID-a1j/7533'
     to='coven@mix.shakespeare.example'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-    <user-preference xmlns='urn:xmpp:mix:anon:0'/>
-     <x xmlns='jabber:x:data' type='submit'>
-        <field var='FORM_TYPE' type='hidden'>
-             <value>urn:xmpp:mix:anon:0</value>
-        </field>
-        <field var='JID Visibility'>
-            <value>never</value>
-        </field>
-        <field var='Private Messages'>
-           <value>allow</value>
-         </field>
-        <field var='vCard'>
-          <value>block</value>
-         </field>
+  <user-preference xmlns='urn:xmpp:mix:anon:0'>
+    <x xmlns='jabber:x:data' type='submit'>
+      <field var='FORM_TYPE' type='hidden'>
+        <value>urn:xmpp:mix:anon:0</value>
+      </field>
+      <field var='JID Visibility'>
+        <value>never</value>
+      </field>
+      <field var='Private Messages'>
+        <value>allow</value>
+      </field>
+      <field var='vCard'>
+        <value>block</value>
+       </field>
      </x>
+  </user-preference>
 </iq>
 
 <iq type='result'
     from='coven@mix.shakespeare.example'
     to='hag66@shakespeare.example/UUID-a1j/7533'
     id='E6E10350-76CF-40C6-B91B-1EA08C332FC7'>
-    <user-preference xmlns='urn:xmpp:mix:anon:0'>
+  <user-preference xmlns='urn:xmpp:mix:anon:0'>
     <x xmlns='jabber:x:data' type='result'>
-        <field var='FORM_TYPE' type='hidden'>
-             <value>urn:xmpp:mix:anon:0</value>
-        </field>
-        <field var='JID Visibility'>
-            <value>never</value>
-        </field>
-        <field var='Private Messages'>
-           <value>allow</value>
-         </field>
-        <field var='vCard'>
-          <value>block</value>
-         </field>
+      <field var='FORM_TYPE' type='hidden'>
+        <value>urn:xmpp:mix:anon:0</value>
+      </field>
+      <field var='JID Visibility'>
+        <value>never</value>
+      </field>
+      <field var='Private Messages'>
+        <value>allow</value>
+      </field>
+      <field var='vCard'>
+        <value>block</value>
+      </field>
      </x>
   </user-preference>
 </iq>

--- a/xep-0408.xml
+++ b/xep-0408.xml
@@ -87,7 +87,7 @@
         type='text'/>
     <feature var='urn:xmpp:mix:core:0'/>
     <feature var='http://jabber.org/protocol/muc'/>
-     <feature var='urn:xmpp:mix:core:0#searchable'>
+    <feature var='urn:xmpp:mix:core:0#searchable'/>
   </query>
 </iq>
 ]]></example>
@@ -103,7 +103,7 @@
     id='lx09df27'
     to='mix.shakespeare.example'
     type='get'>
-  <query xmlns='http://jabber.org/protocol/disco#info'>
+  <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>
 
 <iq from='mix.shakespeare.example'


### PR DESCRIPTION
Commit titles say most of it, but the most important parts are:

* Fixing the namespace used in MIX-Presence examples
* Fixing the belonging of the form element in MIX-Anon examples (child of user-preference instead of sibling) according to the text