### PR TITLE
XEP-0450: Release version 0.4.0

### DIFF
--- a/xep-0450.xml
+++ b/xep-0450.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE xep SYSTEM 'xep.dtd' [
 	<!ENTITY % ents SYSTEM 'xep.ent'>
 	<!ENTITY ns "urn:xmpp:atm:1">
-	<!ENTITY ns-trust-messages "urn:xmpp:tm:0">
-	<!ENTITY ns-omemo "urn:xmpp:omemo:1">
+	<!ENTITY ns-trust-messages "urn:xmpp:tm:1">
+	<!ENTITY ns-omemo "urn:xmpp:omemo:2">
 	<!ENTITY ns-sce "urn:xmpp:sce:1">
 %ents;
 ]>
@@ -37,6 +37,19 @@
 		<email>melvo@olomono.de</email>
 		<jid>melvo@olomono.de</jid>
 	</author>
+	<revision>
+		<version>0.4.0</version>
+		<date>2021-10-04</date>
+		<initials>melvo</initials>
+		<remark>
+			<p>Update to XEP-0434 version 0.6.0 and XEP-0384 version 0.8.0:</p>
+			<ul>
+				<li>Use Base64-encoded key identifiers in examples</li>
+				<li>Update TM's namespace to 'urn:xmpp:tm:1'</li>
+				<li>Update OMEMO's namespace to 'urn:xmpp:omemo:2'</li>
+			</ul>
+		</remark>
+	</revision>
 	<revision>
 		<version>0.3.2</version>
 		<date>2021-06-27</date>
@@ -237,7 +250,7 @@
   <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='bob@example.com'>
-        <trust>623548d3835c6d33ef5cb680f7944ef381cf712bf23a0119dabe5c4f252cd02f</trust>
+        <trust>YjVI04NcbTPvXLaA95RO84HPcSvyOgEZ2r5cTyUs0C8=</trust>
       </key-owner>
     </trust-message>
   </content>
@@ -257,7 +270,7 @@
   <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
-        <trust>6850019d7ed0feb6d3823072498ceb4f616c6025586f8f666dc6b9c81ef7e0a4</trust>
+        <trust>aFABnX7Q/rbTgjBySYzrT2FsYCVYb49mbca5yB734KQ=</trust>
       </key-owner>
     </trust-message>
   </content>
@@ -315,7 +328,7 @@
   <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
-        <trust>221a4f8e228b72182b006e5ca527d3bddccf8d9e6feaf4ce96e1c451e8648020</trust>
+        <trust>IhpPjiKLchgrAG5cpSfTvdzPjZ5v6vTOluHEUehkgCA=</trust>
       </key-owner>
     </trust-message>
   </content>
@@ -330,7 +343,7 @@
   <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
-        <trust>221a4f8e228b72182b006e5ca527d3bddccf8d9e6feaf4ce96e1c451e8648020</trust>
+        <trust>IhpPjiKLchgrAG5cpSfTvdzPjZ5v6vTOluHEUehkgCA=</trust>
       </key-owner>
     </trust-message>
   </content>
@@ -350,10 +363,10 @@
   <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
-        <trust>f3cddd91f25502652483be2fd5faaaa00f80868ac0d51d7eebb1b08a3892e33d</trust>
+        <trust>883dkfJVAmUkg74v1fqqoA+AhorA1R1+67GwijiS4z0=</trust>
       </key-owner>
       <key-owner jid='bob@example.com'>
-        <trust>623548d3835c6d33ef5cb680f7944ef381cf712bf23a0119dabe5c4f252cd02f</trust>
+        <trust>YjVI04NcbTPvXLaA95RO84HPcSvyOgEZ2r5cTyUs0C8=</trust>
       </key-owner>
     </trust-message>
   </content>
@@ -390,7 +403,7 @@
   <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
-        <distrust>221a4f8e228b72182b006e5ca527d3bddccf8d9e6feaf4ce96e1c451e8648020</distrust>
+        <distrust>IhpPjiKLchgrAG5cpSfTvdzPjZ5v6vTOluHEUehkgCA=</distrust>
       </key-owner>
     </trust-message>
   </content>
@@ -405,7 +418,7 @@
   <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='alice@example.org'>
-        <distrust>221a4f8e228b72182b006e5ca527d3bddccf8d9e6feaf4ce96e1c451e8648020</distrust>
+        <distrust>IhpPjiKLchgrAG5cpSfTvdzPjZ5v6vTOluHEUehkgCA=</distrust>
       </key-owner>
     </trust-message>
   </content>
@@ -441,7 +454,7 @@
   <content>
     <trust-message xmlns=']]>&ns-trust-messages;<![CDATA[' usage=']]>&ns;<![CDATA[' encryption=']]>&ns-omemo;<![CDATA['>
       <key-owner jid='bob@example.com'>
-        <distrust>623548d3835c6d33ef5cb680f7944ef381cf712bf23a0119dabe5c4f252cd02f</distrust>
+        <distrust>YjVI04NcbTPvXLaA95RO84HPcSvyOgEZ2r5cTyUs0C8=</distrust>
       </key-owner>
     </trust-message>
   </content>


### PR DESCRIPTION
Update to XEP-0434 version 0.6.0 and XEP-0384 version 0.8.0:

* Use Base64-encoded key identifiers in examples
* Update TM's namespace to `urn:xmpp:tm:1`
* Update OMEMO's namespace to `urn:xmpp:omemo:2`