### PR TITLE
XEP-0434: Release version 0.3.0

### DIFF
--- a/xep-0434.xml
+++ b/xep-0434.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE xep SYSTEM 'xep.dtd' [
 	<!ENTITY % ents SYSTEM 'xep.ent'>
 	<!ENTITY ns "urn:xmpp:trust-messages:0">
-	<!ENTITY ns-example-usage "urn:xmpp:example-usage:0">
+	<!ENTITY ns-atm "urn:xmpp:atm:0">
 	<!ENTITY ns-omemo "urn:xmpp:omemo:1">
 	<!ENTITY ns-sce "urn:xmpp:sce:0">
 %ents;
@@ -36,6 +36,19 @@
 		<email>melvo@olomono.de</email>
 		<jid>melvo@olomono.de</jid>
 		</author>
+	<revision>
+		<version>0.3.0</version>
+		<date>2020-12-19</date>
+		<initials>melvo</initials>
+		<remark>
+			<p>Clarify usage, use real namespace for examples and add missing section:</p>
+			<ul>
+				<li>Clarify usage of trust messages by protocols such as &xep0450;</li>
+				<li>Use namespace 'urn:xmpp:atm:0' of &xep0450; as example for 'usage' attribute.</li>
+				<li>Add section 'Security Considerations'</li>
+			</ul>
+		</remark>
+	</revision>
 	<revision>
 		<version>0.2.0</version>
 		<date>2020-11-05</date>
@@ -124,6 +137,7 @@
 <section1 topic='Why Trust Messages?' anchor='why-trust-messages'>
 	<p>
 		Trust messages can be used in conjunction with an end-to-end encryption protocol such as &xep0373; or &xep0384; to automatically or semi-automatically establish secure channels protected against active attacks.
+		This protocol specifies how trust messages are transmitted and protocols such as &xep0450; specify how and for which purpose they are processed.
 	</p>
 	<section2 topic='General Advantages' anchor='why-trust-messages-general-advantages'>
 		<p>
@@ -244,8 +258,8 @@
 	<p>
 		In the following example, two &xep0384; keys of Alice are indicated as trusted, one key of Bob is indicated as trusted and two other ones of Bob are indicated as untrusted.
 	</p>
-	<example caption='Trust Message Element for Alice&apos;s and Bob&apos;s OMEMO Keys'><![CDATA[
-<trust-message xmlns=']]>&ns;<![CDATA[' usage=']]>&ns-example-usage;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
+	<example caption='Trust Message Element for Alice&apos;s and Bob&apos;s OMEMO Keys used by ATM'><![CDATA[
+<trust-message xmlns=']]>&ns;<![CDATA[' usage=']]>&ns-atm;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
   <key-owner jid='alice@example.org'>
     <trust>6850019d7ed0feb6d3823072498ceb4f616c6025586f8f666dc6b9c81ef7e0a4</trust>
     <trust>221a4f8e228b72182b006e5ca527d3bddccf8d9e6feaf4ce96e1c451e8648020</trust>
@@ -310,7 +324,7 @@
   <from jid='alice@example.org/notebook'/>
   <to jid='carol@example.com'/>
   <payload>
-    <trust-message xmlns=']]>&ns;<![CDATA[' usage=']]>&ns-example-usage;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
+    <trust-message xmlns=']]>&ns;<![CDATA[' usage=']]>&ns-atm;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
         <trust>6850019d7ed0feb6d3823072498ceb4f616c6025586f8f666dc6b9c81ef7e0a4</trust>
         <trust>221a4f8e228b72182b006e5ca527d3bddccf8d9e6feaf4ce96e1c451e8648020</trust>
@@ -351,6 +365,12 @@
 		In that context, sending an encrypted trust message to all endpoints of a contact or to all own endpoints does not mean to encrypt it with the keys of all those endpoints.
 		Instead, it only means that all of those endpoints should receive the trust message even if it is not encrypted for some of them and thereby not decryptable by those endpoints.
 		Keep in mind that a trust message SHOULD only be encrypted for endpoints with authenticated keys.
+	</p>
+</section1>
+<section1 topic='Security Considerations' anchor='security-considerations'>
+	<p>
+		Protocols using trust messages SHOULD specify rules for processing them in order to create or sustain a secure communication.
+		Therefore, those protocols SHOULD state in which cases from which senders trust messages are used for making trust decisions and for which keys they are sent to whom.
 	</p>
 </section1>
 <section1 topic='IANA Considerations' anchor='iana-considerations'>


### PR DESCRIPTION
Clarify usage, use real namespace for examples and add missing section:

* Clarify usage of trust messages by protocols such as Automatic Trust Management (ATM)
* Use namespace `urn:xmpp:atm:0` of Automatic Trust Management (ATM) as example for `usage` attribute.
* Add section 'Security Considerations'

This should be merged after `inbox/automatic-trust-management.xml` moved to `xep-0450.xml`.