### PR TITLE
XEP-0393: further changes for clarity when reading

### DIFF
--- a/xep-0393.xml
+++ b/xep-0393.xml
@@ -27,6 +27,19 @@
   <shortname>styling</shortname>
   &sam;
   <revision>
+    <version>1.1.1</version>
+    <date>2021-04-04</date>
+    <initials>ssw</initials>
+    <remark>
+      <p>
+        General readability changes:
+        Copy part of span definition from glossary to business rules and remove
+        parenthesis for marking spans and blocks which was used inconsistently.
+        Also merge two lists of examples.
+      </p>
+    </remark>
+  </revision>
+  <revision>
     <version>1.1.0</version>
     <date>2021-01-12</date>
     <initials>sw</initials>
@@ -257,17 +270,7 @@
         A group of text that may be rendered inline alongside other spans.
         Spans may be either plain text with no formatting applied, or may be
         formatted text that is enclosed by two styling directives.
-        Spans are always children of blocks and may not escape from their
-        containing block.
         Some spans may contain child spans.
-        The following all contain spans marked by parenthesis:
-        <ul>
-          <li>(plain span)</li>
-          <li>(<strong>*strong span*</strong>)</li>
-          <li>(<em>_emphasized span_</em>)</li>
-          <li>(<em>_emphasized span containing </em>(<em><strong>*strong span*</strong></em>)<em>_</em>)</li>
-          <li>(span one )(<strong>*span two*</strong>)</li>
-        </ul>
       </dd>
     </di>
     <di>
@@ -321,9 +324,9 @@
       </p>
       <example caption='Plain block text'><![CDATA[
 <body>
-  (There are three blocks in this body marked by parens,)
-  (but there is no *formatting)
-  (as spans* may not escape blocks.)
+  There are three blocks in this body, one per line,
+  but there is no *formatting
+  as spans* may not escape blocks.
 </body>
 ]]></example>
     </section3>
@@ -386,11 +389,13 @@
   </section2>
   <section2 topic='Spans' anchor='span'>
     <p>
+      Spans are always the children of blocks and may not escape from their
+      containing block.
       Matches of spans between two styling directives MUST contain some text
-      between the two styling directives, otherwise neither directive is valid.
+      between the two directives, otherwise neither directive is valid.
       The opening styling directive MUST be located at the beginning of the
-      line, after a whitespace character, or after a different opening styling
-      directive.
+      parent block, after a whitespace character, or after a different opening
+      styling directive.
       The opening styling directive MUST NOT be followed by a whitespace
       character and the closing styling directive MUST NOT be preceeded by a
       whitespace character.
@@ -404,9 +409,10 @@
       For example, each of the following would be styled as indicated:
     </p>
     <ul>
-      <li><strong>*strong*</strong></li>
-      <li>plain <strong>*strong*</strong> plain</li>
-      <li><strong>*strong*</strong> plain <strong>*strong*</strong></li>
+      <li>plain span</li>
+      <li><strong>*strong span*</strong></li>
+      <li>plain <em>_emphasis_</em> plain</li>
+      <li><tt>`pre`</tt> plain <strong>*strong*</strong></li>
       <li><strong>*strong*</strong>plain*</li>
       <li>* plain <strong>*strong*</strong></li>
     </ul>
@@ -427,10 +433,12 @@
       <p>
         Any text inside of a block that is not part of another span is
         implicitly considered to be inside of a "plain text" span.
+        In the following example the plain span is everything before the first
+        "*".
       </p>
       <example caption='Plain'><![CDATA[
 <body>
-  (Two spans, both )(*alike in dignity*)
+  Two spans, both *alike in dignity*
 </body>
 ]]></example>
     </section3>


### PR DESCRIPTION
More editorial changes to XEP-0393. Someone pointed out that part of the definition of spans was in the glossary where it's hard to find it. Moving it into the business language makes it easier to find. I also merged a couple of lists of examples and tried to clarify that "new line" == "new block" (mostly).