### PR TITLE
XEP-0384: Fixed HMAC size for encryption

### DIFF
--- a/xep-0384.xml
+++ b/xep-0384.xml
@@ -58,8 +58,8 @@
     <jid>jabber@larma.de</jid>
   </author>
   <revision>
-    <version>0.8.1</version>
-    <date>2021-10-07</date>
+    <version>0.8.2</version>
+    <date>2021-12-27</date>
     <initials>melvo</initials>
     <remark>
       <p>Adjust remaining namespaces:</p>
@@ -67,6 +67,14 @@
         <li>Update namespace to 'urn:xmpp:omemo:2:bundles'</li>
         <li>Update namespace to 'urn:xmpp:omemo:2:devices'</li>
       </ul>
+    </remark>
+  </revision>
+  <revision>
+    <version>0.8.1</version>
+    <date>2021-10-07</date>
+    <initials>fs</initials>
+    <remark>
+      <p>Fixed HMAC size inconsitency (32 bytes vs 16 bytes)</p>
     </remark>
   </revision>
   <revision>

--- a/xep-0384.xml
+++ b/xep-0384.xml
@@ -60,6 +60,14 @@
   <revision>
     <version>0.8.2</version>
     <date>2021-12-27</date>
+    <initials>fs</initials>
+    <remark>
+      <p>Fixed HMAC size inconsitency (32 bytes vs 16 bytes)</p>
+    </remark>
+  </revision>
+  <revision>
+    <version>0.8.1</version>
+    <date>2021-10-07</date>
     <initials>melvo</initials>
     <remark>
       <p>Adjust remaining namespaces:</p>
@@ -67,14 +75,6 @@
         <li>Update namespace to 'urn:xmpp:omemo:2:bundles'</li>
         <li>Update namespace to 'urn:xmpp:omemo:2:devices'</li>
       </ul>
-    </remark>
-  </revision>
-  <revision>
-    <version>0.8.1</version>
-    <date>2021-10-07</date>
-    <initials>fs</initials>
-    <remark>
-      <p>Fixed HMAC size inconsitency (32 bytes vs 16 bytes)</p>
     </remark>
   </revision>
   <revision>

--- a/xep-0384.xml
+++ b/xep-0384.xml
@@ -330,7 +330,7 @@
         <ol>
           <li>Use HKDF-SHA-256 to generate 80 bytes of output from the message key by providing mk as HKDF input, 256 zero-bits as HKDF salt and &quot;OMEMO Message Key Material&quot; as HKDF info.</li>
           <li>Divide the HKDF output into a 32-byte encryption key, a 32-byte authentication key and a 16 byte IV.</li>
-          <li>Encrypt the plaintext (which consists of a 32 bytes key and a 32 bytes HMAC as specified in the section about <link url="#protocol-message_encryption">Message Encryption</link>) using AES-256-CBC with PKCS#7 padding, using the encryption key and IV derived in the previous step.</li>
+          <li>Encrypt the plaintext (which consists of a 32 bytes key and a 16 bytes HMAC as specified in the section about <link url="#protocol-message_encryption">Message Encryption</link>) using AES-256-CBC with PKCS#7 padding, using the encryption key and IV derived in the previous step.</li>
           <li>Split the associated data as returned by <tt>CONCAT</tt> into the original ad and the <tt>OMEMOMessage.proto</tt> structure.</li>
           <li>Add the ciphertext to the <tt>OMEMOMessage.proto</tt> structure.</li>
           <li>Serialize the <tt>OMEMOMessage.proto</tt> structure into a parseable byte array. To avoid potential problems regarding non-uniqueness of the serialization, make sure to only serialize <em>once</em> and to use that exact byte sequence in the following steps.</li>


### PR DESCRIPTION
This PR fixes the given length of the HMAC for encryption.

In the section about `#protocol-message_encryption` it states:

> Truncate the output of the HMAC to 16 bytes/128 bits by cutting off excess bytes from the end.

And then later it says: 

> Encrypt the plaintext (which consists of a 32 bytes key and a 32 bytes HMAC [...]

So the second (32 bytes HMAC) is wrong and fixed in this PR.