### PR TITLE
XEP-0313: add implementation considerations

### DIFF
--- a/xep-0313.xml
+++ b/xep-0313.xml
@@ -30,6 +30,14 @@
   &mwild;
   &ksmith;
   <revision>
+    <version>0.7.4</version>
+    <date>2021-08-23</date>
+    <initials>ssw</initials>
+    <remark>
+      <p>Add implementation note about before/after and before-id/after-id</p>
+    </remark>
+  </revision>
+  <revision>
     <version>0.7.3</version>
     <date>2021-03-02</date>
     <initials>ssw</initials>
@@ -403,7 +411,11 @@
     <section3 topic='Limiting results by id' anchor='query-limit-id'>
       <p>If the client has already seen some messages, it may choose to restrict its query to
       before and/or after messages it already knows about. This may be done through the 'before-id'
-      and 'after-id' fields.</p>
+      and 'after-id' fields.
+        In some cases 'before-id' and 'after-id' are the same as using RSM's
+        'before' and 'after' parameters. For more information, see the
+        <link url='#impl'>Implementation Considerations</link> section.
+      </p>
       <example caption='Querying the archive for all messages after a certain message'><![CDATA[
 <iq type='set' id='juliet1'>
   <query xmlns='urn:xmpp:mam:2'>
@@ -884,6 +896,29 @@
   <section2 topic='MUC message spoofing' anchor='security-muc-spoofing'>
     <p>This specification re-uses the &lt;x&gt; element from the 'http://jabber.org/protocol/muc#user' namespace to convey information about the sender of a message in a MUC room. However this element is not sanitized by MUC services, so the archiving entity MUST strip any existing &lt;x&gt; element in the 'http://jabber.org/protocol/muc#user' namespace from messages before archiving them (regardless of whether it adds in its own &lt;x&gt; element).</p>
   </section2>
+</section1>
+
+<section1 topic='Implementation Considerations' anchor='impl'>
+  <p>
+    Queries in the 'urn:xmpp:mam:2' namespace can be limited using the RSM
+    'before' and 'after' parameters.
+    Normally these are opaque identifiers that are not known until the results
+    of the first query are returned at which point they can be used to fetch
+    subsequent pages.
+    However, MAM specifically defines them as being equal to the archive ID,
+    meaning that an acceptable value can be known and used in the initial query.
+    This makes them equivalent to 'before-id' and 'after-id' defined in the
+    'urn:xmpp:mam:2#extended' namespace except for the following differences:
+  </p>
+  <ol>
+    <li>
+      The behavior of using RSM's 'before' and 'after' together is undefined,
+    </li>
+    <li>
+      And using 'before' implies paging backwards through the result set while
+      using 'before-id' does not.
+    </li>
+  </ol>
 </section1>
 
 <section1 topic='XMPP Registrar Considerations' anchor='registrar'>


### PR DESCRIPTION
Currently this only explains the difference between the before/after
parameters of RSM and the before-id/after-id parameters of mam#extended.