### PR TITLE
Update path for xmpp-logo.svg

### DIFF
--- a/xmpp.css
+++ b/xmpp.css
@@ -1529,7 +1529,7 @@
         margin-bottom: 1em;
         padding: 0.3333333em;
         padding-left: 2.1666667em;
-        background-image: url('https://xmpp.org/theme/images/xmpp-logo.svg');
+        background-image: url('https://xmpp.org/images/logos/xmpp-logo.svg');
         background-repeat: no-repeat;
         background-size: 1.5em;
         background-position: 0.33333333em 0.33333333em;


### PR DESCRIPTION
Due to the change of site generators for xmpp.org, the logo path changed.