### PR TITLE
Fix XMPP logo position

### DIFF
--- a/xmpp.css
+++ b/xmpp.css
@@ -1532,7 +1532,7 @@
         background-image: url('https://xmpp.org/images/logos/xmpp-logo.svg');
         background-repeat: no-repeat;
         background-size: 1.5em;
-        background-position: 0.33333333em 0.33333333em;
+        background-position: 0.3em 0.1em;
     }
 
     nav#toc ol,


### PR DESCRIPTION
The XMPP logo hosted on xmpp.org has been changed in xsf/xmpp.org@a84359cc9f40752485cbc2a4d8a97e7b9da0a3d8

The logo position inside the SVG changed a bit, hence this fix.