### PR TITLE
xep2md: fix spaces around links or spans

### DIFF
--- a/tools/xep2md.lua
+++ b/tools/xep2md.lua
@@ -225,7 +225,7 @@ end
 
 -- Oh god oh god we're all gonna die!
 local function escape_text(event)
-	event.text = event.text:gsub("['&<>\"]", "\\%1"):gsub("^%s+", ""):gsub("%s+$", ""):gsub("%s+", " ");
+	event.text = event.text:gsub("['&<>\"]", "\\%1");
 end
 events.add_handler("#text", escape_text, 1000);
 


### PR DESCRIPTION
I have a vague recollection of some problem that was solved by trimming leading and trailing whitespace in spans, but this unintentionally stripped whitespace next to nested spans, such as links, so you'd have text[like this](https://www.example.com/)throughout the markdownified XEPs.