### PR TITLE
XEP-0452: Clarify that users need to have their nicks registered

### DIFF
--- a/xep-0452.xml
+++ b/xep-0452.xml
@@ -51,9 +51,10 @@
 </section1>
 
 <section1 topic='Requirements' anchor='reqs'>
-  <p>A user's client must be able to receive forwarded groupchat messages from a MUC in which the user is mentioned, while not having an active session in that MUC (i.e. without joining it).</p>
-  <p>The user will have to be affiliated with the MUC, in order to receive the forwarded groupchat messages and whether or not mesages are forwarded will be determined by a configuration setting on the MUC.</p>
-  <p>The MUC owner(s) will therefore determine whether notifications are sent out, and may opt in or out by being affiliated or not with the MUC. Affiliations are long lived associations between users and MUCs, and therefore transcend individual sessions in MUCs.</p>
+  <p>A user's client must be able to receive forwarded groupchat messages from a MUC in which that user is mentioned, while not having an active session in that MUC (i.e. without joining it).</p>
+  <p>For this to be possible, the MUC needs to know the user's JID and MUC nickname even when that user is not currently present in the MUC. &xep0045; section 7.10 ("Registering with a Room") describes a mechanism whereby a user can register a nickname with a MUC and it is recommended that this is the mechanism used to keep track of users across sessions.</p>
+  <p>Whether or not mesages are forwarded will be determined by a configuration setting on the MUC.</p>
+  <p>The MUC owner(s) will therefore determine whether notifications are sent out, and if activated, users may opt in or out (or have that done for them by a privileged user) by having their nicknames registered or not with the MUC.</p>
 </section1>
 
 <section1 topic='Use Cases' anchor='usecases'>


### PR DESCRIPTION
in order for the MUC to be able to notify them when they're not present.