### PR TITLE
XEP-0215: Fix the schema

### DIFF
--- a/xep-0215.xml
+++ b/xep-0215.xml
@@ -25,6 +25,18 @@
   &mlundblad;
   &lance;
   <revision>
+    <version>0.7.2</version>
+    <date>2021-10-23</date>
+    <initials>egp</initials>
+    <remark>
+      <p>Fix the schema to:</p>
+      <ul>
+        <li>Allow more than a single &lt;service/&gt; in &lt;services/&gt;.</li>
+        <li>Restrict the 'port' attribute to xs:unsignedShort, but make it optional as per section 3.3.</li>
+      </ul>
+    </remark>
+  </revision>
+  <revision>
     <version>0.7.1</version>
     <date>2021-08-31</date>
     <initials>ka</initials>
@@ -448,7 +460,7 @@
 
   <xs:element name='services'>
     <xs:complexType>
-      <xs:sequence minOccurs='0'>
+      <xs:sequence minOccurs='0' maxOccurs='unbounded'>
         <xs:element ref='service'/>
       </xs:sequence>
       <xs:attribute name='type' type='xs:NCName' use='optional'/>
@@ -481,7 +493,7 @@
       <xs:attribute name='host' type='xs:string' use='required'/>
       <xs:attribute name='name' type='xs:string' use='optional'/>
       <xs:attribute name='password' type='xs:string' use='optional'/>
-      <xs:attribute name='port' type='xs:string' use='required'/>
+      <xs:attribute name='port' type='xs:unsignedShort' use='optional'/>
       <xs:attribute name='restricted' type='xs:boolean' use='optional'/>
       <xs:attribute name='transport' type='xs:NCName' use='optional'/>
       <xs:attribute name='type' type='xs:NCName' use='required'/>


### PR DESCRIPTION
- Allow more than a single <service/> in <services/>.
- Restrict the 'port' attribute to xs:unsignedShort, and make it optional as per section 3.3.