### PR TITLE
XEP-UDT (432): Declare dependency on XEP-0335

### DIFF
--- a/xep-0432.xml
+++ b/xep-0432.xml
@@ -19,6 +19,7 @@
   <sig>Standards</sig>
   <dependencies>
     <spec>XMPP Core</spec>
+    <spec>XEP-0335</spec>
   </dependencies>
   <supersedes/>
   <supersededby/>


### PR DESCRIPTION
UDT uses XEP-0335 as building block, so it should declare a dependency
on it.