### PR TITLE
Relegate message retraction to xep-0424 instead of using custom one.

### DIFF
--- a/xep-0407.xml
+++ b/xep-0407.xml
@@ -30,6 +30,7 @@
     <spec>XEP-0313</spec>
     <spec>XEP-0369</spec>
     <spec>XEP-0372</spec>
+    <spec>XEP-0424</spec>
   </dependencies>
   <supersedes/>
   <supersededby/>
@@ -172,22 +173,8 @@
 
     <section1 topic="Retracting a Message" anchor="usecase-retract">
       <p>
-        A MIX channel MAY support message retraction, where the sender of a messages or an authorized administrator deletes a message.  A MIX channel MAY limit the time frame in which a message is allowed to be retracted, for example to prevent retraction of very old messages.   When a messages is retracted the original message MAY be replaced by a tombstone.  Message retraction is done by sending a special message that identifies the original message.   This mechanism allows the retraction to be distributed on the same path as the original message so that all participating servers and clients MAY honour the retraction.  The protocol to request retraction does this by adding to a message  a &lt;retract&gt; element qualified by the 'urn:xmpp:mix:misc:0' namespace.  A retract messages MUST NOT have a body.   The &lt;retract&gt; element MUST include an 'id' attribute that holds the MAM-ID of the original  message.  The message sender will need to look up the MAM-ID.   The MAM-ID is the convenient message identification for message recipients.  A message and its retraction shown in the following example.
+        A MIX channel MAY support message retraction, where the sender of a messages or an authorized administrator deletes a message.  A MIX channel MAY limit the time frame in which a message is allowed to be retracted, for example to prevent retraction of very old messages.   When a messages is retracted the original message MAY be replaced by a tombstone.  Message retraction is done by means defined in &xep0424;.
       </p>
-      <example caption="User Retracts a Message"><![CDATA[
-
-<message from='hag66@shakespeare.example/UUID-a1j/7533'
-         to='coven@mix.shakespeare.example'
-         id='abcde'>
-  <body> A Message I did not mean to send </body>
-</message>
-
-<message from='hag66@shakespeare.example/UUID-a1j/7533'
-         to='coven@mix.shakespeare.example'
-         id='92vax143g'>
-  <retract id='77E07BB0-55CF-4BD4-890E-3F7C0E686BBD' xmlns='urn:xmpp:mix:misc:0'/>
-</message>
-]]></example>
       <p>
         The MIX channel will allow a user to retract a message sent by the user if the 'Allow User Message Retraction' option is configured.    The MIX channel will allow an administrative user to retract any message if the user is in the group specified by the 'Administrator Message Retraction Rights' option.
       </p>
@@ -198,23 +185,8 @@
         Two approaches to message retraction can be used.  In the first approach, the retracted message is simply removed.   This is appropriate where retraction is provided as a user service and the user has rights to remove messages sent from the record.
       </p>
       <p>
-        The second approach is to leave a tombstone, which if taken MUST be done in the following manner.  It is recommended to use a tombstone, as simply deleting the message may cause confusion with MAM queries.   Use of a tombstone is appropriate where it is desired to leave a record of the message that was redacted.
-        With this approach, the original message &lt;body&gt; is removed and replaced with a tombstone using the &lt;retracted&gt; element qualified by the 'urn:xmpp:mix:misc:0' namespace that shows the JID of user performing the retraction and the time of the retraction.
+        The second approach is to leave a tombstone.  It is recommended to use a tombstone, as simply deleting the message may cause confusion with MAM queries.   Use of a tombstone is appropriate where it is desired to leave a record of the message that was redacted.
       </p>
-      <example caption="Retracted message tombstone in a MAM result"><![CDATA[
-<message id='aeb213' to='juliet@capulet.example/UUID-e3r/9264'>
-  <result xmlns='urn:xmpp:mam:2' queryid='f27' id='28482-98726-73623'>
-    <forwarded xmlns='urn:xmpp:forward:0'>
-      <delay xmlns='urn:xmpp:delay' stamp='2010-07-10T23:08:25Z'/>
-      <message xmlns='jabber:client' from="hag66@shakespeare.example"
-                 to="macbeth@shakespeare.example">
-        <retracted xmlns='urn:xmpp:mix:misc:0' by='hag66@shakespeare.example'
-                 time='2010-07-10T23:08:25Z'/>
-      </message>
-    </forwarded>
-  </result>
-</message>
-]]></example>
     </section1>
 
     <section1 topic='Telling another User about a Channel' anchor='usecase-user-tell'>


### PR DESCRIPTION
As per, rather small, thread `[XEP-0407] - Message retraction question` on Standards I changed MIX specification (XEP-0407) and replaced custom retraction mechanism with reference to XEP-0424