### PR TITLE
XEP-0177: Made type optional in the schema

### DIFF
--- a/xep-0177.xml
+++ b/xep-0177.xml
@@ -32,6 +32,12 @@
   &hildjj;
   &seanegan;
   <revision>
+    <version>1.1.1</version>
+    <date>2020-12-10</date>
+    <initials>egp</initials>
+    <remark><p>Made type optional in the schema (it’s a MAY in section 4.2), unlike in XEP-0176.</p></remark>
+  </revision>
+  <revision>
     <version>1.1</version>
     <date>2009-12-23</date>
     <initials>psa</initials>
@@ -427,7 +433,7 @@ INITIATOR                            RESPONDER
         <xs:attribute name='id' type='xs:NCName' use='required'/>
         <xs:attribute name='ip' type='xs:string' use='required'/>
         <xs:attribute name='port' type='xs:unsignedShort' use='required'/>
-        <xs:attribute name='type' use='required'>
+        <xs:attribute name='type' use='optional'>
           <xs:simpleType>
             <xs:restriction base='xs:NCName'>
               <xs:enumeration value='host'/>


### PR DESCRIPTION
It’s a MAY in section 4.2, unlike in XEP-0176 where it is mandatory in each candidate.