### PR TITLE
ProtoXEP: WebSocket S2S

### DIFF
--- a/inbox/websocket-s2s.xml
+++ b/inbox/websocket-s2s.xml
@@ -1,0 +1,69 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY % ents SYSTEM 'xep.ent'>
+%ents;
+]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+<header>
+  <title>WebSocket S2S</title>
+  <abstract>This specification defines a procedure to make s2s XMPP connections over WebSocket.</abstract>
+  &LEGALNOTICE;
+  <number>xxxx</number>
+  <status>ProtoXEP</status>
+  <type>Standards Track</type>
+  <sig>Standards</sig>
+  <approver>Council</approver>
+  <dependencies>
+    <spec>XMPP Core</spec>
+    <spec>XEP-0156</spec>
+  </dependencies>
+  <supersedes/>
+  <supersededby/>
+  <shortname>NOT_YET_ASSIGNED</shortname>
+  <author>
+    <firstname>Travis</firstname>
+    <surname>Burtrum</surname>
+    <email>travis@burtrum.org</email>
+    <jid>travis@burtrum.org</jid>
+  </author>
+  <revision>
+    <version>0.0.1</version>
+    <date>2022-06-13</date>
+    <initials>tjb</initials>
+    <remark><p>First draft.</p></remark>
+  </revision>
+</header>
+<section1 topic='Introduction' anchor='intro'>
+  <p>&rfc7395; specifies how to make c2s connections over WebSocket. This XEP extends that to also support s2s connections over WebSocket.</p>
+</section1>
+<section1 topic='Requirements' anchor='reqs'>
+    <p>Everything mentioned in &rfc7395; should be followed with the following changes:</p>
+    <ol>
+      <li>Connection details are discovered by using &xep0156;</li>
+      <li>For c2s, &rfc7395; requires replacing the 'jabber:client' namespace with 'urn:ietf:params:xml:ns:xmpp-framing', for s2s, the 'jabber:server' namespace should be replaced with 'urn:ietf:params:xml:ns:xmpp-framing-server'.</li>
+      <li>wss (TLS) upgraded to a MUST be used, therefore SASL EXTERNAL authentication can be used as defined in &xmppcore;</li>
+    </ol>
+</section1>
+<section1 topic='Use Cases' anchor='usecases'>
+  <p>Some hosting services only allow HTTPS proxies to access servers, meaning federating XMPP servers cannot be ran on these hosts unless s2s is accessible over HTTPS.</p>
+</section1>
+<section1 topic='Security Considerations' anchor='security'>
+  <p>Identical to <link url='https://datatracker.ietf.org/doc/html/rfc7395#page-12'>RFC 7395 Security Considerations</link>.</p>
+</section1>
+<section1 topic='IANA Considerations' anchor='iana'>
+
+ <p>A URN sub-namespace for framing of s2s Extensible Messaging and Presence
+   Protocol (XMPP) streams is defined as follows.</p>
+
+ <p>URI: urn:ietf:params:xml:ns:xmpp-framing-server</p>
+
+ <p>Specification: this document</p>
+
+ <p>Registrant Contact: IESG &lt;iesg@ietf.org&gt;</p>
+
+</section1>
+<section1 topic='XMPP Registrar Considerations' anchor='registrar'>
+  <p>This document requires no interaction with the &REGISTRAR;.</p>
+</section1>
+</xep>


### PR DESCRIPTION
Already have an open source working implementation [here](https://github.com/moparisthebest/xmpp-proxy) and it's running at MUC service at `xmpp:xmpp-proxy@code.moparisthe.best?join` if you would like to test your s2s implementation without running yourself.

I'm happy for you to hold off council voting on this until June 22nd so I can be around to answer questions, but if you feel like voting earlier that's fine with me too.