### PR TITLE
XEP-0256: Deprecate in favour of XEP-0319

### DIFF
--- a/xep-0256.xml
+++ b/xep-0256.xml
@@ -10,7 +10,7 @@
   <abstract>This specification defines a way to use the Last Activity extension in XMPP presence notifications.</abstract>
   &LEGALNOTICE;
   <number>0256</number>
-  <status>Draft</status>
+  <status>Deprecated</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <dependencies>
@@ -19,7 +19,9 @@
     <spec>XEP-0012</spec>
   </dependencies>
   <supersedes/>
-  <supersededby/>
+  <supersededby>
+    <spec>XEP-0319</spec>
+  </supersededby>
   <shortname>N/A</shortname>
   &stpeter;
   <revision>


### PR DESCRIPTION
XEP-0319 already had the `<supersedes/>` element so no change required here.