### PR TITLE
XSLT: Use lang='en' on the html root

### DIFF
--- a/xep.xsl
+++ b/xep.xsl
@@ -172,7 +172,7 @@ OR OTHER DEALINGS IN THE SOFTWARE.
   <xsl:template match='/'>
     <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;
 </xsl:text>
-    <html>
+    <html lang='en'>
       <head>
         <title>XEP-<xsl:value-of select='/xep/header/number'/>:<xsl:text> </xsl:text><xsl:value-of select='/xep/header/title' /></title>
         <style type='text/css'>


### PR DESCRIPTION
This tells the user agent that the page is in English, which it can then use for various natural language operations.

This was reported by this tool: https://wave.webaim.org/