### PR TITLE
fixed examples in OMEMO Media sharing

### DIFF
--- a/inbox/omemo-media-sharing.xml
+++ b/inbox/omemo-media-sharing.xml
@@ -28,6 +28,16 @@
     <jid>daniel@gultsch.de</jid>
   </author>
   <revision>
+    <version>0.0.3</version>
+    <date>2021-01-20</date>
+    <initials>dg</initials>
+    <remark>
+      <ul>
+        <li>Fixed key length in examples</li>
+      </ul>
+    </remark>
+  </revision>
+  <revision>
     <version>0.0.2</version>
     <date>2021-01-10</date>
     <initials>egp</initials>
@@ -60,15 +70,15 @@
   <p>To share the file the entity converts the HTTPS URL, the key and the IV to an aesgcm:// URL. Both IV and key are converted to their hex representation of 24 characters and 64 characters respectively and concatenated for a total of 88 characters (44 bytes). The IV comes first followed by the key. The resulting string is put in the anchor part of the aesgcm URL.</p>
   <code><![CDATA[GET URL: https://download.montague.tld/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/tr%C3%A8s%20cool.jpg
 IV: 8c3d050e9386ec173861778f
-Key: 68e9af38a97aaf82faa4063b4d0878a61261534410c8a84331eaac851759f587ed40ca58
-Resulting URL: aesgcm://download.montague.tld/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/tr%C3%A8s%20cool.jpg#8c3d050e9386ec173861778f68e9af38a97aaf82faa4063b4d0878a61261534410c8a84331eaac851759f587ed40ca58
+Key: 68e9af38a97aaf82faa4063b4d0878a61261534410c8a84331eaac851759f587
+Resulting URL: aesgcm://download.montague.tld/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/tr%C3%A8s%20cool.jpg#8c3d050e9386ec173861778f68e9af38a97aaf82faa4063b4d0878a61261534410c8a84331eaac851759f587
 ]]></code>
   <p>Note: HTTP Upload has transport encryption as a MUST. Non HTTPS URLs MUST not be converted to the aesgcm URL scheme.</p>
   <p>The resulting aesgcm URL is encrypted as an OMEMO message and send to the recipient(s).</p>
 </section1>
 <section1 topic="Embedded Thumbnails" anchor="thumbnails">
  <p>The sending entity MAY also generate a thumbnail as a JPEG data uri and include that in the same message. The aesgcm:// and the data:image/jpep, are seperated by a new line character. The message SHOULD NOT include anything else. The JPEG thumbnail SHOULD be kept small (approximately 5KiB) to not run into into stanza size limitations. As a result the resulting thumbnail is considered to only be a very blury, very rough representation of the image.</p>
- <code><![CDATA[aesgcm://download.montague.tld/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/tr%C3%A8s%20cool.jpg#8c3d050e9386ec173861778f68e9af38a97aaf82faa4063b4d0878a61261534410c8a84331eaac851759f587ed40ca58
+ <code><![CDATA[aesgcm://download.montague.tld/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/tr%C3%A8s%20cool.jpg#8c3d050e9386ec173861778f68e9af38a97aaf82faa4063b4d0878a61261534410c8a84331eaac851759f587
 data:image/jpeg,/9j/4AAQSkZJRgABAQEBLAEsAAD…]]></code>
 </section1>
 <section1 topic='Business Rules' anchor='rules'>


### PR DESCRIPTION
The keys were too long.