### PR TITLE
ProtoXEP: PubSub Node Filtering

### DIFF
--- a/inbox/pubsub-filter.xml
+++ b/inbox/pubsub-filter.xml
@@ -54,7 +54,7 @@
 <section1 anchor="reqs" topic="Requirements">
 
 <ul>
-<li>Allow querying only a subset of nodes in a disco items request, in the form of allow/block</li>
+<li>Allow querying only a subset of nodes in a disco items request, in the form of include/exclude</li>
 </ul>
 
 </section1>
@@ -66,13 +66,13 @@
 </section2>
 <section2 anchor="sending-a-disco-request" topic="Sending a disco request">
 
-<p>While requesting disco#items on a PubSub service, an entity might want to only get nodes of certain <tt>pubsub#type</tt>. To do so, it may add a filter child of namespace <tt>urn:xmpp:pubsub-filter:0</tt> to the query element, containing a &xep0004; form with FORM_TYPE set to <tt>urn:xmpp:pubsub-filter:0</tt> and an <tt>allowed-types</tt> or <tt>blocked-types</tt> list-multi type field containing the various types it wants to filter.</p>
+<p>While requesting disco#items on a PubSub service, an entity might want to only get nodes of certain <tt>pubsub#type</tt>. To do so, it may add a filter child of namespace <tt>urn:xmpp:pubsub-filter:0</tt> to the query element, containing a &xep0004; form with FORM_TYPE set to <tt>urn:xmpp:pubsub-filter:0</tt> and an <tt>included-types</tt> or <tt>excluded-types</tt> list-multi type field containing the various types it wants to filter.</p>
 
-<p>When <tt>allowed-types</tt> is specified, a PubSub service MUST return nodes of matching <tt>pubsub#type</tt> in its response.</p>
+<p>When <tt>included-types</tt> is specified, a PubSub service MUST return nodes of matching <tt>pubsub#type</tt> in its response.</p>
 
-<p>When <tt>blocked-types</tt> is specified, a PubSub service MUST return every node but those of matching <tt>pubsub#types</tt> in its response.</p>
+<p>When <tt>excluded-types</tt> is specified, a PubSub service MUST return every node but those of matching <tt>pubsub#types</tt> in its response.</p>
 
-<p>Both allowed and blocked fields MAY contain an empty value to designate nodes with an empty <tt>pubsub#type</tt>.</p>
+<p>Both included and excluded fields MAY contain an empty value to designate nodes with an empty <tt>pubsub#type</tt>.</p>
 
 <example caption='Requesting disco#items with only nodes of the following types, including empty ones'><![CDATA[<iq type='get'
   from='rosa@com.int/desktop'
@@ -84,7 +84,7 @@
         <field var='FORM_TYPE' type='hidden'>
           <value>urn:xmpp:pubsub-filter:0</value>
         </field>
-        <field type='list-multi' var='allowed-types'>
+        <field type='list-multi' var='included-types'>
           <value>urn:xmpp:microblog:0</value>
           <value/>
         </field>
@@ -93,7 +93,7 @@
   </query>
 </iq>]]></example>
 
-<p>If both the allowed and blocked fields are specified, a service MUST return an error of type <tt>modify</tt> containing a <tt>bad-request</tt> element in the <tt>urn:ietf:params:xml:ns:xmpp-stanzas</tt> namespace.</p>
+<p>If both the included and excluded fields are specified, a service MUST return an error of type <tt>modify</tt> containing a <tt>bad-request</tt> element in the <tt>urn:ietf:params:xml:ns:xmpp-stanzas</tt> namespace.</p>
 
 <example caption='Error returned when a requesting entity includes both fields'><![CDATA[<iq type='error'
     from='news.com.int'

--- a/inbox/pubsub-filter.xml
+++ b/inbox/pubsub-filter.xml
@@ -1,0 +1,147 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY % ents SYSTEM 'xep.ent'>
+%ents;
+]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+<header>
+  <title>PubSub Type Filtering</title>
+  <abstract>This specification provides a way to filter PubSub nodes in a disco query.</abstract>
+  &LEGALNOTICE;
+  <number>xxxx</number>
+  <status>ProtoXEP</status>
+  <type>Standards Track</type>
+  <sig>Standards</sig>
+  <approver>Council</approver>
+  <dependencies>
+    <spec>XEP-0004</spec>
+    <spec>XEP-0030</spec>
+    <spec>XEP-0060</spec>
+  </dependencies>
+  <supersedes/>
+  <supersededby/>
+  <shortname>NOT_YET_ASSIGNED</shortname>
+  <author>
+    <firstname>Timothée</firstname>
+    <surname>Jaussoin</surname>
+    <email>edhelas@movim.eu</email>
+    <jid>edhelas@movim.eu</jid>
+  </author>
+  <author>
+    <firstname>Maxime</firstname>
+    <surname>Buquet</surname>
+    <email>pep@bouah.net</email>
+    <jid>pep@bouah.net</jid>
+  </author>
+  <revision>
+    <version>0.0.1</version>
+    <date>2022-02-01</date>
+    <initials>edhelas, pep</initials>
+    <remark><p>First draft.</p></remark>
+  </revision>
+</header>
+
+<section1 anchor="intro" topic="Introduction">
+
+<p>Implementations have been able to declare a <tt>pubsub#type</tt> attribute on PubSub nodes for about as long as &xep0060; has existed. This attribute doesn’t seem to be widely used in the community though, maybe due to the vagueness of its description, that has recently changed, or the lack of features associated with it.</p>
+
+<p>This specification provides a way for implementations to allow filtering on this attribute when discovering items on a PubSub service.</p>
+
+<p>Filtering is particularly useful for example combined with &xep0277; and comment nodes that are created on the same service. When listing content nodes of a service, one may want to filter out comment nodes.</p>
+
+</section1>
+<section1 anchor="reqs" topic="Requirements">
+
+<ul>
+<li>Allow querying only a subset of nodes in a disco items request, in the form of allow/block</li>
+</ul>
+
+</section1>
+<section1 anchor="usecases" topic="Use Cases">
+<section2 anchor="support" topic="Discovering support">
+
+<p>A service implementing this specification MUST advertize through &xep0030; a <tt>urn:xmpp:pubsub-filter:0</tt> feature.</p>
+
+</section2>
+<section2 anchor="sending-a-disco-request" topic="Sending a disco request">
+
+<p>While requesting disco#items on a PubSub service, an entity might want to only get nodes of certain <tt>pubsub#type</tt>. To do so, it may add a filter child of namespace <tt>urn:xmpp:pubsub-filter:0</tt> to the query element, containing a &xep0004; form with FORM_TYPE set to <tt>urn:xmpp:pubsub-filter:0</tt> and an <tt>allowed-types</tt> or <tt>blocked-types</tt> list-multi type field containing the various types it wants to filter.</p>
+
+<p>When <tt>allowed-types</tt> is specified, a PubSub service MUST return nodes of matching <tt>pubsub#type</tt> in its response.</p>
+
+<p>When <tt>blocked-types</tt> is specified, a PubSub service MUST return every node but those of matching <tt>pubsub#types</tt> in its response.</p>
+
+<p>Both allowed and blocked fields MAY contain an empty value to designate nodes with an empty <tt>pubsub#type</tt>.</p>
+
+<example caption='Requesting disco#items with only nodes of the following types, including empty ones'><![CDATA[<iq type='get'
+  from='rosa@com.int/desktop'
+  to='news.commons.social'
+  id='disco1'>
+  <query xmlns='http://jabber.org/protocol/disco#items>
+    <filter xmlns='urn:xmpp:pubsub-filter:0'>
+      <x xmlns='jabber:x:data' type='submit'>
+        <field var='FORM_TYPE' type='hidden'>
+          <value>urn:xmpp:pubsub-filter:0</value>
+        </field>
+        <field type='list-multi' var='allowed-types'>
+          <value>urn:xmpp:microblog:0</value>
+          <value/>
+        </field>
+      </x>
+    </filter>
+  </query>
+</iq>]]></example>
+
+<p>If both the allowed and blocked fields are specified, a service MUST return an error of type <tt>modify</tt> containing a <tt>bad-request</tt> element in the <tt>urn:ietf:params:xml:ns:xmpp-stanzas</tt> namespace.</p>
+
+<example caption='Error returned when a requesting entity includes both fields'><![CDATA[<iq type='error'
+    from='news.com.int'
+    to='peter@commons.social/desktop'
+    id='error1'>
+  <error type='modify'>
+    <bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
+  </error>
+</iq>]]></example>
+
+</section2>
+</section1>
+<section1 anchor="iana" topic="IANA Considerations">
+
+<p>None.</p>
+
+</section1>
+<section1 anchor="registrar" topic="XMPP Registrar Considerations">
+
+<p>None.</p>
+
+</section1>
+<section1 anchor="schema" topic="XML Schema">
+<section2 anchor="urnxmpppubsub-filter0" topic="urn:xmpp:pubsub-filter:0">
+
+<code><![CDATA[<xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:xdata='jabber:x:data'
+    targetNamespace='urn:xmpp:pubsub-filter:0'
+    xmlns='urn:xmpp:pubsub-filter:0'
+    elementFormDefault='qualified'>
+
+  <xs:annotation>
+    <xs:documentation>
+      The protocol documented by this schema is defined in
+      XEP-XXXX: http://xmpp.org/extensions/xep-xxxx.html
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name='filter'>
+    <xs:complexType>
+      <xs:choice xmlns:xdata='jabber:x:data'>
+        <xs:element ref='xdata:x'/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>]]></code>
+
+</section2>
+</section1>
+</xep>


### PR DESCRIPTION
This is a split of the pubsub-ns protoxep now that pubsub#type is validated. Another one coming with service type restrictions.

Rendered version: https://bouah.net/specs/pubsub-filter.html

Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>