### PR TITLE
Fix mixed spaces/tabs in the template

### DIFF
--- a/xep-template.xml
+++ b/xep-template.xml
@@ -94,10 +94,10 @@
     </ul>
     <dl>
       <di>
-	<dt>Definition List</dt>
-	<dd>
-	  A definition list contains definition items with a title and a description.
-	</dd>
+        <dt>Definition List</dt>
+        <dd>
+          A definition list contains definition items with a title and a description.
+        </dd>
       </di>
     </dl>
     <p class='box'>Note: This is an informational box</p>
@@ -112,7 +112,7 @@
     <section3 topic='3rd Level Heading' anchor='syling-examples-3rd'>
       <p>Text in a Sub-Sub-Section.</p>
       <section4 topic='4th Level Heading' anchor='syling-examples-4th'>
-	<p>Text in a Sub-Sub-Sub-Section.</p>
+        <p>Text in a Sub-Sub-Sub-Section.</p>
       </section4>
     </section3>
   </section2>


### PR DESCRIPTION
A few lines of indentation were using tabs and everything else was using spaces. This fixes the indentation to be consistent.