### PR TITLE
XEP-0402: Add missing supersedes for XEP-0411

### DIFF
--- a/xep-0402.xml
+++ b/xep-0402.xml
@@ -20,13 +20,21 @@
         <dependencies>
           <spec>XEP-0223</spec>
         </dependencies>
-        <supersedes/>
+        <supersedes>
+          <spec>XEP-0411</spec>
+        </supersedes>
         <supersededby/>
         <shortname>bookmarks2</shortname>
         <registry/>
         <discuss>standards</discuss>
         &dcridland;
         &jcbrand;
+        <revision>
+          <version>1.1.3</version>
+          <date>2021-12-27</date>
+          <initials>egp</initials>
+          <remark><p>Add missing &lt;supersedes/&gt; for XEP-0411</p></remark>
+        </revision>
         <revision>
           <version>1.1.2</version>
           <date>2021-02-03</date>


### PR DESCRIPTION
The other direction is already ok.

Maybe we should have a lint to check that both directions are always set?