### PR TITLE
XEP-0450: Release version 0.3.1

### DIFF
--- a/xep-0450.xml
+++ b/xep-0450.xml
@@ -38,6 +38,19 @@
 		<jid>melvo@olomono.de</jid>
 	</author>
 	<revision>
+		<version>0.3.1</version>
+		<date>2021-05-14</date>
+		<initials>melvo</initials>
+		<remark>
+			<p>Improve examples and apply consistent formatting:</p>
+			<ul>
+				<li>Replace wrong recipient in example by 'alice@example.org'</li>
+				<li>Use recipient 'bob@example.com' in examples consistently</li>
+				<li>Apply consistent formatting for revision history</li>
+			</ul>
+		</remark>
+	</revision>
+	<revision>
 		<version>0.3.0</version>
 		<date>2021-04-16</date>
 		<initials>melvo</initials>
@@ -75,7 +88,7 @@
 		<version>0.0.1</version>
 		<date>2020-11-05</date>
 		<initials>melvo</initials>
-		<remark><p>First draft</p></remark>
+		<remark>First draft</remark>
 	</revision>
 </header>
 <section1 topic='Introduction' anchor='introduction'>
@@ -234,7 +247,7 @@
   <rpad>Wvj25aDkNbAnSxMIDQo1pjIKRowIMGrF72hSJeXS</rpad>
   <time stamp='2020-01-01T12:00:01'/>
   <from jid='alice@example.org/A1'/>
-  <to jid='bob@example.org'/>
+  <to jid='bob@example.com'/>
   <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
@@ -292,7 +305,7 @@
   <rpad>O2vRKkmtsXsKSk2hPDkrpQQ4Og272qFGB1Srp64vaDrMTNhrV6</rpad>
   <time stamp='2020-01-01T14:00:01'/>
   <from jid='alice@example.org/A2'/>
-  <to jid='bob@example.org'/>
+  <to jid='bob@example.com'/>
   <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
@@ -327,7 +340,7 @@
   <rpad>98WA6U92twcVkAXM44UU</rpad>
   <time stamp='2020-01-01T14:00:02'/>
   <from jid='alice@example.org/A2'/>
-  <to jid='bob@example.org'/>
+  <to jid='alice@example.org'/>
   <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
@@ -367,7 +380,7 @@
   <rpad>NF5MOJdt8TBbItt4AHXOUKWncRmw5B</rpad>
   <time stamp='2020-01-01T16:00:01'/>
   <from jid='alice@example.org/A1'/>
-  <to jid='bob@example.org'/>
+  <to jid='bob@example.com'/>
   <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>


### PR DESCRIPTION
Improve examples and apply consistent formatting:

* Replace wrong recipient in example by 'alice@example.org'
* Use recipient 'bob@example.com' in examples consistently
* Apply consistent formatting for revision history