### PR TITLE
XEP-0115: mention the pre-image attacks in the XEP

### DIFF
--- a/xep-0115.xml
+++ b/xep-0115.xml
@@ -602,7 +602,7 @@
       &ltwarning;
     </section2>
     <section2 topic='Caps Poisoning' anchor='security-poisoning'>
-      <p>Adherence to the method defined in the <link url='#ver'>Verification String</link> section of this document for both generation and processing of the 'ver' attribute helps to guard against poisoning of entity capabilities information by malicious or improperly implemented entities.</p>
+      <p>Adherence to the method defined in the <link url='#ver'>Verification String</link> section of this document for processing of the 'ver' attribute is known to be vulnerable to certain cache poisoning attacks that can not be fixed in a backwards compatible manner <note><link url="https://mail.jabber.org/pipermail/security/2009-July/000812.html">[Security] Trivial preimage attack against the entity capabilities protocol</link>.</note>.</p>
       <p>If the value of the 'ver' attribute is a verification string as defined herein (i.e., if the 'ver' attribute is not generated according to the <link url='#legacy'>Legacy Format</link>), inclusion of the 'hash' attribute is REQUIRED. Knowing explicitly that the value of the 'ver' attribute is a verification string enables the recipient to avoid spurious notification of invalid or poisoned hashes.</p>
     </section2>
     <section2 topic='Information Exposure' anchor='security-exposure'>


### PR DESCRIPTION
This XEP currently does not mention several [known vulnerabilities](https://mail.jabber.org/pipermail/security/2009-July/000812.html). The security considerations section even suggests that the algorithm protects against this kind of attack.

I am not sure what the best path forward here is, but if it had mentioned it I would have at least considered this when writing my initial implementation, even if it's still not visible enough. Other suggestions welcome, and I'd love to see the council discuss this again.