### PR TITLE
XEP-0001: add Archived status

### DIFF
--- a/xep-0001.xml
+++ b/xep-0001.xml
@@ -23,6 +23,12 @@
   &dcridland;
   &ralphm;
   <revision>
+  <revision>
+    <version>1.25.0</version>
+    <date>2022-07-25</date>
+    <initials>ssw</initials>
+    <remark><p>Add Archived XEP status.</p></remark>
+  </revision>
     <version>1.24.0</version>
     <date>2021-08-24</date>
     <initials>ssw</initials>
@@ -334,10 +340,11 @@
      |         |      |
 Experimental --+-> Proposed ----> Stable ---> Final
      ^                |             |           |
-     +----------------+             |           |
-                                    +-----------+---> Deprecated
-                                                          |
-                                                          +--> Obsolete
+     +----------------+             +-----------+---> Archived
+                                    |           |         |
+                                    +-----------+---------+--> Deprecated
+                                                                   |
+                                                                   +--> Obsolete
     </code>
     <p>After an XMPP Extension Protocol has been accepted for publication by the XMPP Council and before it is proposed for advancement to a status of Stable (or retracted or deferred), it shall have a status of Experimental. Publication as an Experimental XEP does not indicate approval of the protocol by the XMPP Council or the broader XMPP community.</p>
     <p><em>Note: An Experimental specification is a work in progress and may undergo significant modification before advancing to a status of Stable. While implementation of an Experimental protocol is encouraged in order to determine the feasibility of the proposed solution, it is not recommended for such implementations to be included in the primary release for a software product (as opposed to an experimental branch).</em></p>
@@ -372,9 +379,11 @@ Experimental --+-> Proposed ----> Stable ---> Final
 Experimental ----> Proposed ----> Active
                                     |
                                     |
-                                    +--> Deprecated
-                                             |
-                                             +--> Obsolete
+                                    +---> Archived
+                                    |         |
+                                    +---------+-> Deprecated
+                                                      |
+                                                      +--> Obsolete
     </code>
     <p>Because such XEPs do not seek to define standard protocols, in general they are less controversial and tend to proceed from Proposed to Active without controversy on a vote of the XMPP Council. However, some of these XEPs may be remanded from the Council to the XEP author and/or XMPP Extensions Editor for revision in order to be suitable for advancement from Proposed to Active (e.g., documentation of protocols in use must be accurate and describe any existing security concerns). As with Standards Track XEPs, the XEP author may retract such a XEP when it is Experimental, and the Council may reject such a XEP when it is Proposed.</p>
     <p>Once approved, Historical, Informational, and Procedural XEPs will have a status of Active. Such a XEP may be replaced by a new XEP on the same or a similar topic, thus rendering the earlier XEP out of date; in such cases, the earlier XEP shall be assigned a status of Deprecated (and eventually Obsolete) with a note specifying the superseding XEP.</p>
@@ -418,6 +427,9 @@ Experimental ----> Proposed ----> Active
   </section2>
   <section2 topic='Obsolete' anchor='states-Obsolete'>
     <p>A XEP of any type is changed from Deprecated to Obsolete if the XMPP Council has determined that the protocol defined therein should no longer be implemented or deployed.</p>
+  </section2>
+  <section2 topic='Archived' anchor='states-Archived'>
+    <p>A XEP of any type is in the Archived state if the XMPP Council has determined that the protocol defined therein is still the correct way to implement a protocol if needed but that the protocol or an underlying technology is out of date or not likely to receive updates.</p>
   </section2>
 </section1>
 <section1 topic='Modification of Final and Active XEPs' anchor='mods'>
@@ -544,6 +556,7 @@ THE SOFTWARE.
     <xs:simpleType>
       <xs:restriction base='xs:NCName'>
         <xs:enumeration value='Active'/>
+        <xs:enumeration value='Archived'/>
         <xs:enumeration value='Deferred'/>
         <xs:enumeration value='Deprecated'/>
         <xs:enumeration value='Draft'/>


### PR DESCRIPTION
It was thrown out that an "Archived" status might be useful for XEPs like "SOAP over XMPP" that are still the "correct" way to implement the technology, but also they aren't likely to get implementations or ever be useful to anyone again. This PR is to start more discussion on that.