### PR TITLE
XEP-0448: Encryption for stateless file sharing v0.2.0

### DIFF
--- a/xep-0448.xml
+++ b/xep-0448.xml
@@ -1,9 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!--
-Note to editor: Remove xep-sfs entity declared below and change all references from &xep-sfs; to respective &xepXXXX; to refeence sfs when moving to experimental.
--->
 <!DOCTYPE xep SYSTEM 'xep.dtd' [
-  <!ENTITY xep-sfs "<span class='ref'><link url='./sfs.html'>Stateless file sharing (XEP-xxxx)</link></span> <note>XEP-xxxx: Stateless file sharing &lt;<link url='./sfs.html'>https://xmpp.org/extensions/inbox/sfs.html</link>&gt;.</note>" >
   <!ENTITY % ents SYSTEM 'xep.ent'>
 %ents;
 ]>
@@ -11,7 +7,7 @@ Note to editor: Remove xep-sfs entity declared below and change all references f
 <xep>
 <header>
   <title>Encryption for stateless file sharing</title>
-  <abstract>This specification provides a protocol for sharing encrypted files using the stateless file sharing protocol (XEP-xxxx).</abstract>
+  <abstract>This specification provides a protocol for sharing encrypted files using the stateless file sharing protocol (XEP-0447).</abstract>
   &LEGALNOTICE;
   <number>0448</number>
   <status>Experimental</status>
@@ -21,12 +17,21 @@ Note to editor: Remove xep-sfs entity declared below and change all references f
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0001</spec>
-    <spec>XEP-xxxx</spec>
+    <spec>XEP-0447</spec>
   </dependencies>
   <supersedes/>
   <supersededby/>
   <shortname>esfs</shortname>
   &larma;
+  <revision>
+    <version>0.2.0</version>
+    <date>2022-07-17</date>
+    <initials>lmw</initials>
+    <remark><ul>
+      <li>Replace the ProtoXEP reference with a reference to the published XEP.</li>
+      <li>Add urn:xmpp:ciphers:aes-256-cbc-pkcs7:0 (same as used in XEP-0384).</li>
+    </ul></remark>
+  </revision>
   <revision>
     <version>0.1.0</version>
     <date>2020-11-24</date>
@@ -47,10 +52,10 @@ Note to editor: Remove xep-sfs entity declared below and change all references f
     &xep0343; and &xep0391; specify protocols for establishing an encrypted transport using Jingle to share files using &xep0234;.
   </p>
   <p>
-    &xep-sfs; describes a protocol that can be used to share files, previously uploaded using &xep0363;, but lacks means of encrypting files.
+    &xep0447; describes a protocol that can be used to share files, previously uploaded using &xep0363;, but lacks means of encrypting files.
     This leaves files uploaded using &xep0363; without any standardized means of encrypting them.
   </p>
-  <p>This XEP describes a protocol building on top of &xep-sfs; to allow encrypting files.</p>
+  <p>This XEP describes a protocol building on top of &xep0447; to allow encrypting files.</p>
 </section1>
 <section1 topic='Requirements' anchor='reqs'>
   <ul>
@@ -71,11 +76,11 @@ Note to editor: Remove xep-sfs entity declared below and change all references f
       Before sharing the file, the sending entity MUST create random symmetric private key and initialization vector (IV) as required by the selected encryption cipher (see <link url='#ciphers'>Ciphers</link>). The file is then encrypted using selected encryption cipher and the generated key and IV. After this it can be uploaded using &xep0363; or prepared for any other means of file sharing.
     </p>
     <p>
-      The file is then shared using the protocol described in &xep-sfs;.
+      The file is then shared using the protocol described in &xep0447;.
       The <tt>&lt;file/&gt;</tt> metadata element still refers to the original file, i.e. it describes the original file name, size and hashes. The <tt>&lt;size/&gt;</tt> element and one or multiple <tt>&lt;hash/&gt;</tt> elements are REQUIRED when sending encrypted files.
     </p>
     <p>
-      For the encrypted file, a source is added as an <tt>&lt;encrypted/&gt;</tt> element to the <tt>&lt;sources/&gt;</tt>. It carries an attribute <tt>cipher</tt> with the namespace of the encryption cipher being used. The <tt>&lt;encrypted/&gt;</tt> element contains a <tt>&lt;key/&gt;</tt> and an <tt>&lt;iv/&gt;</tt> element, containing both values as Base64-encoded strings. The <tt>&lt;encrypted/&gt;</tt> element MAY also include <tt>&lt;hash/&gt;</tt> elements as described in &xep0300;, referring to the hash of the encrypted file. At last, the <tt>&lt;encrypted/&gt;</tt> element also includes another <tt>&lt;sources/&gt;</tt> element as described in &xep-sfs;, specifying sources to obtain the encrypted file.
+      For the encrypted file, a source is added as an <tt>&lt;encrypted/&gt;</tt> element to the <tt>&lt;sources/&gt;</tt>. It carries an attribute <tt>cipher</tt> with the namespace of the encryption cipher being used. The <tt>&lt;encrypted/&gt;</tt> element contains a <tt>&lt;key/&gt;</tt> and an <tt>&lt;iv/&gt;</tt> element, containing both values as Base64-encoded strings. The <tt>&lt;encrypted/&gt;</tt> element MAY also include <tt>&lt;hash/&gt;</tt> elements as described in &xep0300;, referring to the hash of the encrypted file. At last, the <tt>&lt;encrypted/&gt;</tt> element also includes another <tt>&lt;sources/&gt;</tt> element as described in &xep0447;, specifying sources to obtain the encrypted file.
       The outer <tt>&lt;sources/&gt;</tt> may contain additional sources that directly allow for end-to-end encrypted file transfers, for example &xep0234; using &xep0391;.
     </p>
     <example caption='Sharing summit.jpg with juliet@shakespeare.lit using encryption'><![CDATA[
@@ -110,7 +115,7 @@ Note to editor: Remove xep-sfs entity declared below and change all references f
 ]]></example>
   </section2>
   <section2 topic='Receiving a file' anchor='file-receive'>
-    <p>On receive of a message including a <tt>&lt;file-sharing/&gt;</tt> element, that has an <tt>&lt;encrypted/&gt;</tt> element in its sources, normal processing as described in &xep-sfs; applies.</p>
+    <p>On receive of a message including a <tt>&lt;file-sharing/&gt;</tt> element, that has an <tt>&lt;encrypted/&gt;</tt> element in its sources, normal processing as described in &xep0447; applies.</p>
     <p>
       When the receiving entity tries to obtain the file from the source described by the <tt>&lt;encrypted/&gt;</tt> element, it will try to obtain any of its inner sources instead.
       On success, it decrypts the obtained file using the encryption cipher, private key and IV provided.
@@ -119,7 +124,7 @@ Note to editor: Remove xep-sfs entity declared below and change all references f
   </section2>
   <section2 topic='Attaching a source' anchor='attach-source'>
     <p>
-      The protocol to attach a source described in &xep-sfs; can also be used to attach encrypted sources.
+      The protocol to attach a source described in &xep0447; can also be used to attach encrypted sources.
       After receiving a file using encrypted means, it is RECOMMENDED to only attach additional sources that support encryption.
     </p>
   </section2>
@@ -145,6 +150,12 @@ Note to editor: Remove xep-sfs entity declared below and change all references f
       <td>AES</td>
       <td>Key: 256, IV: 96</td>
       <td>GCM/NoPadding</td>
+    </tr>
+    <tr>
+      <td>urn:xmpp:ciphers:aes-256-cbc-pkcs7:0</td>
+      <td>AES</td>
+      <td>Key: 256, IV: 128</td>
+      <td>CBC/PKCS#7</td>
     </tr>
   </table>
   <p>For compatibility reasons, it is RECOMMENDED to append the GCM authentication tag to the uploaded file when using any AES cipher with GCM. The GCM authentication tag is not needed when using the protocol described in this document as a hash of the resulting file is transported independently.</p>


### PR DESCRIPTION
- Replace the ProtoXEP reference with a reference to the published XEP.
- Add urn:xmpp:ciphers:aes-256-cbc-pkcs7:0 (same as used in XEP-0384).