### PR TITLE
XEP-0060: Release version 1.23.0

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -50,6 +50,19 @@
   &stpeter;
   &ralphm;
   <revision>
+    <version>1.23.0</version>
+    <date>2021-11-18</date>
+    <initials>melvo</initials>
+    <remark>
+      <p>Advertise support, specify handling of partial configuration forms and fix typo:</p>
+      <ul>
+        <li>Advertise support for publishing items</li>
+        <li>Specify how submitted partial configuration forms must be processed</li>
+        <li>Replace 'allow' with 'allows'</li>
+      </ul>
+    </remark>
+  </revision>
+  <revision>
     <version>1.22.0</version>
     <date>2021-09-07</date>
     <initials>jp</initials>
@@ -2708,7 +2721,7 @@ And by opposing end them?
 <section1 topic='Publisher Use Cases' anchor='publisher'>
   <section2 topic='Publish an Item to a Node' anchor='publisher-publish'>
     <section3 topic='Request' anchor='publisher-publish-request'>
-      <p>Any entity that is allowed to publish items to a node (i.e., a publisher or an owner) may do so at any time by sending an IQ-set to the service containing a pubsub element with a &lt;publish/&gt; child.</p>
+      <p>A pubsub service MAY support the ability to publish items (if so, it MUST advertise support for the "http://jabber.org/protocol/pubsub#publish" feature). Any entity that is allowed to publish items to a node (i.e., a publisher or an owner) may do so at any time by sending an IQ-set to the service containing a pubsub element with a &lt;publish/&gt; child.</p>
       <p>The syntax is as follows:</p>
       <ul>
         <li>The &lt;publish/&gt; element MUST possess a 'node' attribute, specifying the NodeID of the node.</li>
@@ -3718,7 +3731,7 @@ And by opposing end them?
       </section4>
     </section3>
     <section3 topic='Form Submission' anchor='owner-configure-submit'>
-      <p>After receiving the configuration form, the owner SHOULD submit a completed configuration form.</p>
+      <p>After receiving the configuration form, the owner SHOULD submit a completed configuration form. The submitted configuration form MAY contain a subset of possible configuration options. In that case, the service MUST only change the submitted configuration options.</p>
       <example caption='Owner submits node configuration form'><![CDATA[
 <iq type='set'
     from='hamlet@denmark.lit/elsinore'
@@ -5251,7 +5264,7 @@ And by opposing end them?
     </tr>
     <tr>
       <td>multi-items</td>
-      <td>The service supports the storage of multiple items per node. It requires the pubsub#max_items configuration item to be exposed to the user and allow sensible values (higher than one) to be set in <link url='#owner-configure'>Configure a Node</link>.</td>
+      <td>The service supports the storage of multiple items per node. It requires the pubsub#max_items configuration item to be exposed to the user and allows sensible values (higher than one) to be set in <link url='#owner-configure'>Configure a Node</link>.</td>
       <td>OPTIONAL</td>
       <td>&#160;</td>
     </tr>


### PR DESCRIPTION
Advertise support, specify handling of partial configuration forms and fix typo:

* Advertise support for publishing items
* Specify how submitted partial configuration forms must be processed
* Replace 'allow' with 'allows'