### PR TITLE
XEP-0447: Fix typo in example

### DIFF
--- a/xep-0447.xml
+++ b/xep-0447.xml
@@ -28,6 +28,12 @@ Note to editor: Remove xep-file-metadata entity declared below and change all re
   <shortname>sfs</shortname>
   &larma;
   <revision>
+    <version>0.1.1</version>
+    <date>2020-12-30</date>
+    <initials>ps</initials>
+    <remark>Fixed typo in example.</remark>
+  </revision>
+  <revision>
     <version>0.1.0</version>
     <date>2020-11-24</date>
     <initials>XEP Editor (jsc)</initials>
@@ -79,7 +85,7 @@ Note to editor: Remove xep-file-metadata entity declared below and change all re
       <media-type>image/jpeg</media-type>
       <name>summit.jpg</name>
       <size>3032449</size>
-      <dimension>4096x2160</dimension>
+      <dimensions>4096x2160</dimensions>
       <hash xmlns='urn:xmpp:hashes:2' algo='sha3-256'>2XarmwTlNxDAMkvymloX3S5+VbylNrJt/l5QyPa+YoU=</hash>
       <hash xmlns='urn:xmpp:hashes:2' algo='id-blake2b256'>2AfMGH8O7UNPTvUVAM9aK13mpCY=</hash>
       <desc>Photo from the summit.</desc>


### PR DESCRIPTION
The example had an element named `<dimension/>`, while the file metadata XEP defines this as `<dimensions/>`.