### PR TITLE
XEP-0369 fix date format

### DIFF
--- a/xep-0369.xml
+++ b/xep-0369.xml
@@ -267,7 +267,7 @@
   </revision>
   <revision>
     <version>0.8.2</version>
-    <date>2017-03-3</date>
+    <date>2017-03-03</date>
     <initials>sek</initials>
     <remark><p>
      Make example ids pseudo-random;


### PR DESCRIPTION
Every other date (including the month in this revision) uses a two digit day. Fix this so that parsers can be more strict.