### PR TITLE
XEP-0270, XEP-0302, XEP-0375: Fix the superseded chain

### DIFF
--- a/xep-0270.xml
+++ b/xep-0270.xml
@@ -35,7 +35,7 @@
     <spec>XEP-0243</spec>
   </supersedes>
   <supersededby>
-    <spec>XEP-0375</spec>
+    <spec>XEP-0302</spec>
   </supersededby>
   <shortname>N/A</shortname>
   &stpeter;

--- a/xep-0302.xml
+++ b/xep-0302.xml
@@ -34,7 +34,7 @@
     <spec>XEP-0270</spec>
   </supersedes>
   <supersededby>
-    <spec>XEP-0387</spec>
+    <spec>XEP-0375</spec>
   </supersededby>
   <shortname>N/A</shortname>
   &stpeter;

--- a/xep-0375.xml
+++ b/xep-0375.xml
@@ -36,7 +36,7 @@
       <spec>XEP-0369</spec>
     </dependencies>
     <supersedes>
-      <spec>XEP-0270</spec>
+      <spec>XEP-0302</spec>
     </supersedes>
     <supersededby>
       <spec>XEP-0387</spec>


### PR DESCRIPTION
Each CS supersedes its predecessor, and is supersededby its successor, thanks Ge0rG for finding this issue.