### PR TITLE
XEP-0060: Specify pubsub#type to reflect semantic info

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -50,6 +50,12 @@
   &stpeter;
   &ralphm;
   <revision>
+    <version>1.23.0</version>
+    <date>2022-01-14</date>
+    <initials>edhelas, pep</initials>
+    <remark><p>Clarify (redefine) pubsub#type field.</p></remark>
+  </revision>
+  <revision>
     <version>1.22.0</version>
     <date>2021-09-07</date>
     <initials>jp</initials>
@@ -1100,8 +1106,8 @@ And by opposing end them?
       <field var='FORM_TYPE' type='hidden'>
         <value>http://jabber.org/protocol/pubsub#meta-data</value>
       </field>
-      <field var='pubsub#type' label='Payload type' type='text-single'>
-        <value>http://www.w3.org/2005/Atom</value>
+      <field var='pubsub#type' label='Payload semantic type information' type='text-single'>
+        <value>urn:example:e2ee:bundle</value>
       </field>
       <field var='pubsub#creator' label='Node creator' type='jid-single'>
         <value>hamlet@denmark.lit</value>
@@ -3488,7 +3494,7 @@ And by opposing end them?
         <field var='pubsub#notify_retract'><value>0</value></field>
         <field var='pubsub#notify_sub'><value>0</value></field>
         <field var='pubsub#max_payload_size'><value>1028</value></field>
-        <field var='pubsub#type'><value>http://www.w3.org/2005/Atom</value></field>
+        <field var='pubsub#type'><value>urn:example:e2ee:bundle</value></field>
         <field var='pubsub#body_xslt'>
           <value>http://jabxslt.jabberstudio.org/atom_body.xslt</value>
         </field>
@@ -3627,8 +3633,8 @@ And by opposing end them?
           <value>headline</value>
         </field>
         <field var='pubsub#type' type='text-single'
-               label='Specify the type of payload data to be provided at this node'>
-          <value>http://www.w3.org/2005/Atom</value>
+               label='Specify the semantic type of payload data to be provided at this node.'>
+          <value>urn:example:e2ee:bundle</value>
         </field>
         <field var='pubsub#dataform_xslt' type='text-single'
                label='Payload XSLT'/>
@@ -3752,7 +3758,7 @@ And by opposing end them?
         <field var='pubsub#notify_retract'><value>0</value></field>
         <field var='pubsub#notify_sub'><value>0</value></field>
         <field var='pubsub#max_payload_size'><value>1028</value></field>
-        <field var='pubsub#type'><value>http://www.w3.org/2005/Atom</value></field>
+        <field var='pubsub#type'><value>urn:example:e2ee:bundle</value></field>
         <field var='pubsub#body_xslt'>
           <value>http://jabxslt.jabberstudio.org/atom_body.xslt</value>
         </field>
@@ -3834,7 +3840,7 @@ And by opposing end them?
         <field var='pubsub#send_last_published_item'><value>never</value></field>
         <field var='pubsub#presence_based_delivery'><value>0</value></field>
         <field var='pubsub#notification_type'><value>headline</value></field>
-        <field var='pubsub#type'><value>http://www.w3.org/2005/Atom</value></field>
+        <field var='pubsub#type'><value>urn:example:e2ee:bundle</value></field>
         <field var='pubsub#body_xslt'>
           <value>http://jabxslt.jabberstudio.org/atom_body.xslt</value>
         </field>
@@ -6423,7 +6429,7 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
          label='The name of the node'/>
   <field var='pubsub#type'
          type='text-single'
-         label='Payload type'/>
+         label='Payload semantic type information'/>
   <field var='pubsub#max_items'
          type='text-single'
          label='Max # of items to persist'/>
@@ -6608,8 +6614,8 @@ xmpp:pubsub.shakespeare.lit?pubsub;action=retrieve;node=princely_musings;item=ae
          label='A friendly name for the node'/>
   <field var='pubsub#type'
          type='text-single'
-         label='The type of node data, usually specified by
-                the namespace of the payload (if any)'/>
+        label='The semantic type information of data in the node, usually specified
+               by the namespace of the payload (if any)'/>
 </form_type>
 ]]></code>
     </section3>


### PR DESCRIPTION
For more information:
- https://github.com/xsf/xeps/pull/986
- https://mail.jabber.org/pipermail/standards/2022-January/038695.html

I also changed the example NS to be slightly more obvious than `http://www.w3.org/2005/Atom` when it comes to semantics.

Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>