### PR TITLE
XEP-0405: Clarify behaviour on later roster gets without <annotate/>

### DIFF
--- a/xep-0405.xml
+++ b/xep-0405.xml
@@ -39,8 +39,14 @@
   &ksmithisode;
   &skille;
   <revision>
+    <version>0.5.3</version>
+    <date>2022-07-15</date>
+    <initials>lnj</initials>
+    <remark><p>Clarify that later roster requests reset the state of the annotation setting</p></remark>
+  </revision>
+  <revision>
     <version>0.5.2</version>
-    <date>2021-07-02</date>
+    <date>2022-07-02</date>
     <initials>lnj</initials>
     <remark><p>Fix wrong mix presence extension namespace in examples</p></remark>
   </revision>
@@ -547,6 +553,10 @@ This approach  enables flexible support of multiple clients for a MIX channel pa
 <p>
   Once a client has made an IQ request to return additional MIX information, the server MUST return this information on all subsequent roster updates that are sent by the server to the client.   The server MUST NOT send additional MIX information when this has not been explicitly requested.  It is anticipated that a client will fetch the roster after connection has been established and will set its preference for this MIX capability information at that time.
 </p>
+
+    <p>
+      Each later roster request resets the state of the MIX annotations.  If a roster request is missing the &lt;annotate/&gt; element, the server MUST stop sending the additional MIX information.
+    </p>
   </section2>
 
   <section2 topic="MAM Archive Support" anchor="usecase-mam">


### PR DESCRIPTION
Approved by XEP author: https://mail.jabber.org/pipermail/standards/2022-July/038898.html