### PR TITLE
XEP-0030: remove security considerations preventing requests on a bar…

### DIFF
--- a/xep-0030.xml
+++ b/xep-0030.xml
@@ -37,6 +37,12 @@
     &reatmon;
     &stpeter;
     <revision>
+      <version>2.6</version>
+      <date>2022-01-07</date>
+      <initials>jp</initials>
+      <remark><p>Removed security considerations preventing disco#info requests on a bare JID without presence subscription: these considerations are outdated as well-known public node are nowadays in use, and JID can be checked by requesting one of those nodes. Furthermore, it prevents doing a disco#info request on a PEP service with public nodes.</p></remark>
+    </revision>
+    <revision>
       <version>2.5rc3</version>
       <date>2017-10-03</date>
       <initials>th</initials>
@@ -697,23 +703,7 @@
   <section1 topic='Security Considerations' anchor='security'>
     <p>Certain attacks may be made easier when an entity discloses (via disco#info responses) that it supports particular protocols or features; however, in general, service discovery introduces no new vulnerabilities, since a malicious entity could discover that the responding entity supports such protocols and features by sending requests specific to those protocols rather than by sending service discovery requests.</p>
     <p>A responding entity is under no obligation to return the identical service discovery response when replying to service discovery requests received from different requesting entities, and MAY perform authorization checks before responding in order to determine how (or whether) to respond.</p>
-    <p>A server MUST carefully control access to any functionality that would enable directory harvesting attacks or that would leak information about connected or available resources; this functionality consists of the server's replies to disco#info and disco#items requests sent to bare JIDs (addresses of the form account@domain.tld) hosted on the server, since the server responds to such requests on behalf of the account. The following rules apply to the handling of service discovery requests sent to bare JIDs:</p>
-    <ol>
-      <li>
-        <p>In response to a disco#info request, the server MUST return a &unavailable; error if one of the following is true:</p>
-        <ol>
-          <li>The target entity does not exist (no matter if the request specifies a node or not).</li>
-          <li>The requesting entity is not authorized to receive presence from the target entity (i.e., via the target having a presence subscription to the requesting entity of type "both" or "from") or is not otherwise trusted (e.g., another server in a trusted network).</li>
-        </ol>
-      </li>
-      <li>
-        <p>In response to a disco#items request, the server MUST return an empty result set if:</p>
-        <ol>
-          <li>The target entity does not exist (no matter if the request specifies a node or not).</li>
-          <li>The request did not specify a node, the only items are available resources (as defined in <cite>RFC 3921</cite>), and the requesting entity is not authorized to receive presence from the target entity (i.e., via the target having a presence subscription to the requesting entity of type "both" or "from") or is not otherwise trusted (e.g., another server in a trusted network). <note>However, the server MAY return items other than available resources (if any).</note></li>
-        </ol>
-      </li>
-    </ol>
+    <p>A server MUST carefully control access to any functionality that would leak information about connected or available resources; this functionality consists of the server's replies to disco#items requests sent to bare JIDs (addresses of the form account@domain.tld) hosted on the server, since the server responds to such requests on behalf of the account. In response to a disco#items request, the server MUST NOT return available resources if the requesting entity is not authorized to receive presence from the target entity  (i.e., via the target having a presence subscription to the requesting entity of type "both" or "from") or is not otherwise trusted (e.g., another server in a trusted network). </p>
   </section1>
   <section1 topic='IANA Considerations' anchor='iana'>
     <p>This document requires no interaction with &IANA;.</p>


### PR DESCRIPTION
…e JID

Removed security considerations preventing disco#info requests on a bare
JID without presence subscription: these considerations are outdated as
well-known public node are nowadays in use, and JID can be checked by
requesting one of those nodes. Furthermore, it prevents doing a
disco#info request on a PEP service with public nodes.