### PR TITLE
Expire old XEPs

### DIFF
--- a/xep-0328.xml
+++ b/xep-0328.xml
@@ -10,7 +10,7 @@
   <abstract>This specification defines a way for an XMPP entity to request another entity to prepare and validate a given JID.</abstract>
   &LEGALNOTICE;
   <number>0328</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <dependencies>

--- a/xep-0333.xml
+++ b/xep-0333.xml
@@ -10,7 +10,7 @@
   <abstract>This specification describes a solution of marking the last received, displayed and acknowledged message in a chat.</abstract>
   &LEGALNOTICE;
   <number>0333</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <lastcall>2017-03-01</lastcall>
   <lastcall>2017-02-22</lastcall>
   <lastcall>2017-02-11</lastcall>

--- a/xep-0357.xml
+++ b/xep-0357.xml
@@ -10,7 +10,7 @@
         <abstract>This specification defines a way for an XMPP servers to deliver information for use in push notifications to mobile and other devices.</abstract>
         &LEGALNOTICE;
         <number>0357</number>
-        <status>Experimental</status>
+        <status>Deferred</status>
         <lastcall>2020-04-15</lastcall>
         <lastcall>2018-11-03</lastcall>
         <type>Standards Track</type>

--- a/xep-0380.xml
+++ b/xep-0380.xml
@@ -11,7 +11,7 @@
     recipient can discover how to decrypt it.</abstract>
   &LEGALNOTICE;
   <number>0380</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0392.xml
+++ b/xep-0392.xml
@@ -14,7 +14,7 @@
   <abstract>This specification provides a set of algorithms to consistently generate colors given a string. The string can be a nickname, a JID or any other piece of information. All entities adhering to this specification generate the same color for the same string, which provides a consistent user experience across platforms.</abstract>
   &LEGALNOTICE;
   <number>0392</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0398.xml
+++ b/xep-0398.xml
@@ -10,7 +10,7 @@
   <abstract>This specification describes a method for using PEP based avatars and vCard based avatars in parallel by having the user’s server do a conversion between the two.</abstract>
   &LEGALNOTICE;
   <number>0398</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <lastcall>2020-02-26</lastcall>
   <type>Standards Track</type>
   <sig>Standards</sig>

--- a/xep-0401.xml
+++ b/xep-0401.xml
@@ -10,7 +10,7 @@
   <abstract>This document defines a protocol and URI scheme for user invitation in order to allow a third party to register on a server. The goal of this is to make onboarding for XMPP IM newcomers as easy as possible.</abstract>
   &LEGALNOTICE;
   <number>0401</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0413.xml
+++ b/xep-0413.xml
@@ -10,7 +10,7 @@
   <abstract>This specification allows to change order of items retrieval in a Pubsub or MAM query</abstract>
   &LEGALNOTICE;
   <number>0413</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0414.xml
+++ b/xep-0414.xml
@@ -10,7 +10,7 @@
   <abstract>This document provides recommendations for the use of cryptographic hash functions in XMPP protocol extensions.</abstract>
   &LEGALNOTICE;
   <number>0414</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Informational</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0415.xml
+++ b/xep-0415.xml
@@ -11,7 +11,7 @@
   <abstract>This specification defines an XMPP Usage of REsource LOcation And Discovery (RELOAD). The XMPP usage provides an ability for XMPP clients to discover other peers' location through the peer-to-peer overlay. Once a peer location is determined, the RELOAD AppAttach method is used to establish a direct connection between peers through which XMPP streams are exchanged.</abstract>
   &LEGALNOTICE;
   <number>0415</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0416.xml
+++ b/xep-0416.xml
@@ -10,7 +10,7 @@
   <abstract>This specification describes how X.509 certificates can be used for end-to-end authentication in XMPP.</abstract>
   &LEGALNOTICE;
   <number>0416</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0417.xml
+++ b/xep-0417.xml
@@ -10,7 +10,7 @@
   <abstract>This specification defines a way for a certificate authority to serve certificate signing requests via XMPP in order to issue X.509 certificates for the use in end-to-end and c2s SASL EXTERNAL authentication.</abstract>
   &LEGALNOTICE;
   <number>0417</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0418.xml
+++ b/xep-0418.xml
@@ -11,7 +11,7 @@
    into an IQ exchange.</abstract>
   &LEGALNOTICE;
   <number>0418</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0421.xml
+++ b/xep-0421.xml
@@ -10,7 +10,7 @@
   <abstract>This specification defines a method that allows clients to identify a MUC participant across reconnects and renames. It thus prevents impersonification of anonymous users.</abstract>
   &LEGALNOTICE;
   <number>0421</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0422.xml
+++ b/xep-0422.xml
@@ -10,7 +10,7 @@
   <abstract>This specification defines a way for payloads on a message to be marked as being logically fastened to a previous message.</abstract>
   &LEGALNOTICE;
   <number>0422</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0424.xml
+++ b/xep-0424.xml
@@ -10,7 +10,7 @@
   <abstract>This specification defines a method for indicating that a message should be retracted.</abstract>
   &LEGALNOTICE;
   <number>0424</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0425.xml
+++ b/xep-0425.xml
@@ -10,7 +10,7 @@
   <abstract>This specification defines a method for groupchat moderators to moderate messages.</abstract>
   &LEGALNOTICE;
   <number>0425</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0426.xml
+++ b/xep-0426.xml
@@ -13,7 +13,7 @@
   </abstract>
   &LEGALNOTICE;
   <number>0426</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Informational</type>
   <sig>Standards</sig>
   <dependencies/>

--- a/xep-0427.xml
+++ b/xep-0427.xml
@@ -12,7 +12,7 @@
   <abstract>This specification proposes a mechanism by which MAM results containing fastenings can be collated effectively.</abstract>
   &LEGALNOTICE;
   <number>0427</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <dependencies>

--- a/xep-0428.xml
+++ b/xep-0428.xml
@@ -12,7 +12,7 @@
     purposes, and therefore to be ignored by intermediaries and anything that understands the remainder of the message.</abstract>
   &LEGALNOTICE;
   <number>0428</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <dependencies>

--- a/xep-0430.xml
+++ b/xep-0430.xml
@@ -12,7 +12,7 @@
   <abstract>This specification proposes a mechanism by which clients can find a list of ongoing conversations and their state.</abstract>
   &LEGALNOTICE;
   <number>0430</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <dependencies>

--- a/xep-0431.xml
+++ b/xep-0431.xml
@@ -12,7 +12,7 @@
   <abstract>This specification proposes a field in the MAM form for full text searching.</abstract>
   &LEGALNOTICE;
   <number>0431</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <dependencies>

--- a/xep-0432.xml
+++ b/xep-0432.xml
@@ -14,7 +14,7 @@
   be driven with a simple API.</abstract>
   &LEGALNOTICE;
   <number>0432</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <dependencies>

--- a/xep-0433.xml
+++ b/xep-0433.xml
@@ -27,7 +27,7 @@
   <abstract>This specification provides a standardised protocol to search for public group chats. In contrast to XEP-0030 (Service Discovery), it works across multiple domains and in contrast to XEP-0055 (Jabber Search) it more clearly handles extensibility.</abstract>
   &LEGALNOTICE;
   <number>0433</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0435.xml
+++ b/xep-0435.xml
@@ -10,7 +10,7 @@
 	<abstract>This specification provides a way to set up reminders.</abstract>
 &LEGALNOTICE;
 	<number>0435</number>
-	<status>Experimental</status>
+	<status>Deferred</status>
 	<type>Standards Track</type>
 	<sig>Standards</sig>
 	<approver>Council</approver>

--- a/xep-0436.xml
+++ b/xep-0436.xml
@@ -10,7 +10,7 @@
   <abstract>This specification defines a versioning mechanism which reduces the amount of presence traffic in a XEP-0045 MUC</abstract>
   &LEGALNOTICE;
   <number>0436</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0437.xml
+++ b/xep-0437.xml
@@ -10,7 +10,7 @@
   <abstract>This specification describes a lightweight mechanism for activity notifications in MUCs</abstract>
   &LEGALNOTICE;
   <number>0437</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>

--- a/xep-0439.xml
+++ b/xep-0439.xml
@@ -12,7 +12,7 @@
   <abstract>Quickly respond to automated messages.</abstract>
   &LEGALNOTICE;
   <number>0439</number>
-  <status>Experimental</status>
+  <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <dependencies>


### PR DESCRIPTION
It appears that XEPs aren't expiring properly. I wrote a quick script to expire all the ones that are older than 12 months in experimental.