### PR TITLE
Make XEP superseded more visible in HTML output

### DIFF
--- a/xep.xsl
+++ b/xep.xsl
@@ -271,6 +271,28 @@ content: "XEP-<xsl:value-of select='/xep/header/number'/>";
               <xsl:with-param name='thetype' select='/xep/header/type'/>
             </xsl:call-template>
           </dd>
+          <xsl:variable name='supersedes.count' select='count(/xep/header/supersedes/spec)'/>
+          <xsl:choose>
+            <xsl:when test='$supersedes.count &gt; 0'>
+              <dt>Supersedes</dt>
+              <dd>
+                <xsl:apply-templates select='/xep/header/supersedes/spec'>
+                  <xsl:with-param name='speccount' select='$supersedes.count'/>
+                </xsl:apply-templates>
+              </dd>
+            </xsl:when>
+          </xsl:choose>
+            <xsl:variable name='supersededby.count' select='count(/xep/header/supersededby/spec)'/>
+          <xsl:choose>
+            <xsl:when test='$supersededby.count &gt; 0'>
+              <dt>Superseded By</dt>
+              <dd>
+                <xsl:apply-templates select='/xep/header/supersededby/spec'>
+                  <xsl:with-param name='speccount' select='$supersededby.count'/>
+                </xsl:apply-templates>
+              </dd>
+            </xsl:when>
+          </xsl:choose>
           <dt>Type</dt>
           <dd><xsl:value-of select='/xep/header/type'/></dd>
           <dt>Version</dt>


### PR DESCRIPTION
When a XEP has been superseded (or supersedes something else) it's not
always immediately obvious in the HTML output. It exists at the bottom
of the page in the appendices, but this requires a lot of digging, and
in the status message, but this is a big red blob of text that we don't
expect to differ from XEP to XEP and is harder to parse through than the
information we want being in a table.

This adds the information to a third place, the table in the header to
make it accessible at a glance:

![A screenshot of the header for XEP-0411 showing a new row "Superseded By"](https://user-images.githubusercontent.com/512573/154710000-131131d3-b9b5-48f6-b803-41f8a2e75a57.png)
