### PR TITLE
XEP-0339: Add a XML schema

### DIFF
--- a/xep-0339.xml
+++ b/xep-0339.xml
@@ -23,6 +23,12 @@
   <shortname>NOT_YET_ASSIGNED</shortname>
   &fippo;
   <revision>
+    <version>1.0.1</version>
+    <date>2021-10-23</date>
+    <initials>egp</initials>
+    <remark><p>Add a XML Schema, and fix an example lacking a namespace.</p></remark>
+  </revision>
+  <revision>
     <version>1.0.0</version>
     <date>2020-05-26</date>
     <initials>XEP Editor (jsc)</initials>
@@ -107,7 +113,7 @@ a=ssrc:2613715171 cname:f83avsiw6n1m7vi
     </code>
     <p>This is mapped to Jingle as follows:</p>
     <code><![CDATA[
-<content creator='initiator' name='webcam'>
+<content xmlns='http://jabber.org/protocols/jingle' creator='initiator' name='webcam'>
   <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='video'>
     <payload-type id='100' name='VP8' clockrate='90000'/>
     <ssrc-group xmlns='urn:xmpp:jingle:apps:rtp:ssma:0' semantics='FID'>
@@ -182,6 +188,63 @@ a=ssrc:2613715171 cname:f83avsiw6n1m7vi
   </section2>
 </section1>
 <section1 topic='XML Schema' anchor='schema'>
-  <p>TODO</p>
+  <code><![CDATA[
+<?xml version='1.0' encoding='UTF-8'?>
+
+<xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='urn:xmpp:jingle:apps:rtp:ssma:0'
+    xmlns='urn:xmpp:jingle:apps:rtp:ssma:0'
+    elementFormDefault='qualified'>
+
+  <xs:annotation>
+    <xs:documentation>
+      The protocol documented by this schema is defined in
+      XEP-0339: http://www.xmpp.org/extensions/xep-0339.html
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name='ssrc-group'>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref='source'
+                    minOccurs='0'
+                    maxOccurs='unbounded'/>
+      </xs:sequence>
+      <xs:attribute name='semantics' use='required'>
+        <xs:simpleType>
+          <xs:restriction base='xs:NCName'>
+            <xs:enumeration value='LS'/>
+            <xs:enumeration value='FID'/>
+            <xs:enumeration value='SRF'/>
+            <xs:enumeration value='ANAT'/>
+            <xs:enumeration value='FEC'/>
+            <xs:enumeration value='DDP'/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='source'>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref='parameter'
+                    minOccurs='0'
+                    maxOccurs='unbounded'/>
+      </xs:sequence>
+      <xs:attribute name='ssrc' type='xs:unsignedInt' use='required'/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='parameter'>
+    <xs:complexType>
+      <xs:attribute name='name' type='xs:string' use='required'/>
+      <xs:attribute name='value' type='xs:string' use='optional'/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>
+]]></code>
 </section1>
 </xep>


### PR DESCRIPTION
Also fix an example missing a Jingle namespace.

Of note: many examples are invalid yet not clearly marked so, they contain the string `"ssrc-id"` instead of an actual ssrc-id.