### PR TITLE
XEP-0450: Release version 0.3.0

### DIFF
--- a/xep-0450.xml
+++ b/xep-0450.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE xep SYSTEM 'xep.dtd' [
 	<!ENTITY % ents SYSTEM 'xep.ent'>
-	<!ENTITY ns "urn:xmpp:atm:0">
-	<!ENTITY ns-trust-messages "urn:xmpp:trust-messages:0">
+	<!ENTITY ns "urn:xmpp:atm:1">
+	<!ENTITY ns-trust-messages "urn:xmpp:tm:0">
 	<!ENTITY ns-omemo "urn:xmpp:omemo:1">
-	<!ENTITY ns-sce "urn:xmpp:sce:0">
+	<!ENTITY ns-sce "urn:xmpp:sce:1">
 %ents;
 ]>
 <?xml-stylesheet type='text/xsl' href='xep.xsl'?>
@@ -37,6 +37,21 @@
 		<email>melvo@olomono.de</email>
 		<jid>melvo@olomono.de</jid>
 	</author>
+	<revision>
+		<version>0.3.0</version>
+		<date>2021-04-16</date>
+		<initials>melvo</initials>
+		<remark>
+			<p>Update to XEP-0420 version 0.4.0 and XEP-0434 version 0.5.0:</p>
+			<ul>
+				<li>Replace SCE's old 'content' element by its new 'envelope' element</li>
+				<li>Replace SCE's old 'payload' element by its new 'content' element</li>
+				<li>Update SCE's namespace to 'urn:xmpp:sce:1'</li>
+				<li>Update TM's namespace to 'urn:xmpp:tm:0'</li>
+				<li>Update namespace to 'urn:xmpp:atm:1'</li>
+			</ul>
+		</remark>
+	</revision>
 	<revision>
 		<version>0.2.0</version>
 		<date>2021-04-13</date>
@@ -171,7 +186,7 @@
 	</p>
 	<p>
 		Note that the examples in the following use cases are consecutive and therefore must be read chronologically to properly understand them.
-		Since ATM uses &xep0420;, only the SCE <![CDATA[<content/>]]> elements are shown.
+		Since ATM uses &xep0420;, only the SCE <![CDATA[<envelope/>]]> elements are shown.
 	</p>
 	<p>
 		Alice would like to use OMEMO when communicating with Bob.
@@ -195,19 +210,19 @@
 					... the key that has been authenticated, to each own endpoint with an already authenticated key.
 				</p>
 				<example caption='A1 sends an authentication message for B1&apos;s key to A2'><![CDATA[
-<content xmlns=']]>&ns-sce;<![CDATA['>
+<envelope xmlns=']]>&ns-sce;<![CDATA['>
   <rpad>QHqW2arWFewoERL1a43wonBKpTmsrBWnc1d66HSDq85NgMLmjrDJV9lV</rpad>
   <time stamp='2020-01-01T12:00:00'/>
   <from jid='alice@example.org/A1'/>
   <to jid='alice@example.org'/>
-  <payload>
+  <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='bob@example.com'>
         <trust>623548d3835c6d33ef5cb680f7944ef381cf712bf23a0119dabe5c4f252cd02f</trust>
       </key-owner>
     </trust-message>
-  </payload>
-</content>
+  </content>
+</envelope>
 ]]></example>
 			</section4>
 			<section4 topic='To Contact&apos;s Endpoint' anchor='use-case-authentication-contact-endpoint-sending-to-contact-endpoint'>
@@ -215,19 +230,19 @@
 					... each already authenticated key of all own endpoints, to the endpoint whose key has been authenticated.
 				</p>
 				<example caption='A1 sends an authentication message for A2&apos;s key to B1'><![CDATA[
-<content xmlns=']]>&ns-sce;<![CDATA['>
+<envelope xmlns=']]>&ns-sce;<![CDATA['>
   <rpad>Wvj25aDkNbAnSxMIDQo1pjIKRowIMGrF72hSJeXS</rpad>
   <time stamp='2020-01-01T12:00:01'/>
   <from jid='alice@example.org/A1'/>
   <to jid='bob@example.org'/>
-  <payload>
+  <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
         <trust>6850019d7ed0feb6d3823072498ceb4f616c6025586f8f666dc6b9c81ef7e0a4</trust>
       </key-owner>
     </trust-message>
-  </payload>
-</content>
+  </content>
+</envelope>
 ]]></example>
 			</section4>
 		</section3>
@@ -273,34 +288,34 @@
 					... the key that has been authenticated to each other endpoint with an already authenticated key.
 				</p>
 				<example caption='A2 sends an authentication message for A3&apos;s key to B1 and by using Message Carbons also to A1'><![CDATA[
-<content xmlns=']]>&ns-sce;<![CDATA['>
+<envelope xmlns=']]>&ns-sce;<![CDATA['>
   <rpad>O2vRKkmtsXsKSk2hPDkrpQQ4Og272qFGB1Srp64vaDrMTNhrV6</rpad>
   <time stamp='2020-01-01T14:00:01'/>
   <from jid='alice@example.org/A2'/>
   <to jid='bob@example.org'/>
-  <payload>
+  <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
         <trust>221a4f8e228b72182b006e5ca527d3bddccf8d9e6feaf4ce96e1c451e8648020</trust>
       </key-owner>
     </trust-message>
-  </payload>
-</content>
+  </content>
+</envelope>
 ]]></example>
 				<example caption='A2 would send an authentication message for A3&apos;s key only to A1 if there were no contacts with authenticated keys'><![CDATA[
-<content xmlns=']]>&ns-sce;<![CDATA['>
+<envelope xmlns=']]>&ns-sce;<![CDATA['>
   <rpad>s5jP95kvpRNg92XLLo8OkLCvUDT53S</rpad>
   <time stamp='2020-01-01T14:00:00'/>
   <from jid='alice@example.org/A2'/>
   <to jid='alice@example.org'/>
-  <payload>
+  <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
         <trust>221a4f8e228b72182b006e5ca527d3bddccf8d9e6feaf4ce96e1c451e8648020</trust>
       </key-owner>
     </trust-message>
-  </payload>
-</content>
+  </content>
+</envelope>
 ]]></example>
 			</section4>
 			<section4 topic='To Endpoint Whose Key Has Been Authenticated' anchor='use-case-authentication-own-endpoint-sending-to-endpoint-key-authenticated'>
@@ -308,12 +323,12 @@
 					... each already authenticated key of all endpoints to the endpoint whose key has been authenticated.
 				</p>
 				<example caption='A2 sends an authentication message for A1&apos;s and B1&apos;s key to A3'><![CDATA[
-<content xmlns=']]>&ns-sce;<![CDATA['>
+<envelope xmlns=']]>&ns-sce;<![CDATA['>
   <rpad>98WA6U92twcVkAXM44UU</rpad>
   <time stamp='2020-01-01T14:00:02'/>
   <from jid='alice@example.org/A2'/>
   <to jid='bob@example.org'/>
-  <payload>
+  <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
         <trust>f3cddd91f25502652483be2fd5faaaa00f80868ac0d51d7eebb1b08a3892e33d</trust>
@@ -322,8 +337,8 @@
         <trust>623548d3835c6d33ef5cb680f7944ef381cf712bf23a0119dabe5c4f252cd02f</trust>
       </key-owner>
     </trust-message>
-  </payload>
-</content>
+  </content>
+</envelope>
 ]]></example>
 			</section4>
 		</section3>
@@ -348,34 +363,34 @@
 				An endpoint that initially distrusts the key of an own endpoint MUST send a distrust message for that key to each other endpoint with an already authenticated key.
 			</p>
 			<example caption='A1 sends a distrust message for A3&apos;s key to B1 and by using Message Carbons also to A2'><![CDATA[
-<content xmlns=']]>&ns-sce;<![CDATA['>
+<envelope xmlns=']]>&ns-sce;<![CDATA['>
   <rpad>NF5MOJdt8TBbItt4AHXOUKWncRmw5B</rpad>
   <time stamp='2020-01-01T16:00:01'/>
   <from jid='alice@example.org/A1'/>
   <to jid='bob@example.org'/>
-  <payload>
+  <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
         <distrust>221a4f8e228b72182b006e5ca527d3bddccf8d9e6feaf4ce96e1c451e8648020</distrust>
       </key-owner>
     </trust-message>
-  </payload>
-</content>
+  </content>
+</envelope>
 ]]></example>
 			<example caption='A1 would send a distrust message for A3&apos;s key only to A2 if there were no contacts with authenticated keys'><![CDATA[
-<content xmlns=']]>&ns-sce;<![CDATA['>
+<envelope xmlns=']]>&ns-sce;<![CDATA['>
   <rpad>798BFSTQqPjVtiLok3EGtQ7VgB3GGP7eT9P4FhO5</rpad>
   <time stamp='2020-01-01T16:00:00'/>
   <from jid='alice@example.org/A1'/>
   <to jid='alice@example.org'/>
-  <payload>
+  <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
         <distrust>221a4f8e228b72182b006e5ca527d3bddccf8d9e6feaf4ce96e1c451e8648020</distrust>
       </key-owner>
     </trust-message>
-  </payload>
-</content>
+  </content>
+</envelope>
 ]]></example>
 		</section3>
 		<section3 topic='Receiving' anchor='use-case-distrusting-own-endpoint-receiving'>
@@ -399,19 +414,19 @@
 				An endpoint that distrusts the key of a contact's endpoint MUST send a distrust message for that key to each other own endpoint with an authenticated key.
 			</p>
 			<example caption='A1 sends a distrust message for B1&apos;s key to A2'><![CDATA[
-<content xmlns=']]>&ns-sce;<![CDATA['>
+<envelope xmlns=']]>&ns-sce;<![CDATA['>
   <rpad>x4LJDawLHgnTJRC7T1mndKEQLPR658NQmXAPQRVnhM1QQ861ve</rpad>
   <time stamp='2020-01-01T18:00:00'/>
   <from jid='alice@example.org/A1'/>
   <to jid='alice@example.org'/>
-  <payload>
+  <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='bob@example.com'>
         <distrust>623548d3835c6d33ef5cb680f7944ef381cf712bf23a0119dabe5c4f252cd02f</distrust>
       </key-owner>
     </trust-message>
-  </payload>
-</content>
+  </content>
+</envelope>
 ]]></example>
 		</section3>
 		<section3 topic='Receiving' anchor='use-case-distrusting-contact-endpoint-receiving'>


### PR DESCRIPTION
Update to XEP-0420 version 0.4.0 and XEP-0434 version 0.5.0:

* Replace SCE's old 'content' element by its new 'envelope' element
* Replace SCE's old 'payload' element by its new 'content' element
* Update SCE's namespace to `urn:xmpp:sce:1`
* Update TM's namespace to `urn:xmpp:tm:0`
* Update namespace to `urn:xmpp:atm:1`

This should be merged after #1056.