### PR TITLE
Update xep-iwe.xml

### DIFF
--- a/inbox/xep-iwe.xml
+++ b/inbox/xep-iwe.xml
@@ -49,10 +49,10 @@
 
   <p>The following implicit XMPP WebSocket endpoints are specified:</p>
   <ul>
-	<li>wss://&lt;xmpp-service-name>:5443/ws</li>
-	<li>ws://&lt;xmpp-service-name>:5443/ws</li>
-	<li>wss://&lt;xmpp-service-name>/ws</li>
-	<li>ws://&lt;xmpp-service-name>/ws</li>
+	<li>wss://&lt;xmpp-service-name>:5443/.well-known/xmpp-websocket</li>
+	<li>ws://&lt;xmpp-service-name>:5280/.well-known/xmpp-websocket</li>
+	<li>wss://&lt;xmpp-service-name>/.well-known/xmpp-websocket</li>
+	<li>ws://&lt;xmpp-service-name>/.well-known/xmpp-websocket</li>
   </ul>
 
   <p>TODO: Use implicit endpoints only if no other endpoints were
@@ -72,6 +72,9 @@
   discovered endpoints serially, as opposed to concurrently, may use
   the implicit endpoints only as last resort.</p>
 
+  <p>XMPP servers vendors are REQUIRED to use one or several of these
+  endpoints as default WebSocket endpoint configuration</p>
+  
 </section1>
 
 <section1 topic='Security Considerations' anchor='security'>


### PR DESCRIPTION
I really like this proposal and have been wanting something similar for a while.

# `/ws` -> `/.well-known/xmpp-websocket`

In deployments, `/ws` is too generic and the domain might already have something running there for :443.

# `5443` -> `5280`

Quoting Marvin W

> - ws://...:5443/ws makes no sense. Port 5443 is obviously a reference to
HTTPS 443 port which is TLS encrypted, so you shouldn't make non-TLS
connections to 5443. If any, use something like port 5080 or 5280.

# server vendors

I'm not happy with the wording, suggestions?