### PR TITLE
XEP-0277: remove the extra layer of xml escaping in examples

### DIFF
--- a/xep-0277.xml
+++ b/xep-0277.xml
@@ -143,7 +143,7 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
     <publish node='urn:xmpp:microblog:0'>
       <item id='1cb57d9c-1c46-11dd-838c-001143d5d5db'>
         <entry xmlns='http://www.w3.org/2005/Atom'>
-          <title type='text'>hanging out at the Caf&amp;#233; Napolitano</title>
+          <title type='text'>hanging out at the Caf&#233; Napolitano</title>
           <id>tag:montague.lit,2008-05-08:posts-1cb57d9c-1c46-11dd-838c-001143d5d5db</id>
           <published>2008-05-08T18:30:02Z</published>
           <updated>2008-05-08T18:30:02Z</updated>
@@ -167,7 +167,7 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
         <entry xmlns='http://www.w3.org/2005/Atom'>
           <title type='xhtml'>
             <div xmlns="http://www.w3.org/1999/xhtml">
-              <p>hanging out at the <strong>Caf&amp;#233; Napolitano</strong></p>
+              <p>hanging out at the <strong>Caf&#233; Napolitano</strong></p>
             </div>
           </title>
           <id>tag:montague.lit,2008-05-08:posts-1cb57d9c-1c46-11dd-838c-001143d5d5db</id>
@@ -188,12 +188,12 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
 <message from='romeo@montague.lit'
          to='juliet@capulet.lit'
          type='headline'>
-  <body>hanging out at the Caf&amp;#233; Napolitano</body>
+  <body>hanging out at the Caf&#233; Napolitano</body>
   <event xmlns='http://jabber.org/protocol/pubsub#event'>
     <items node='urn:xmpp:microblog:0'>
       <item id='1cb57d9c-1c46-11dd-838c-001143d5d5db' publisher='romeo@montague.lit'>
         <entry xmlns='http://www.w3.org/2005/Atom'>
-          <title type='text'>hanging out at the Caf&amp;#233; Napolitano</title>
+          <title type='text'>hanging out at the Caf&#233; Napolitano</title>
           <link rel='alternate'
                 type='text/html'
                 href='http://montague.lit/romeo/posts/1cb57d9c-1c46-11dd-838c-001143d5d5db'/>
@@ -272,7 +272,7 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
             <name>Romeo Montague</name>
             <uri>xmpp:romeo@montague.lit</uri>
           </author>
-          <title type='text'>hanging out at the Caf&amp;#233; Napolitano</title>
+          <title type='text'>hanging out at the Caf&#233; Napolitano</title>
           <link rel='alternate'
                 type='text/html'
                 href='http://montague.lit/benvolio/posts/1re57d3c-1q46-11dd-748r-024943d2d5rt'/>
@@ -319,7 +319,7 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
     <publish node='urn:xmpp:microblog:0'>
       <item id='2ze57d9c-1c46-21df-830c-002143d3d2qgf'>
         <entry xmlns='http://www.w3.org/2005/Atom'>
-          <title type='text'>hanging out at the Caf&amp;#233; Napolitano</title>
+          <title type='text'>hanging out at the Caf&#233; Napolitano</title>
           <link rel='replies'
                 title='comments'
                 href='xmpp:pubsub.montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0%3Acomments%2Fdd88c9bc58886fce0049ed050df0c5f2'/>
@@ -393,7 +393,7 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
     <publish node='urn:xmpp:microblog:0'>
       <item id='0'>
         <feed xmlns='http://www.w3.org/2005/Atom'>
-          <title>Romeo&amp;apos;s Microblog</title>
+          <title>Romeo&apos;s Microblog</title>
           <id>tag:montague.lit,2008:home</id>
           <updated>2008-05-08T18:30:02Z</updated>
           <author>


### PR DESCRIPTION
The double escaping would only be needed for [type='html'](https://datatracker.ietf.org/doc/html/rfc4287#section-3.1.1.2), not 'text' or 'xhtml'.  It even leaked outside Atom elements in one place. :)