### PR TITLE
XEP-0459: Replace deprecated XEP-0411 with XEP-0402

### DIFF
--- a/xep-0459.xml
+++ b/xep-0459.xml
@@ -51,6 +51,7 @@
       <spec>XEP-0313</spec>
       <spec>XEP-0352</spec>
       <spec>XEP-0368</spec>
+      <spec>XEP-0402</spec>
     </dependencies>
     <supersedes>
       <spec>XEP-0443</spec>
@@ -63,6 +64,14 @@
       <email>sonny@fastmail.net</email>
       <jid>sonny@jabberfr.org</jid>
     </author>
+  <revision>
+    <version>1.1.0</version>
+    <date>2021-12-01</date>
+    <initials>egp</initials>
+    <remark>
+      <p>Replace deprecated XEP-0411 with XEP-0402 in Advanced Group Chat.</p>
+    </remark>
+  </revision>
   <revision>
     <version>1.0.0</version>
     <date>2021-11-09</date>
@@ -144,6 +153,11 @@
         <li>Web category:
           <ul>
             <li>Client: required Connection Mechanism Discovery.</li>
+          </ul>
+        </li>
+        <li>IM category:
+          <ul>
+	    <li>Advanced Group Chat: replaced &xep0411; with &xep0402; conversion</li>
           </ul>
         </li>
       </ul>
@@ -369,7 +383,7 @@
           <td align='center'>&no;</td>
           <td align='center'>&yes;&component;</td>
           <td align='center'>&yes;</td>
-	  <td>&xep0048;, &xep0313;<note>Support for requesting history from a MUC archive as opposed to from the user's account.</note>, &xep0410;, &xep0411;</td>
+	  <td>&xep0048;, &xep0313;<note>Support for requesting history from a MUC archive as opposed to from the user's account.</note>, &xep0402;<note>Usage of which should only happen when the 'urn:xmpp:bookmarks:1#compat' is exposed by the server, otherwise &xep0049; should be used instead.</note>, &xep0410;</td>
         </tr>
         <tr>
           <td><strong>Persistent Storage of Private Data via PubSub</strong></td>
@@ -581,7 +595,7 @@
           <li>&xep0374;</li>
         </ul>
       </li>
-      <li>&xep0402; to phase out &xep0048;, &xep0049;, and &xep0411;</li>
+      <li>&xep0402; to phase out &xep0048; and &xep0049;</li>
       <li>&xep0225; to phase out &xep0114;</li>
       <li>&xep0390; to phase out &xep0115;</li>
       <li>&xep0455;</li>


### PR DESCRIPTION
This is the way forward, as we deprecated the previous conversion method.

This keeps XEP-0048 stored in XEP-0049 as the preferred bookmarks storage in the absence of the `bookmarks2#compat` feature.