### PR TITLE
XEP-0452: Fix reference to Stanza Forwarding

### DIFF
--- a/xep-0452.xml
+++ b/xep-0452.xml
@@ -31,6 +31,12 @@
   </author>
   &mwild;
   <revision>
+    <version>0.2.1</version>
+    <date>2021-02-12</date>
+    <initials>ps</initials>
+    <remark>Fix reference to XEP-0297: Stanza Forwarding</remark>
+  </revision>
+  <revision>
     <version>0.2.0</version>
     <date>2021-02-09</date>
     <initials>jcb</initials>
@@ -137,7 +143,7 @@
   </mentions>
 </message>
 ]]></example>
-    <p>Notice that in the example above, the entire original 'groupchat' message (including elements added server-side, like the &xep0359; stanza-id) is encapsulated inside a &xep0279; element.</p>
+    <p>Notice that in the example above, the entire original 'groupchat' message (including elements added server-side, like the &xep0359; stanza-id) is encapsulated inside a &xep0297; element.</p>
   </section2>
 </section1>
 


### PR DESCRIPTION
The XEP was erroneously referencing to XEP-0279 (Server IP Check) instead of XEP-0297: Stanza Forwarding.
