### PR TITLE
XEP-0308: Correct `disco#info` example JIDs

### DIFF
--- a/xep-0308.xml
+++ b/xep-0308.xml
@@ -72,13 +72,14 @@
     <example caption='Client requests information about a chat partner&apos;s client'><![CDATA[
 <iq type='get'
     from='romeo@montague.net/orchard'
+    to='juliet@capulet.net/balcony'
     id='info1'>
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>]]></example>
     <example caption='Partner&apos;s client advertises support for correction'><![CDATA[
 <iq type='get'
-    to='romeo@montague.net/home'
-    from='montague.net'
+    to='romeo@montague.net/orchard'
+    from='juliet@capulet.net/balcony'
     id='info1'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
 ...


### PR DESCRIPTION
This commit corrects the JIDs provided in the query/response examples for XEP-0308,
specifically: the request example did not provide a valid `to` attribute, and the response
example did not have matching JIDs for the `from` and `to` attributes.