### PR TITLE
XEP template: add `<cve>` element for security vulnerabilities

### DIFF
--- a/xep-0280.xml
+++ b/xep-0280.xml
@@ -533,6 +533,9 @@
     <li>any copies that do not meet this requirement MUST be ignored.</li>
   </ul>
   <p>Outbound chat messages that are encrypted end-to-end are not often useful to receive on other resources.  As such, they should use the &lt;private/&gt; element specified above to avoid such copying, unless the encryption mechanism is able to accommodate this protocol.</p>
+  <cve id="2017-5589" url="https://rt-solutions.de/en/cve-2017-5589_xmpp_carbons/">Multiple XMPP Clients User Impersonation Vulnerability</cve>
+  <cve id="2019-16235" url="https://gultsch.de/dino_multiple.html">Multiple Vulnerabilities found in Dino</cve>
+  <cve id="2020-26547" url="https://monal.im/blog/cve-2020-26547/">Missing sender verification for Carbons and MAM in Monal before 4.9</cve>
 </section1>
 <section1 topic='IANA Considerations' anchor='iana'>
   <p>This document requires no interaction with &IANA;.</p>

--- a/xep-template.xml
+++ b/xep-template.xml
@@ -109,6 +109,8 @@
   <query xmlns='http://jabber.org/protocol/disco#items'/>
 </iq>
 ]]></example>
+    <cve id="2017-5589" url="https://rt-solutions.de/en/cve-2017-5589_xmpp_carbons/">Name of a CVE relevant to the XEP</cve>
+    <cve id="2017-5589">Another CVE with no primary source</cve>
     <section3 topic='3rd Level Heading' anchor='syling-examples-3rd'>
       <p>Text in a Sub-Sub-Section.</p>
       <section4 topic='4th Level Heading' anchor='syling-examples-4th'>

--- a/xep.dtd
+++ b/xep.dtd
@@ -68,27 +68,27 @@ THE SOFTWARE.
 <!ELEMENT initials (#PCDATA)* >
 <!ELEMENT remark (#PCDATA | p | ul)* >
 <!ELEMENT councilnote (#PCDATA)* >
-<!ELEMENT section1 ( div | p | section2 | example | code | ul | ol | dl | table )* >
+<!ELEMENT section1 ( div | p | section2 | example | code | cve | ul | ol | dl | table )* >
 <!ATTLIST section1
           topic CDATA ''
           anchor CDATA '' >
-<!ELEMENT section2 ( div | p | section3 | example | code | ul | ol | dl | table )* >
+<!ELEMENT section2 ( div | p | section3 | example | code | cve | ul | ol | dl | table )* >
 <!ATTLIST section2
           topic CDATA ''
           anchor CDATA '' >
-<!ELEMENT section3 ( div | p | section4 | example | code | ul | ol | dl | table )* >
+<!ELEMENT section3 ( div | p | section4 | example | code | cve | ul | ol | dl | table )* >
 <!ATTLIST section3
           topic CDATA ''
           anchor CDATA '' >
-<!ELEMENT section4 ( div | p | section5 | example | code | ul | ol | dl | table )* >
+<!ELEMENT section4 ( div | p | section5 | example | code | cve | ul | ol | dl | table )* >
 <!ATTLIST section4
           topic CDATA ''
           anchor CDATA '' >
-<!ELEMENT section5 ( div | p | example | code | ul | ol | dl | table )* >
+<!ELEMENT section5 ( div | p | example | code | cve | ul | ol | dl | table )* >
 <!ATTLIST section5
           topic CDATA ''
           anchor CDATA '' >
-<!ELEMENT div ( #PCDATA | div | p | example | code | ul | ol | dl | table | blockquote )* >
+<!ELEMENT div ( #PCDATA | div | p | example | code | cve | ul | ol | dl | table | blockquote )* >
 <!ATTLIST div
           class CDATA ''
           style CDATA '' >
@@ -130,6 +130,10 @@ THE SOFTWARE.
 <!ATTLIST example caption CDATA '' >
 <!ELEMENT code (#PCDATA | span | em | strong)* >
 <!ATTLIST code caption CDATA '' >
+<!ELEMENT cve (#PCDATA)* >
+<!ATTLIST cve
+          id CDATA ''
+          url CDATA '' >
 <!ELEMENT table (tr)* >
 <!ATTLIST table caption CDATA '' >
 <!ELEMENT tr ( th | td )* >

--- a/xep.xsd
+++ b/xep.xsd
@@ -209,6 +209,7 @@ THE SOFTWARE.
     <xs:complexType>
       <xs:choice maxOccurs='unbounded'>
         <xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/>
+        <xs:element ref='cve' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='dl' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/>
@@ -227,6 +228,7 @@ THE SOFTWARE.
     <xs:complexType>
       <xs:choice maxOccurs='unbounded'>
         <xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/>
+        <xs:element ref='cve' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='dl' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/>
@@ -245,6 +247,7 @@ THE SOFTWARE.
     <xs:complexType>
       <xs:choice maxOccurs='unbounded'>
         <xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/>
+        <xs:element ref='cve' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='dl' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/>
@@ -263,6 +266,7 @@ THE SOFTWARE.
     <xs:complexType>
       <xs:choice maxOccurs='unbounded'>
         <xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/>
+        <xs:element ref='cve' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='dl' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/>
@@ -283,6 +287,7 @@ THE SOFTWARE.
         <xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/>
+        <xs:element ref='cve' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/>
       </xs:choice>
@@ -374,6 +379,17 @@ THE SOFTWARE.
       <xs:simpleContent>
         <xs:extension base='xs:string'>
           <xs:attribute name='caption' use='optional'/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='cve'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='xs:string'>
+          <xs:attribute name='id' use='required'/>
+          <xs:attribute name='url' use='optional'/>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>

--- a/xep.xsl
+++ b/xep.xsl
@@ -1015,6 +1015,26 @@ content: "XEP-<xsl:value-of select='/xep/header/number'/>";
     </figure>
   </xsl:template>
 
+  <xsl:template match='cve'>
+    <figure class='cve'>
+      <figcaption>CVE-<xsl:value-of select='@id'/>
+	(<a><xsl:attribute name='href'>https://nvd.nist.gov/vuln/detail/CVE-<xsl:value-of select='@id'/></xsl:attribute>NIST</a>,
+	<a><xsl:attribute name='href'>https://cve.mitre.org/cgi-bin/cvename.cgi?name=<xsl:value-of select='@id'/></xsl:attribute>Mitre</a>)
+      </figcaption>
+      <xsl:choose>
+	<xsl:when test="@url != ''">
+	  <a>
+	    <xsl:attribute name='href'><xsl:value-of select='@url'/></xsl:attribute>
+	    <xsl:apply-templates/>
+	  </a>
+	</xsl:when>
+	<xsl:otherwise>
+	  <xsl:apply-templates/>
+	</xsl:otherwise>
+      </xsl:choose>
+    </figure>
+  </xsl:template>
+
   <xsl:template match='img'>
     <img>
       <xsl:attribute name='alt'><xsl:value-of select='@alt'/></xsl:attribute>

--- a/xmpp.css
+++ b/xmpp.css
@@ -1290,6 +1290,11 @@
         padding: 1.5em;
         border: 1px solid rgba(19, 181, 234, 1.0);
     }
+    figure.cve {
+        padding: 1.5em;
+        background-color: rgba(255, 220, 220, 1.0);
+        border: 5px solid rgba(180, 0, 0, 1.0);
+    }
 
     figure > figcaption {
         margin-bottom: 0.5em;

--- a/xmpp.css
+++ b/xmpp.css
@@ -1292,7 +1292,6 @@
     }
     figure.cve {
         padding: 1.5em;
-        background-color: rgba(255, 220, 220, 1.0);
         border: 5px solid rgba(180, 0, 0, 1.0);
     }
 
@@ -1714,7 +1713,6 @@
     }
     figure.cve {
         border: 5px solid rgba(120, 0, 0, 1.0);
-        background-color: #200000;
     }
 
     .box {

--- a/xmpp.css
+++ b/xmpp.css
@@ -1712,6 +1712,10 @@
     figure.example {
         background-color: #282828;
     }
+    figure.cve {
+        border: 5px solid rgba(120, 0, 0, 1.0);
+        background-color: #200000;
+    }
 
     .box {
         color: #ccc;


### PR DESCRIPTION
This adds a new `<cve>` element to highlight what implementations have done wrong in the past.