### PR TITLE
XEP-0434: Release version 0.5.0

### DIFF
--- a/xep-0434.xml
+++ b/xep-0434.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE xep SYSTEM 'xep.dtd' [
 	<!ENTITY % ents SYSTEM 'xep.ent'>
-	<!ENTITY ns "urn:xmpp:trust-messages:0">
+	<!ENTITY ns "urn:xmpp:tm:0">
 	<!ENTITY ns-atm "urn:xmpp:atm:0">
 	<!ENTITY ns-omemo "urn:xmpp:omemo:1">
-	<!ENTITY ns-sce "urn:xmpp:sce:0">
+	<!ENTITY ns-sce "urn:xmpp:sce:1">
 %ents;
 ]>
 <?xml-stylesheet type='text/xsl' href='xep.xsl'?>
@@ -36,6 +36,20 @@
 		<email>melvo@olomono.de</email>
 		<jid>melvo@olomono.de</jid>
 	</author>
+	<revision>
+		<version>0.5.0</version>
+		<date>2021-04-16</date>
+		<initials>melvo</initials>
+		<remark>
+			<p>Update to XEP-0420 version 0.4.0 and adapt namespace to shortname:</p>
+			<ul>
+				<li>Replace SCE's old 'content' element by its new 'envelope' element</li>
+				<li>Replace SCE's old 'payload' element by its new 'content' element</li>
+				<li>Update SCE's namespace to 'urn:xmpp:sce:1'</li>
+				<li>Change namespace to 'urn:xmpp:tm:0'</li>
+			</ul>
+		</remark>
+	</revision>
 	<revision>
 		<version>0.4.0</version>
 		<date>2021-04-13</date>
@@ -304,11 +318,11 @@
 		<p>
 			Describing how the <![CDATA[<trust-message/>]]> element has to be used by each existing encryption protocol is out of scope.
 			&xep0420; specifies a common method for encrypting arbitrary elements which can be used by different encryption protocols.
-			When using an encryption protocol such as &xep0384; that uses &xep0420; (SCE), the SCE <![CDATA[<payload/>]]> element MUST contain the <![CDATA[<trust-message/>]]> element as a direct child.
+			When using an encryption protocol such as &xep0384; that uses &xep0420; (SCE), the SCE <![CDATA[<content/>]]> element MUST contain the <![CDATA[<trust-message/>]]> element as a direct child.
 		</p>
 		<section3 topic='SCE Profile' anchor='use-cases-encrypted-trust-message-sce-profile'>
 			<p>
-				A trust message SCE <![CDATA[<content/>]]> element
+				A trust message SCE <![CDATA[<envelope/>]]> element
 			</p>
 			<ul>
 				<li>
@@ -330,13 +344,13 @@
 				</li>
 			</ul>
 		</section3>
-		<example caption='SCE Content Element Used for a Trust Message from Alice&apos;s Endpoint to Carol'><![CDATA[
-<content xmlns=']]>&ns-sce;<![CDATA['>
+		<example caption='SCE Envelope Element Used for a Trust Message from Alice&apos;s Endpoint to Carol'><![CDATA[
+<envelope xmlns=']]>&ns-sce;<![CDATA['>
   <rpad>QHqW2arWFewoERL1a43wonBKpTmsrBWnc1d66HSDq85NgMLmjrDJV9lV</rpad>
   <time stamp='2020-01-01T00:00:00'/>
   <from jid='alice@example.org/notebook'/>
   <to jid='carol@example.com'/>
-  <payload>
+  <content>
     <trust-message xmlns=']]>&ns;<![CDATA[' usage=']]>&ns-atm;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
         <trust>6850019d7ed0feb6d3823072498ceb4f616c6025586f8f666dc6b9c81ef7e0a4</trust>
@@ -348,8 +362,8 @@
         <distrust>d9f849b6b828309c5f2c8df4f38fd891887da5aaa24a22c50d52f69b4a80817e</distrust>
       </key-owner>
     </trust-message>
-  </payload>
-</content>
+  </content>
+</envelope>
 ]]></example>
 	</section2>
 </section1>


### PR DESCRIPTION
Update to XEP-0420 version 0.4.0 and adapt namespace to shortname:

* Replace SCE's old 'content' element by its new 'envelope' element
* Replace SCE's old 'payload' element by its new 'content' element
* Update SCE's namespace to `urn:xmpp:sce:1`
* Change namespace to `urn:xmpp:tm:0`