### PR TITLE
XEP-0277: Rename and Upgrade Microblog to Pubsub Social Feed

### DIFF
--- a/xep-0277.xml
+++ b/xep-0277.xml
@@ -6,8 +6,8 @@
 <?xml-stylesheet type='text/xsl' href='xep.xsl'?>
 <xep>
 <header>
-  <title>Microblogging over XMPP</title>
-  <abstract>This specification defines a method for microblogging over XMPP.</abstract>
+  <title>PubSub Social Feed</title>
+  <abstract>This specification defines a way of publishing social content over XMPP.</abstract>
   &LEGALNOTICE;
   <number>0277</number>
   <status>Deferred</status>
@@ -17,7 +17,7 @@
   <dependencies/>
   <supersedes/>
   <supersededby/>
-  <shortname>microblog</shortname>
+  <shortname>psf</shortname>
   &stpeter;
   &hildjj;
   <author>
@@ -34,6 +34,12 @@
     <jid>valerian@jappix.com</jid>
     <uri>https://valeriansaliou.name/</uri>
   </author>
+  <revision>
+    <version>0.7.0</version>
+    <date>2021-12-25</date>
+    <initials>tj</initials>
+    <remark>Generalize Microblog to any Pubsub services; rename the XEP to Pubsub Social Feed; remove the Microblog metadata section; remove some superfluous sections; reorganize the XEP sections; add some new Profiles (Base, Microblog, Gallery)</remark>
+  </revision>
   <revision>
     <version>0.6.5</version>
     <date>2022-02-15</date>
@@ -109,44 +115,33 @@
 </header>
 
 <section1 topic='Introduction' anchor='intro'>
-  <p>Microblogging is an increasingly popular technology for lightweight interaction over the Internet. It differs from traditional blogging in that:</p>
-  <ul>
-    <li>Posts are short (typically less than 140 characters, which is the limit in SMS).</li>
-    <li>Posts are in plain text.</li>
-    <li>People can reply to your posts, but not directly comment on them.</li>
-    <li>People learn about your posts only if they have permission to view them.</li>
-    <li>Your microblogging feed is discovered based on your identity at a domain or with a service.</li>
-  </ul>
-  <p>These characteristics map well to instant messaging systems such as those built using Jabber/XMPP technologies (e.g., permissions can be based on existing presence subscriptions as reflected in the XMPP roster or "buddy list"). Furthermore, the push nature of XMPP (especially as formalized in the &xep0163; profile of &xep0060;) overcomes the problems of polling for updates via HTTP, which has caused scaling issues in existing microblogging services. Therefore this specification defines a method for microblogging over XMPP, building on the existing method for transporting Atom syndication data &rfc4287; over XMPP as described in &atomsub;. These XMPP-based methods are complementary to HTTP-based methods, and can provide an XMPP interface to existing microblogging services (which may also be accessible via HTTP, Short Message Service (SMS), and other messaging transports).</p>
+  <p>Social Networking plaftorms are often built around the concept of feeds. XMPP offers, through &xep0060;, a really generic way of Publishing and Subscribing elements on XMPP nodes. This extension defines a way to publish social content on PubSub nodes using &rfc4287;</p>
+
+  <p>Previous versions of this XEP were designed around Microblogging. However in practice Microblogging related features were not used. The current XEP defines a more generic way of handling Social Feeds on XMPP but keep the existing Microblogging features as a subset of it.</p>
 </section1>
 
-<section1 topic='Protocol' anchor='proto'>
+<section1 topic='Glossary' anchor='glossary'>
+  <dl>
+    <di><dt>Profile</dt><dd>Defined by a specific Pubsub type (see "pubsub#type" in &xep0060;) a profile is a Pubsub Social Feed with some constraints. See the <link url="#profiles">Profiles</link> section.</dd></di>
+  </dl>
+</section1>
+
+<section1 topic='Protocol' anchor='protocol'>
   <section2 topic='Location' anchor='location'>
-    <p>A person's microblog SHOULD be located at a personal eventing (PEP) node named "urn:xmpp:microblog:0" but MAY be located at a generic publish-subscribe node that is not attached to a user's IM account. For instance, if the Shakespearean character Romeo has a JabberID of &lt;romeo@montague.lit&gt; then his microblog would be located at that JID with a node of "urn:xmpp:microblog:0". Outside of native XMPP systems, this node can be referred to as the following XMPP URI (see <cite>XEP-0060 § 12.21</cite>).</p>
-    <code><![CDATA[
-xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
-]]></code>
-	<p>Note that the ":" character from the namespace URN is percent-encoded in the query component (see &rfc5122; and &rfc3986;).</p>
-    <p>Naturally, this node can be discovered by contacting romeo@montague.lit directly using &xep0030;.</p>
+    <p>A PubSub Social feed can be located on any PubSub node on the XMPP network. Some specific use cases, such as the personal eventing (PEP) node Microblog is defined in the <link url="#profiles">Profiles</link> section.</p>
   </section2>
-  <section2 topic='Subscribing to a Microblog' anchor='subscribe'>
-    <p>Let us imagine that Juliet wishes to receive the posts that Romeo publishes to his microblog. She has two options:</p>
-    <ol>
-      <li>Implicitly subscribe by advertising support for "urn:xmpp:microblog:0+notify" in her &xep0115; data. Romeo's PEP service then automatically sends posts to her when it receives presence from her, until and unless she sends presence of type unavailable or stops advertising an interest in microblog updates.</li>
-      <li>Explicitly subscribe by sending a formal subscription request to the "urn:xmpp:microblog:0" node at Romeo's JabberID. Romeo's PEP service may send her all posts even if she is offline at the time (depending on service policies regarding presence integration).</li>
-    </ol>
-  </section2>
+
   <section2 topic='Publishing a Post' anchor='publish'>
-    <p>Romeo can publish a post via any interface provided by his service, such as a website, the Atom Publishing Protocol (see &rfc5023;), SMS, an IM bot, or XMPP pubsub. Here we assume that the post is provided via XMPP pubsub.</p>
+    <p>Romeo can publish a post via any interface provided by his service, such as a website, the Atom Publishing Protocol (see &rfc5023;), SMS, an IM bot, or XMPP PubSub. Here we assume that the post will be published on a XMPP PubSub node.</p>
     <p>The post content itself can be either text (content element without "type" attribute or with "type" attribute with "text" value) or XHTML ("content" element "type" attribute with "xhtml" value). If Romeo publishes XHTML content, his client MUST publish two "content" elements: a text one, and a XHTML one. For XHTML publishing, see &xep0060;.</p>
     <p>Note: Publishing via HTTP, AtomPub, SMS, or IM bot is simpler for the client (e.g., because the client does not need to generate an Item ID).</p>
     <example caption="Publishing a post"><![CDATA[
 <iq from='romeo@montague.lit/pda'
     id='pub1'
-    to='romeo@montague.lit'
+    to='new.montague.lit'
     type='set'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-    <publish node='urn:xmpp:microblog:0'>
+    <publish node='montague-family'>
       <item id='1cb57d9c-1c46-11dd-838c-001143d5d5db'>
         <entry xmlns='http://www.w3.org/2005/Atom'>
           <title type='text'>hanging out at the Caf&#233; Napolitano</title>
@@ -164,11 +159,11 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
         <p>It's possible to insert some rich content in the post or comment. It can be some text formatting, images, etc. Only "xhtml" content type is supported for the moment by this document but possibly it will be extended later. Also, it is RECOMMENDED for the client to restrict XHTML content to the XHTML-IM subset (&xep0071;).</p>
         <example caption="Publishing a post with rich content"><![CDATA[
 <iq from='romeo@montague.lit/pda'
-    id='pub1'
-    to='romeo@montague.lit'
+    id='pub2'
+    to='news.montague.lit'
     type='set'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-    <publish node='urn:xmpp:microblog:0'>
+    <publish node='montague-family'>
       <item id='1cb57d9c-1c46-11dd-838c-001143d5d5db'>
         <entry xmlns='http://www.w3.org/2005/Atom'>
           <title type='xhtml'>
@@ -189,14 +184,14 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
     </section3>
   </section2>
   <section2 topic='Receiving a Post' anchor='receive'>
-    <p>Because Juliet has sent presence to Romeo including Entity Capabilities data that encapsulates the "urn:xmpp:microblog:0+notify" feature, Romeo's XMPP server will send a PEP notification to Juliet. The notification can include an XMPP message body for backwards-compatibility with Jabber clients that are not pubsub-capable (see <link url="#body">Message Body</link>).</p>
+    <p>Because Juliet is subscribed to some Romeo's family PubSub service nodes. Romeo's XMPP server will send a PubSub notification to Juliet. The notification can include an XMPP message body for backwards-compatibility with Jabber clients that are not pubsub-capable (see <link url="#body">Message Body</link>).</p>
     <example caption="Receiving a post"><![CDATA[
-<message from='romeo@montague.lit'
+<message from='news.montague.lit'
          to='juliet@capulet.lit'
          type='headline'>
   <body>hanging out at the Caf&#233; Napolitano</body>
   <event xmlns='http://jabber.org/protocol/pubsub#event'>
-    <items node='urn:xmpp:microblog:0'>
+    <items node='montague-family'>
       <item id='1cb57d9c-1c46-11dd-838c-001143d5d5db' publisher='romeo@montague.lit'>
         <entry xmlns='http://www.w3.org/2005/Atom'>
           <title type='text'>hanging out at the Caf&#233; Napolitano</title>
@@ -204,7 +199,7 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
                 type='text/html'
                 href='http://montague.lit/romeo/posts/1cb57d9c-1c46-11dd-838c-001143d5d5db'/>
           <link rel='alternate'
-                href='xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0;item=1cb57d9c-1c46-11dd-838c-001143d5d5db'/>
+                href='xmpp:news.montague.lit?;node=montague-family;item=1cb57d9c-1c46-11dd-838c-001143d5d5db'/>
           <id>tag:montague.lit,2008-05-08:posts-1cb57d9c-1c46-11dd-838c-001143d5d5db</id>
           <published>2008-05-08T18:30:02Z</published>
           <updated>2008-05-08T18:30:02Z</updated>
@@ -224,10 +219,10 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
     <example caption="Publishing a reply"><![CDATA[
 <iq from='benvolio@montague.lit/mobile'
     id='uv2x37s5'
-    to='benvolio@montague.lit'
+    to='news.montague.lit'
     type='set'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-    <publish node='urn:xmpp:microblog:0'>
+    <publish node='montague-family'>
       <item id='c4145006-1c53-11dd-b2d5-000bcd82471e'>
         <entry xmlns='http://www.w3.org/2005/Atom'
                xmlns:thr='http://purl.org/syndication/thread/1.0'>
@@ -240,8 +235,8 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
                 type='text/html'
                 href='http://montague.lit/benvolio/posts/c4145006-1c53-11dd-b2d5-000bcd82471e'/>
           <link rel='alternate'
-                href='xmpp:benvolio@montague.lit?;
-                      node=urn%3Axmpp%3Amicroblog%3A0;
+                href='xmpp:news.montague.lit?;
+                      node=montague-family;
                       item=c4145006-1c53-11dd-b2d5-000bcd82471e'/>
           <id>tag:montague.lit,2008-05-08:posts-c4145006-1c53-11dd-b2d5-000bcd82471e</id>
           <published>2008-05-08T18:31:21Z</published>
@@ -252,14 +247,14 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
                href='http://montague.lit/romeo/posts/1cb57d9c-1c46-11dd-838c-001143d5d5db'/>
           <thr:in-reply-to
                ref='tag:montague.lit,2008-05-08:posts-1cb57d9c-1c46-11dd-838c-001143d5d5db'
-               href='xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0;item=1cb57d9c-1c46-11dd-838c-001143d5d5db'/>
+               href='xmpp:news.montague.lit?;node=montague-family;item=1cb57d9c-1c46-11dd-838c-001143d5d5db'/>
         </entry>
       </item>
     </publish>
   </pubsub>
 </iq>
 ]]></example>
-    <p>Assuming that Romeo has also shared presence with Benvolio and has advertised support for "urn:xmpp:microblog:0+notify", he will receive the reply that Benvolio sent.</p>
+    <p>Assuming that Romeo has also subscribed to the same node he will receive the reply that Benvolio sent.</p>
   </section2>
   <section2 topic='Repeating a Post' anchor='repeat'>
     <p>When Benvolio wants to repeat a Romeo's post, his client publishes the same post under a different name. But to be able to track the repeated post original author, Benvolio's client MAY use specific "atom:author" child node, "atom:name" and "atom:uri", containing, respectively, the name of the original post author, and his XMPP URI (JID).</p>
@@ -268,10 +263,10 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
     <example caption="Repeating a Post"><![CDATA[
 <iq from='benvolio@montague.lit/mobile'
     id='pub2'
-    to='benvolio@montague.lit'
+    to='news.montague.lit'
     type='set'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-    <publish node='urn:xmpp:microblog:0'>
+    <publish node='montague-family'>
       <item id='1re57d3c-1q46-11dd-748r-024943d2d5rt'>
         <entry xmlns='http://www.w3.org/2005/Atom'>
           <author>
@@ -283,9 +278,9 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
                 type='text/html'
                 href='http://montague.lit/benvolio/posts/1re57d3c-1q46-11dd-748r-024943d2d5rt'/>
           <link rel='alternate'
-                href='xmpp:benvolio@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0;item=1re57d3c-1q46-11dd-748r-024943d2d5rt'/>
+                href='xmpp:news.montague.lit?;node=montague-family;item=1re57d3c-1q46-11dd-748r-024943d2d5rt'/>
           <link rel='via'
-                href='xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0;item=1cb57d9c-1c46-11dd-838c-001143d5d5db'
+                href='xmpp:rnews.montague.lit?;node=montague-family;item=1cb57d9c-1c46-11dd-838c-001143d5d5db'
                 ref='tag:montague.lit,2008-05-08:posts-1cb57d9c-1c46-11dd-838c-001143d5d5db'/>
           <id>tag:montague.lit,2008-05-08:posts-1re57d3c-1q46-11dd-748r-024943d2d5rt</id>
           <published>2008-05-08T18:30:02Z</published>
@@ -296,206 +291,106 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
   </pubsub>
 </iq>
 ]]></example>
-    <p>Thus, a different author JID value lets the client know the microblog item has been repeated from another one.</p>
+    <p>Thus, a different author JID value lets the client know the item has been repeated from another one.</p>
     <p>It's also possible for Benvolio to add his own thougths to the repost. To do this he SHOULD wrap the original content in the "xhtml:blockquote" element and after it add his own content. Also, the client MAY post reply without quotation to the original thread to inform users about the repost.</p>
   </section2>
-  <section2 topic="Post Categories" anchor="categories">
-    <p>It's often handy to specify categories (or tags) to a post to make it easier to find it or to structure a blog. It's possible by adding "atom:category" element to the entry (it can be blog or replies entry).</p>
-    <example caption="Specify post's categories"><![CDATA[
-<entry xmlns='http://www.w3.org/2005/Atom'>
-  ...
-  <category term='humour'/>
-  <category term='xmpp'/>
-  ...
-</entry>
-]]></example>
-  </section2>
-</section1>
 
-<section1 topic='Comments' anchor='comments'>
-  <p>Juliet and Benvolio may want to discuss about latest Romeo's post. To enable this, Romeo's client MAY add a "atom:link" element to the PubSub item. The element MUST have "rel", "title" and "href" attributes, where "rel" MUST have the "replies" value; "title" MUST have the "comments" value; "href" MUST be an XMPP URI (see &rfc5122; and &rfc3986;).</p>
-  <section2 topic='Post Comments' anchor='post_comments'>
-    <p>We assume Romeo's client first created a comments node (named "urn:xmpp:microblog:0:comments/ID", where "ID" is the microblog item ID, or the SHA-1 encoded attachment URI, as defined in &rfc3174;).</p>
-    <example caption="Adding a comments link to a Post"><![CDATA[
-<iq from='romeo@montague.lit/pda'
-    id='pub4'
-    to='romeo@montague.lit'
-    type='set'>
-  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-    <publish node='urn:xmpp:microblog:0'>
-      <item id='2ze57d9c-1c46-21df-830c-002143d3d2qgf'>
-        <entry xmlns='http://www.w3.org/2005/Atom'>
-          <title type='text'>hanging out at the Caf&#233; Napolitano</title>
-          <link rel='replies'
-                title='comments'
-                href='xmpp:pubsub.montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0%3Acomments%2Fdd88c9bc58886fce0049ed050df0c5f2'/>
-          <id>tag:montague.lit,2008-05-08:posts-2ze57d9c-1c46-21df-830c-002143d3d2qgf</id>
-          <published>2008-05-08T18:38:02Z</published>
-          <updated>2008-05-08T18:38:02Z</updated>
-        </entry>
-      </item>
-    </publish>
-  </pubsub>
-</iq>
-]]></example>
-  </section2>
-  <section2 topic='Adding a Comment' anchor='comment_add'>
-    <p>If Juliet wants to comment Romeo's latest post, her client sends a new Atom entry to the defined PubSub node.</p>
-    <p>Note: A comments node SHOULD be located at a generic publish-subscribe node that is not attached to a user's IM account, but MAY be located at a personal eventing (PEP) node.</p>
-    <example caption="Adding a comment to a comments node"><![CDATA[
-<iq from='juliet@capulet.lit/pc'
-    id='comment1'
-    to='pubsub.capulet.lit'
-    type='set'>
-  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-    <publish node='urn:xmpp:microblog:0:comments/dd88c9bc58886fce0049ed050df0c5f2'>
-      <item id='b2106a80de39ef5ec6b8f7b69cb610c2'>
-        <entry xmlns='http://www.w3.org/2005/Atom'>
-          <author>
-            <name>Juliet Capulet</name>
-            <uri>xmpp:juliet@capulet.lit</uri>
-          </author>
-          <title type='text'>She is so pretty!</title>
-          <published>2008-05-08T18:39:02Z</published>
-        </entry>
-      </item>
-    </publish>
-  </pubsub>
-</iq>
-]]></example>
-    <p>If Benvolio wants to retrieve the comments node, his client will send a standard PubSub stanza to request all items (see &xep0060; for all items retrieving).</p>
-  </section2>
-</section1>
-
-<section1 topic="Pubsub Node Configuration" anchor="node_config">
-    <p>We have described two pubsub nodes types here: the one is for the microblog itself and the other one is for comments to posts.</p>
-    <p>Usage specific requires the special parameters to these nodes to be specified. This section describes recommendation for them.</p>
-    <section2 topic="Microblog node configuration" anchor="microblog_node_config">
-        <p>Here are recommendations for a microblogging node (usually located at PEP and named by the "urn:xmpp:microblog:0" namespace) configuration:</p>
-        <ol>
-          <li>The "pubsub#notify_retract" MUST be set to true to provide clients the ability to track if some items were retracted and reflect such changes in the UI correctly.</li>
-          <li>The "pubsub#max_items" SHOULD be increased from the default value to some reasonable value.</li>
-          <li>The "pubsub#send_last_published_item" SHOULD be changed to "never".</li>
-        </ol>
-    </section2>
-    <section2 topic="Comments node configuration" anchor="comments_node_config">
-        <p>Here are recommendations for a comments node configuration:</p>
-        <ol>
-          <li>The "pubsub#notify_retract" MUST be set to true to provide clients the ability to track if some items were retracted and reflect such changes in the UI correctly.</li>
-          <li>The "pubsub#max_items" SHOULD be increased from the default value to some reasonable value.</li>
-          <li>The "pubsub#access_model" SHOULD be set to "open" to allow any user to comment to a post. Other values are suitable too according to the user's settings.</li>
-        </ol>
-    </section2>
-</section1>
-
-<section1 topic='Microblog Metadata' anchor='metadata'>
-  <p>In order to provide users with some metadata (i.e. blog title or author information) about the microblog, the client MUST add an item with such information. The client MUST set the ID of the item to "0".</p>
-  <example caption="Publishing microblog metadata"><![CDATA[
-<iq from='romeo@montague.lit/pc'
-    id='pub8'
-    to='romeo@montague.lit'
-    type='set'>
-  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-    <publish node='urn:xmpp:microblog:0'>
-      <item id='0'>
-        <feed xmlns='http://www.w3.org/2005/Atom'>
-          <title>Romeo&apos;s Microblog</title>
-          <id>tag:montague.lit,2008:home</id>
-          <updated>2008-05-08T18:30:02Z</updated>
-          <author>
-            <name>Romeo Montague</name>
-            <uri>xmpp:romeo@montague.lit</uri>
-          </author>
-        </feed>
-      </item>
-    </publish>
-  </pubsub>
-</iq>
-]]></example>
-  <p>It also necessary to link a comments node to the post which discussed in the node. We will do it by adding the "atom:link" element with "rel=start" attribute:</p>
-
-  <example caption="Publishing comments node metadata"><![CDATA[
-<iq from='romeo@montague.lit/pc'
-    id='pub8'
-    to='pubsub.montague.lit'
-    type='set'>
-  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-    <publish node='urn:xmpp:microblog:0'>
-      <item id='0'>
-        <feed xmlns='http://www.w3.org/2005/Atom'>
-          <title>Comments to a post</title>
-          <id>tag:pubsub.montague.lit,2008:comments-2ze57d9c-1c46-21df-830c-002143d3d2qgf</id>
-          <updated>2008-05-08T18:30:02Z</updated>
-          <link rel='start'
-                href='xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0;item=1cb57d9c-1c46-11dd-838c-001143d5d5db'
-                ref='tag:montague.lit,2008-05-08:posts-1cb57d9c-1c46-11dd-838c-001143d5d5db'/>
-        </feed>
-      </item>
-    </publish>
-  </pubsub>
-</iq>
-]]></example>
-</section1>
-
-<section1 topic='Geotagging' anchor='geotagging'>
-  <p>Juliet may want to know which places are Romeo's notices related to. That's why Romeo's client MAY geotag microblog entries, using the &xep0080; protocol for storing geolocation information.</p>
-  <p>Romeo's client MUST create a "geoloc" element, with the &xep0080; reference namespace: "http://jabber.org/protocol/geoloc".</p>
-  <example caption="Geotagging a Post"><![CDATA[
-<iq from='romeo@montague.lit/mobile'
-    id='pub7'
-    to='romeo@montague.lit'
-    type='set'>
-  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-    <publish node='urn:xmpp:microblog:0'>
-      <item id='1zr23z8a-3g12-34fh-750b-120867gjc1sqh'>
-        <entry xmlns='http://www.w3.org/2005/Atom'>
-          <author>
-            <name>Romeo Montague</name>
-            <uri>xmpp:romeo@montague.lit</uri>
-          </author>
-          <title type='text'>Is lost in the forest. Need help!</title>
-          <link rel='replies'
-                title='comments'
-                href='xmpp:pubsub.montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0%3Acomments%2F36ec6dfe61e52b1e2cdb248823520233'/>
-          <id>tag:montague.lit,2008-05-08:posts-1zr23z8a-3g12-34fh-750b-120867gjc1sqh</id>
-          <published>2008-05-08T18:43:01Z</published>
-          <updated>2008-05-08T18:43:01Z</updated>
-          <geoloc xmlns="http://jabber.org/protocol/geoloc">
-            <lat>48.171761</lat>
-            <lon>-3.3667986</lon>
-            <country>France</country>
-            <countrycode>FR</countrycode>
-            <region>Brittany</region>
-          </geoloc>
-        </entry>
-      </item>
-    </publish>
-  </pubsub>
-</iq>
-]]></example>
-</section1>
-
-<section1 topic="Aggregators" anchor="aggregators">
-  <p>In order to provide some statistical information, to represent the blogs other ways than XMPP (i.e. in web or NNTP), we will need other entities called "Aggregators".</p>
-  <p>You can think of aggregators like about search engines in the web: they gather information from the whole web and then represent it suitable ways. The same is true here: Aggregators just subscibe to many entities and then they can build a database to make queries and show appropriate information according to these queries. Also they can be used to represent information in web or other networks.</p>
-  <p>Unlike web search engines, an XMPP aggregator does not need to gather information by downloading it frequently to check if something was changed. Instead, it can listen to pubsub events and make its database up-to-date based on this information.</p>
-  <p>Aggregators can be started by different people with different aims. It can be aggregator which devoted to the concrete blog service provider which will be subscribed only to its own users, or it can be a global search engine which tries to subscribe to most of users or to aggregate the feeds of other aggregators.</p>
-  <p>This section will describe most used aggregator usecases but the list is not exhaustive.</p>
-  <section2 topic="Pubsub Item ID vs. Atom Entry id" anchor="pubsub_id_vs_atom_id">
-    <p>There are two different things that carry a similar sense: the XMPP pubsub Item ID and the "atom:id" element. This section is devoted to make a separation between them.</p>
-    <p>The pubsub Item ID MUST be used when linking to an entry with an XMPP channel (i.e. by including it in the URI with the "xmpp" schema). the Atom entry ID MUST be built according to &rfc4287; and used in aggregators with the aim of revealing of post duplicates, reposts, mentions, syndications, etc.</p>
-    <p>Note that the rules of comparing, building and security notes for "atom:id" are listed in the &rfc4287;.</p>
-  </section2>
-  <section2 topic="Aggregator Usecases" anchor="aggregator_usecases">
-    <section3 topic="Representing Posts in the Web" anchor="aggregator_web">
-      <p>One of the possible aims of aggregator services is to provide web representaion of blogs.</p>
-      <p>TBD: insert alternate link to the post with the http address of the post.</p>
+  <section2 topic='Atom and XMPP integration' anchor='atom_xmpp_integration'>
+    <section3 topic="Pubsub Item ID vs. Atom Entry id" anchor="pubsub_id_vs_atom_id">
+      <p>There are two different things that carry a similar sense: the XMPP pubsub Item ID and the "atom:id" element. This section is devoted to make a separation between them.</p>
+      <p>The pubsub Item ID MUST be used when linking to an entry with an XMPP channel (i.e. by including it in the URI with the "xmpp" schema). the Atom entry ID MUST be built according to &rfc4287; and used in aggregators with the aim of revealing of post duplicates, reposts, mentions, syndications, etc.</p>
+      <p>Note that the rules of comparing, building and security notes for "atom:id" are listed in the &rfc4287;.</p>
+    </section3>
+    <section3 topic='Message Body' anchor='body'>
+      <p>Depending on service policies and the value of the "pubsub#include_body" node configuration option, PubSub Social Feed notifications SHOULD include a message "body" element for backwards-compatibility with Jabber clients that are not pubsub-capable. It is RECOMMENDED for the XML character value of the "body" element to be the same as that of the "atom:title" child of the "atom:entry".</p>
+    </section3>
+    <section3 topic='Geotagging' anchor='geotagging'>
+      <p>Juliet may want to know which places are Romeo's notices related to. That's why Romeo's client MAY geotag microblog entries, using the &xep0080; protocol for storing geolocation information.</p>
+      <p>Romeo's client MUST create a "geoloc" element, with the &xep0080; reference namespace: "http://jabber.org/protocol/geoloc".</p>
+      <example caption="Geotagging a Post"><![CDATA[
+    <iq from='romeo@montague.lit/mobile'
+        id='pub7'
+        to='romeo@montague.lit'
+        type='set'>
+      <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+        <publish node='urn:xmpp:microblog:0'>
+          <item id='1zr23z8a-3g12-34fh-750b-120867gjc1sqh'>
+            <entry xmlns='http://www.w3.org/2005/Atom'>
+              <author>
+                <name>Romeo Montague</name>
+                <uri>xmpp:romeo@montague.lit</uri>
+              </author>
+              <title type='text'>Is lost in the forest. Need help!</title>
+              <link rel='replies'
+                    title='comments'
+                    href='xmpp:pubsub.montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0%3Acomments%2F36ec6dfe61e52b1e2cdb248823520233'/>
+              <id>tag:montague.lit,2008-05-08:posts-1zr23z8a-3g12-34fh-750b-120867gjc1sqh</id>
+              <published>2008-05-08T18:43:01Z</published>
+              <updated>2008-05-08T18:43:01Z</updated>
+              <geoloc xmlns="http://jabber.org/protocol/geoloc">
+                <lat>48.171761</lat>
+                <lon>-3.3667986</lon>
+                <country>France</country>
+                <countrycode>FR</countrycode>
+                <region>Brittany</region>
+              </geoloc>
+            </entry>
+          </item>
+        </publish>
+      </pubsub>
+    </iq>
+    ]]></example>
     </section3>
   </section2>
 </section1>
 
-<section1 topic='Message Body' anchor='body'>
-  <p>Depending on service policies and the value of the "pubsub#include_body" node configuration option, microblogging notifications SHOULD include a message "body" element for backwards-compatibility with Jabber clients that are not pubsub-capable. It is RECOMMENDED for the XML character value of the "body" element to be the same as that of the "atom:title" child of the "atom:entry".</p>
+<section1 topic="Profiles" anchor="profiles">
+  <p>PubSub Social feeds are specified under profiles. Those profiles are constraints applied to nodes and defined by a specific PubSub type (see "pubsub#type" in &xep0060;)</p>
+  <p>All the profiles MUST base their default configuration on the <link url="#profile_base">Base profile</link>.</p>
+
+  <section2 topic="Base profile" anchor="profile_base">
+    <p>This profile is specified by the PubSub type `urn:xmpp:social:0` and defines a generic PubSub Social Feed that can be hosted on any PubSub service node or PEP node.</p>
+    <p>Those restrictions MUST be used by all the other profiles defined bellow and in other XEPs based on Pubsub Social Feed.</p>
+
+    <section3 topic="Pubsub Node Configuration" anchor="profile_base_node_config">
+        <ol>
+          <li>The "pubsub#type" MUST be set to `urn:xmpp:social:0` except if overwritten be another profile.</li>
+          <li>The "pubsub#notify_retract" MUST be set to `true` to provide clients the ability to track if some items were retracted and reflect such changes in the UI correctly.</li>
+          <li>The "pubsub#max_items" MUST be set to the `max` value, as defined in the &xep0060;.</li>
+          <li>The "pubsub#persist_items" MUST be set to `true`.</li>
+          <li>The "pubsub#send_last_published_item" SHOULD be set to `never`.</li>
+          <li>The "pubsub#deliver_payloads" SHOULD be set to `false`. The social content can be quite large so it is advised to let the clients to manually query the content if it is not already cached.</li>
+        </ol>
+    </section3>
+  </section2>
+
+  <section2 topic="Microblog profile" anchor="profile_microblog">
+    <p>This profile is defined by the PubSub type `urn:xmpp:microblog:0` and MUST be created and configured under the PEP `urn:xmpp:microblog:0` node.</p>
+
+    <section3 topic="Pubsub Node Configuration" anchor="profile_microblog_node_config">
+      <p>On top of the <link url="#profile_base_node_config">Base profile Pubsub Node Configuration</link> the following node configuration is applied:</p>
+      <ol>
+        <li>The "pubsub#type" SHOULD be set to `urn:xmpp:microblog:0` except if overwritten be another profile.</li>
+        <li>The "pubsub#access_model" SHOULD be set to `presence` by default to allow the other presence JIDs to receive the newly published elements without an explicit subscription (using the +notify feature of &xep0163;).</li>
+      </ol>
+    </section3>
+  </section2>
+
+  <section2 topic="Gallery profile" anchor="profile_gallery">
+    <p>This profile is defined by the PubSub type `urn:xmpp:gallery:0` and can be hosted on any PubSub service.</p>
+    <p>All the items published in a gallery node MUST only have at least one attached picture. This picture MUST be of type `enclosure` as specified in &rfc4287;.</p>
+    <example caption="An Atom attached picture"><![CDATA[
+    <link rel='enclosure' href='https://capulet.lit/upload/romeo.jpg' type='image/jpeg' title='Romeo Portrait'/>
+]]></example>
+
+    <section3 topic="Pubsub Node Configuration" anchor="profile_microblog_node_config">
+      <p>On top of the <link url="#profile_base_node_config">Base profile Pubsub Node Configuration</link> the following node configuration is applied:</p>
+      <ol>
+        <li>The "pubsub#type" MUST be set to `urn:xmpp:gallery:0` except if overwritten be another profile.</li>
+        <li>If hosted as a &xep0163; node the "pubsub#access_model" SHOULD be set to `presence` by default to allow the other presence JIDs to receive the newly published elements without an explicit subscription (using the +notify feature of &xep0163;).</li>
+      </ol>
+    </section3>
+  </section2>
 </section1>
 
 <section1 topic='Security Considerations' anchor='security'>


### PR DESCRIPTION
* generalize Microblog to any Pubsub services
* rename the XEP to Pubsub Social Feed
* remove the Microblog metadata section
* remove some superfluous sections
* reorganize the XEP sections
* add some new Profiles (Base, Microblog, Gallery)

Thoses changes were planned for several years already. The general ideas is to simplify to remove some superfluous content (already defined in the Atom RFC or other XEPs most of the time) and reorganize it to clarify the different sections.

This XEP should be fully retro-compatible with the existing Microblog XEP. It just generalize the concept of "Atom in Pubsub" and then redefine Microblog as a subset of it using newly introduced Profiles.

This XEP relies on `pubsub#type`.