### PR TITLE
XEP-0434: Release version 0.6.0

### DIFF
--- a/xep-0434.xml
+++ b/xep-0434.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE xep SYSTEM 'xep.dtd' [
 	<!ENTITY % ents SYSTEM 'xep.ent'>
-	<!ENTITY ns "urn:xmpp:tm:0">
+	<!ENTITY ns "urn:xmpp:tm:1">
 	<!ENTITY ns-atm "urn:xmpp:atm:1">
-	<!ENTITY ns-omemo "urn:xmpp:omemo:1">
+	<!ENTITY ns-omemo "urn:xmpp:omemo:2">
 	<!ENTITY ns-sce "urn:xmpp:sce:1">
 %ents;
 ]>
@@ -36,6 +36,22 @@
 		<email>melvo@olomono.de</email>
 		<jid>melvo@olomono.de</jid>
 	</author>
+	<revision>
+		<version>0.6.0</version>
+		<date>2021-10-04</date>
+		<initials>melvo</initials>
+		<remark>
+			<p>Specify key identifier encoding, improve glossary and update to XEP-0384 version 0.8.0:</p>
+			<ul>
+				<li>Specify usage of Base64 encoding for key identifiers within trust messages</li>
+				<li>Specify usage of Base16 encoding for key identifiers within Trust Message URIs</li>
+				<li>Use Base64-encoded key identifiers in examples</li>
+				<li>Add 'hash value' as example of key identifier</li>
+				<li>Update OMEMO's namespace to 'urn:xmpp:omemo:2'</li>
+				<li>Update namespace to 'urn:xmpp:tm:1'</li>
+			</ul>
+		</remark>
+	</revision>
 	<revision>
 		<version>0.5.1</version>
 		<date>2021-05-14</date>
@@ -155,7 +171,7 @@
 		<di>
 			<dt>Key identifier</dt>
 			<dd>
-				Identifier of a key (e.g., a fingerprint or the key itself)
+				Identifier of a key (e.g., a hash value / fingerprint or the key itself)
 			</dd>
 		</di>
 		<di>
@@ -268,7 +284,7 @@
 					MUST have a <em>usage</em> attribute specifying the namespace of the protocol that uses the trust message for a specific purpose.
 				</li>
 				<li>
-					MUST have an <em>encryption</em> attribute specifying the namespace of the encryption protocol for which the keys are used.
+					MUST have an <em>encryption</em> attribute specifying the namespace of the encryption protocol that uses the keys.
 				</li>
 				<li>
 					MUST contain at least one <![CDATA[<key-owner/>]]> direct child element that
@@ -278,7 +294,8 @@
 						</li>
 						<li>
 							MUST contain at least one <![CDATA[<trust/>]]> or <![CDATA[<distrust/>]]> direct child element indicating the trust respectively distrust in a key.
-							Each <![CDATA[<trust/>]]> and <![CDATA[<distrust/>]]> element MUST contain exactly one key identifier.
+							Each <![CDATA[<trust/>]]> and <![CDATA[<distrust/>]]> element MUST contain exactly one Base64-encoded (see &rfc4648;) key identifier.
+							The kind of identifier that the key's encryption protocol specifies MUST be used.
 						</li>
 					</ul>
 				</li>
@@ -300,13 +317,13 @@
 	<example caption='Trust Message Element for Alice&apos;s and Bob&apos;s OMEMO Keys used by ATM'><![CDATA[
 <trust-message xmlns=']]>&ns;<![CDATA[' usage=']]>&ns-atm;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
   <key-owner jid='alice@example.org'>
-    <trust>6850019d7ed0feb6d3823072498ceb4f616c6025586f8f666dc6b9c81ef7e0a4</trust>
-    <trust>221a4f8e228b72182b006e5ca527d3bddccf8d9e6feaf4ce96e1c451e8648020</trust>
+    <trust>aFABnX7Q/rbTgjBySYzrT2FsYCVYb49mbca5yB734KQ=</trust>
+    <trust>IhpPjiKLchgrAG5cpSfTvdzPjZ5v6vTOluHEUehkgCA=</trust>
   </key-owner>
   <key-owner jid='bob@example.com'>
-    <trust>623548d3835c6d33ef5cb680f7944ef381cf712bf23a0119dabe5c4f252cd02f</trust>
-    <distrust>b423f5088de9a924d51b31581723d850c7cc67d0a4fe6b267c3d301ff56d2413</distrust>
-    <distrust>d9f849b6b828309c5f2c8df4f38fd891887da5aaa24a22c50d52f69b4a80817e</distrust>
+    <trust>YjVI04NcbTPvXLaA95RO84HPcSvyOgEZ2r5cTyUs0C8=</trust>
+    <distrust>tCP1CI3pqSTVGzFYFyPYUMfMZ9Ck/msmfD0wH/VtJBM=</distrust>
+    <distrust>2fhJtrgoMJxfLI3084/YkYh9paqiSiLFDVL2m0qAgX4=</distrust>
   </key-owner>
 </trust-message>
 ]]></example>
@@ -365,13 +382,13 @@
   <content>
     <trust-message xmlns=']]>&ns;<![CDATA[' usage=']]>&ns-atm;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
-        <trust>6850019d7ed0feb6d3823072498ceb4f616c6025586f8f666dc6b9c81ef7e0a4</trust>
-        <trust>221a4f8e228b72182b006e5ca527d3bddccf8d9e6feaf4ce96e1c451e8648020</trust>
+        <trust>aFABnX7Q/rbTgjBySYzrT2FsYCVYb49mbca5yB734KQ=</trust>
+        <trust>IhpPjiKLchgrAG5cpSfTvdzPjZ5v6vTOluHEUehkgCA=</trust>
       </key-owner>
       <key-owner jid='bob@example.com'>
-        <trust>623548d3835c6d33ef5cb680f7944ef381cf712bf23a0119dabe5c4f252cd02f</trust>
-        <distrust>b423f5088de9a924d51b31581723d850c7cc67d0a4fe6b267c3d301ff56d2413</distrust>
-        <distrust>d9f849b6b828309c5f2c8df4f38fd891887da5aaa24a22c50d52f69b4a80817e</distrust>
+        <trust>YjVI04NcbTPvXLaA95RO84HPcSvyOgEZ2r5cTyUs0C8=</trust>
+        <distrust>tCP1CI3pqSTVGzFYFyPYUMfMZ9Ck/msmfD0wH/VtJBM=</distrust>
+        <distrust>2fhJtrgoMJxfLI3084/YkYh9paqiSiLFDVL2m0qAgX4=</distrust>
       </key-owner>
     </trust-message>
   </content>
@@ -436,6 +453,7 @@
 				The <em>JID</em> attribute of the <![CDATA[<key-owner/>]]> element MUST be used as the Trust Message URI's path.
 				The first key-value pair of the URI's query MUST represent the <em>encryption</em> attribute of the <![CDATA[<trust-message/>]]> element.
 				All remaining key-value pairs of the URI's query MUST represent the <![CDATA[<trust/>]]> respectively <![CDATA[<distrust/>]]> elements of the <![CDATA[<key-owner/>]]> element.
+				Each key identifier MUST be Base16-encoded (see &rfc4648;).
 				The key of a key-value pair MUST be the element's respectively attribute's name and the value their content.
 			</p>
       <example caption='Trust Message URI for Bob&apos;s OMEMO keys'><![CDATA[
@@ -477,8 +495,8 @@ xmpp:bob@example.com?trust-message;encryption=]]>&ns-omemo;<![CDATA[;trust=62354
     <xs:complexType>
       <xs:attribute name='jid' type='xs:string' use='required'/>
       <xs:sequence>
-        <xs:element name='trust' type='xs:string' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element name='distrust' type='xs:string' minOccurs='0' maxOccurs='unbounded'/>
+        <xs:element name='trust' type='xs:base64Binary' minOccurs='0' maxOccurs='unbounded'/>
+        <xs:element name='distrust' type='xs:base64Binary' minOccurs='0' maxOccurs='unbounded'/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
Specify key identifier encoding, improve glossary and update to XEP-0384 version 0.8.0:

* Specify usage of Base64 encoding for key identifiers within trust messages
* Specify usage of Base16 encoding for key identifiers within Trust Message URIs
* Use Base64-encoded key identifiers in examples
* Add 'hash value' as example of key identifier
* Update OMEMO's namespace to `urn:xmpp:omemo:2`
* Update namespace to `urn:xmpp:tm:1`