### PR TITLE
Revert `pubsub#metadata` to `pubsub#meta-data`.

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -385,7 +385,7 @@
     <version>1.6</version>
     <date>2004-07-13</date>
     <initials>pgm/psa</initials>
-    <remark><p>Added service discovery features for pubsub#metadata, and pubsub#retrieve-items. Added pubsub#subscription_depth configuration option. Specified pubsub-specific error condition elements qualified by pubsub#errors namespace.</p></remark>
+    <remark><p>Added service discovery features for pubsub#meta-data, and pubsub#retrieve-items. Added pubsub#subscription_depth configuration option. Specified pubsub-specific error condition elements qualified by pubsub#errors namespace.</p></remark>
   </revision>
   <revision>
     <version>1.5</version>
@@ -1065,7 +1065,7 @@ And by opposing end them?
 ]]></example>
   </section2>
   <section2 topic='Discover Node Metadata' anchor='entity-metadata'>
-    <p>The "disco#info" result MAY include detailed metadata about the node, encapsulated in the &xep0004; format as described in &xep0128;, where the data form context is specified by including a FORM_TYPE of "http://jabber.org/protocol/pubsub#metadata" in accordance with &xep0068;. If metadata is provided, it SHOULD include values for all configured options as well as "automatic" information such as the node creation date, a list of publishers, and the like.</p>
+    <p>The "disco#info" result MAY include detailed metadata about the node, encapsulated in the &xep0004; format as described in &xep0128;, where the data form context is specified by including a FORM_TYPE of "http://jabber.org/protocol/pubsub#meta-data" in accordance with &xep0068;. If metadata is provided, it SHOULD include values for all configured options as well as "automatic" information such as the node creation date, a list of publishers, and the like.</p>
     <example caption='Entity queries a node for information'><![CDATA[
 <iq type='get'
     from='francisco@denmark.lit/barracks'
@@ -1086,7 +1086,7 @@ And by opposing end them?
     <feature var='http://jabber.org/protocol/pubsub'/>
     <x xmlns='jabber:x:data' type='result'>
       <field var='FORM_TYPE' type='hidden'>
-        <value>http://jabber.org/protocol/pubsub#metadata</value>
+        <value>http://jabber.org/protocol/pubsub#meta-data</value>
       </field>
       <field var='pubsub#type' label='Payload type' type='text-single'>
         <value>http://www.w3.org/2005/Atom</value>
@@ -5220,7 +5220,7 @@ And by opposing end them?
       <td><link url='#affiliations'>Affiliations</link></td>
     </tr>
     <tr>
-      <td>metadata</td>
+      <td>meta-data</td>
       <td>Node metadata is supported.</td>
       <td>RECOMMENDED</td>
       <td>&#160;</td>
@@ -6143,7 +6143,7 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
   <doc>XEP-0060</doc>
 </var>
 <var>
-  <name>http://jabber.org/protocol/pubsub#metadata</name>
+  <name>http://jabber.org/protocol/pubsub#meta-data</name>
   <desc>Node metadata is supported.</desc>
   <doc>XEP-0060</doc>
 </var>
@@ -6266,7 +6266,7 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
       <li>Authorization of subscriptions using the 'http://jabber.org/protocol/pubsub#subscribe_authorization' namespace.</li>
       <li>Configuration of subscription options using the 'http://jabber.org/protocol/pubsub#subscribe_options' namespace.</li>
       <li>Configuration of a node using the 'http://jabber.org/protocol/pubsub#node_config' namespace.</li>
-      <li>Setting of metadata information using the 'http://jabber.org/protocol/pubsub#metadata' namespace.</li>
+      <li>Setting of metadata information using the 'http://jabber.org/protocol/pubsub#meta-data' namespace.</li>
     </ol>
     <p>The registry submissions associated with these namespaces are defined below.</p>
     <p>Note: There is no requirement that configuration fields need to be registered with the XMPP Registrar. However, as specified in Section 3.4 of <cite>XEP-0068</cite>, names of custom (unregistered) fields MUST begin with the characters "x-" if the form itself is scoped by a registered FORM_TYPE.</p>
@@ -6370,10 +6370,10 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
 </form_type>
 ]]></code>
     </section3>
-    <section3 topic='pubsub#metadata FORM_TYPE' anchor='registrar-formtypes-metadata'>
+    <section3 topic='pubsub#meta-data FORM_TYPE' anchor='registrar-formtypes-metadata'>
       <code><![CDATA[
 <form_type>
-  <name>http://jabber.org/protocol/pubsub#metadata</name>
+  <name>http://jabber.org/protocol/pubsub#meta-data</name>
   <doc>XEP-0060</doc>
   <desc>Forms enabling setting of metadata information about pubsub nodes</desc>
   <field var='pubsub#contact'
@@ -7022,7 +7022,7 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings
                 <xs:enumeration value='leased-subscription'/>
                 <xs:enumeration value='manage-subscriptions'/>
                 <xs:enumeration value='member-affiliation'/>
-                <xs:enumeration value='metadata'/>
+                <xs:enumeration value='meta-data'/>
                 <xs:enumeration value='modify-affiliations'/>
                 <xs:enumeration value='multi-collection'/>
                 <xs:enumeration value='multi-items'/>

--- a/xep-0214.xml
+++ b/xep-0214.xml
@@ -133,7 +133,7 @@
     <configure node='juliets_sonnets'/>
       <x xmlns='jabber:x:data' type='submit'>
         <field var='FORM_TYPE' type='hidden'>
-          <value>http://jabber.org/protocol/pubsub#metadata</value>
+          <value>http://jabber.org/protocol/pubsub#meta-data</value>
         </field>
         <field var='pubsub#title'><value>Juliet's Sonnets</value></field>
         <field var='pubsub#description'><value>Optional Description</value></field>
@@ -169,7 +169,7 @@
     <configure node='35227eec194a4f3971a5f3771e9c2271'/>
       <x xmlns='jabber:x:data' type='submit'>
         <field var='FORM_TYPE' type='hidden'>
-          <value>http://jabber.org/protocol/pubsub#metadata</value>
+          <value>http://jabber.org/protocol/pubsub#meta-data</value>
         </field>
         <field var='pubsub#title'><value>Sonnets About Romeo</value></field>
         <field var='pubsub#description'><value>Optional Description</value></field>
@@ -224,7 +224,7 @@
     <configure node='a6190c5d38e22452041d1c5798eff3f5'>
       <x xmlns='jabber:x:data' type='submit'>
         <field var='FORM_TYPE' type='hidden'>
-          <value>http://jabber.org/protocol/pubsub#metadata</value>
+          <value>http://jabber.org/protocol/pubsub#meta-data</value>
         </field>
         <field var='pubsub#title'><value>sonnet.txt</value></field>
         <field var='pubsub#description'><value>Sonnet 42</value></field>
@@ -338,7 +338,7 @@
     <configuration node='a6190c5d38e22452041d1c5798eff3f5'>
       <x xmlns='jabber:x:data' type='result'>
         <field var='FORM_TYPE' type='hidden'>
-          <value>http://jabber.org/protocol/pubsub#metadata</value>
+          <value>http://jabber.org/protocol/pubsub#meta-data</value>
         </field>
         <field var='pubsub#description'><var>Sonnet 42</var></field>
         <field var='pubsub#title'><var>sonnet.txt</var></field>

--- a/xep-0248.xml
+++ b/xep-0248.xml
@@ -265,7 +265,7 @@
       <associate node='new-node-id'>
         <x xmlns='jabber:x:data' type='result'>
           <field var='FORM_TYPE' type='hidden'>
-            <value>http://jabber.org/protocol/pubsub#metadata</value>
+            <value>http://jabber.org/protocol/pubsub#meta-data</value>
           </field>
           <field var='pubsub#creation_date'>
             <value>2003-07-29T22:56Z</value>


### PR DESCRIPTION
This partially reverts mass replacements of `meta-data` with `metadata`,
as per #710, to ensure that protocol literals don't change.