### PR TITLE
XEP-0411: Move to status deprecated

### DIFF
--- a/xep-0411.xml
+++ b/xep-0411.xml
@@ -10,7 +10,7 @@
   <abstract>This specification describes a method to migrate to PEP based bookmarks without loosing compatibility with client that still use Private XML.</abstract>
   &LEGALNOTICE;
   <number>0411</number>
-  <status>Draft</status>
+  <status>Deprecated</status>
   <lastcall>2020-10-14</lastcall>
   <type>Standards Track</type>
   <sig>Standards</sig>
@@ -21,7 +21,9 @@
     <spec>XEP-0153</spec>
   </dependencies>
   <supersedes/>
-  <supersededby/>
+  <supersededby>
+    <spec>XEP-0402</spec>
+  </supersededby>
   <shortname>bookmarks-conversion</shortname>
   <author>
     <firstname>Daniel</firstname>


### PR DESCRIPTION
With XEP-0048 being deprecated, this specification should follow, with XEP-0402 as the obvious path forward.