### PR TITLE
Update ProtoXEP: Pubsub Attachments

### DIFF
--- a/inbox/pubsub-attachments.xml
+++ b/inbox/pubsub-attachments.xml
@@ -29,6 +29,12 @@
     <jid>goffi@jabber.fr</jid>
   </author>
   <revision>
+    <version>0.0.2</version>
+    <date>2022-07-11</date>
+    <initials>jp</initials>
+    <remark><p>Update reactions to be similar to &xep0444;</p></remark>
+  </revision>
+  <revision>
     <version>0.0.1</version>
     <date>2022-07-11</date>
     <initials>jp</initials>
@@ -56,7 +62,7 @@
       <li>handle uniqueness of attachment per JID</li>
       <li>have an extensible mechanism for future use</li>
       <li>re-use pubsub subscription and access control mechanism</li>
-      <li>suitable to implement feature similar to commonly seen "like/favourite" and "reaction".</li>
+      <li>suitable to implement feature similar to commonly seen "like/favourite" and "reactions".</li>
       <li>optionally have a way to "group" or "summarize" informations: get a summary of all attachment without needing to retrieve each of them individually.</li>
   </ul>
   <p>To facilitate the bootstrapping of this XEP, it is also designed to work in a basic way with generic pubsub service. However, some implementation work is necessary to offer the full potential of the XEP (and notably to be able to scale).</p>
@@ -64,7 +70,7 @@
 <section1 topic='Glossary' anchor='glossary'>
     <ul>
         <li><strong>like/favourite</strong>: a common way to indicate interest in item</li>
-        <li><strong>reaction</strong>: attaching one or more emoji(s) to an item</li>
+        <li><strong>reactions</strong>: attaching one or more emoji(s) to an item</li>
         <li><strong>attachment node</strong>: node where attached data of an item are published</li>
         <li><strong>summary node</strong>: node managed by pubsub service which keep a summary of all attachment of target items</li>
         <li><strong>target item</strong>: item to which metadata is attached</li>
@@ -105,7 +111,10 @@
       <item id='romeo@montague.lit'>
         <attachments>
           <noticed timestamp="2022-07-11T12:07:24Z" />
-          <reaction timestamp="2022-07-11T12:07:48Z">👷🔨</reaction>
+          <reactions timestamp="2022-07-11T12:07:48Z">
+            <reaction>👷</reaction>
+            <reaction>🔨</reaction>
+          </reactions>
         </attachments>
       </item>
     </publish>
@@ -124,9 +133,9 @@
         <p>This node SHOULD have the same access model than the target node.</p>
         <p>To publish to this node, an entity MUST use its own bare JID for the ID of the item. It is both to keep the uniqueness of the item per JID and to make the retrieval of attachment for a particular entity easy.</p>
         <p>The entity willing to publish attachment tries directly to publish to the above mentioned node. If the node doesn't exist (and is not created on the fly by the pubsub service, see below), the pubsub service SHOULD answer with &lt;item-not-found&gt; error as explained in <link url="https://xmpp.org/extensions/xep-0060.html#publisher-publish-error-node">XEP-0060 §7.1.3.3 Node Does Not Exist</link>. If the node doesn't not exist, that means that it's not possible to attach metadata to the target item, the entity willing to publish the attachment MUST NOT try to create the node itself (that would result in wrong ownership of the node).</p>
-        <p>An attachment payload is build with a top level &lt;attachments&gt; element which has zero, one or more child elements. This specification defines 2 child elements, &lt;noticed&gt; and &lt;reaction&gt;, but future XEPs may add their own elements qualified by their own namespaces to extend the functionalities. Each child element MAY have an optional 'timestamp' attribute indicating when the element has been attached. The value of this attribute is a DateTime as specified in &xep0082;.</p>
+        <p>An attachment payload is build with a top level &lt;attachments&gt; element which has zero, one or more child elements. This specification defines 2 child elements, &lt;noticed&gt; and &lt;reactions&gt;, but future XEPs may add their own elements qualified by their own namespaces to extend the functionalities. Each child element MAY have an optional 'timestamp' attribute indicating when the element has been attached. The value of this attribute is a DateTime as specified in &xep0082;.</p>
         <p>Because there is one item per JID; to update, add or remove attachments an entity simply re-publish an item on the same node with its bare JID as ID. It is the responsibility of the publishing entity to republish all previously existing attachments (except those who need to be removed). If an XMPP client doesn't know a specific attachment, it MUST keep it and republish it when updating attachments.</p>
-        <p>All attachments of a specific JID can be deleted at once by retracting the item as specified at <link url="https://xmpp.org/extensions/xep-0060.html#publisher-delete">XEP-0060 §7.2 Delete an Item from a Node</link>. A client SHOULD not retract an attachment item if there are attachments it doesn't know, instead it SHOULD publish a new attachment item without the attachments which must be removed, and with the unknown attachments left in place.</p>
+        <p>All attachments of a specific JID can be deleted at once by retracting the item as specified at <link url="https://xmpp.org/extensions/xep-0060.html#publisher-delete">XEP-0060 §7.2 Delete an Item from a Node</link>. A client SHOULD NOT retract an attachment item if there are attachments it doesn't know, instead it SHOULD publish a new attachment item without the attachments which must be removed, and with the unknown attachments left in place.</p>
       </section3> 
     </section2>
 
@@ -139,7 +148,7 @@
         <li>forbid manual creation of attachment or summary node</li>
         <li>check validity of items published to attachment node, and notably the item ID</li>
         <li>create and maintain a summary node</li>
-        <li>handle &lt;noticed&gt; and &lt;reaction&gt; attachments</li>
+        <li>handle &lt;noticed&gt; and &lt;reactions&gt; attachments</li>
       </ul>
     </section2>
 
@@ -173,7 +182,7 @@
         <li>the <strong>name of the target node</strong></li>
       </ol>
       <p>Thus in the initial example, for the blog of Juliet, the summary node name would be 'urn:xmpp:pubsub-attachments:summary:0/urn:xmpp:microblog:0' and it would be located at the PEP service juliet@capulet.lit.</p>
-      <p>For each item of the target node which has attachments, the summary node MUST contain an item which MUST have the same ID. This item contain a &lt;summary&gt; element qualified with the namespace 'urn:xmpp:pubsub-attachments:summary:0'. This item has elements with names matching attachments elements names, and a summary data which depend of the attachment. This specifications explain below how to summarize &lt;noticed&gt; and &lt;reaction&gt; attachments, it is the up to other XEPs specifying other features to explain how to summarize their own attachments. If a service doesn't know how to summarize an attachment, it SHOULD ignore it.</p>
+      <p>For each item of the target node which has attachments, the summary node MUST contain an item which MUST have the same ID. This item contain a &lt;summary&gt; element qualified with the namespace 'urn:xmpp:pubsub-attachments:summary:0'. This item has elements with names matching attachments elements names, and a summary data which depend of the attachment. This specifications explain below how to summarize &lt;noticed&gt; and &lt;reactions&gt; attachments, it is the up to other XEPs specifying other features to explain how to summarize their own attachments. If a service doesn't know how to summarize an attachment, it SHOULD ignore it.</p>
       <p>If a target item has no attachment at all, or if all attachments have been removed, the node MAY either return an &lt;item-not-found&gt; error, or an empty &lt;summary&gt; element, whatever is simpler for the service implementation.</p>
       <p>Summary node subscriptions are working as for normal pubsub nodes: when a new attachment is published, resulting in the corresponding summary item updated, an event is sent with the new item to every subscribers.</p>
   <example caption="Romeo Check Summary of Attachments of Juliet Blog"><![CDATA[
@@ -196,10 +205,12 @@
         <item id='balcony-restoration-afd1'>
           <summary xmlns='urn:xmpp:pubsub-attachments:summary:0'>
             <noticed count="5" />
-            <reaction >
-              <multiple count="2">👷</multiple>
-                🔨🔧🚧
-            </reaction>
+            <reactions>
+              <reaction count="2">👷</reaction>
+	      <reaction>🔨</reaction>
+	      <reaction>🔧</reaction>
+	      <reaction>🚧</reaction>
+            </reactions>
           </summary>
         </item>
         <!-- ... -->
@@ -252,17 +263,17 @@
 
     </section2>
 
-    <section2 topic="Reaction Attachment" anchor="reaction">
-      <section3 topic="Attachment Overview" anchor="reaction_overview">
-        <p>&lt;reaction&gt; element lets an entity attach various emojis to an item. Emojis are simply put in the content of a &lt;reaction&gt; element, and a client MUST ensure that any given emoji only appears once at most. A for any attachment, a "timestamp" attribute may be set with the DateTime of latest publication.</p>
+    <section2 topic="Reactions Attachment" anchor="reactions">
+      <section3 topic="Attachment Overview" anchor="reactions_overview">
+        <p>&lt;reactions&gt; element lets an entity attach various emojis to an item. Each emoji is put as the content of a single &lt;reaction&gt; element, and a client SHOULD ensure that any &lt;reaction&gt; element only appears once at most. As for any attachment, a "timestamp" attribute may be set with the DateTime of latest publication to the root &lt;reactions&gt; element. The protocol is similar to &xep0444; which is used for &MESSAGE; stanza.</p>
 
 
       </section3>
-      <section3 topic="Summarizing" anchor="reaction_summarizing">
-        <p>To summarize &lt;reaction&gt; attachments, a fully-compliant pubsub service counts how many times each emoji is attached, ignoring duplicate from the same JID if any. If an emoji only appears once, it is simply put in the content of the &lt;reaction&gt;, however if it appears several times, it must be put in a &lt;multiple&gt; child element which MUST have a "count" attribute with the number of times that the emoji appears as value.</p>
+      <section3 topic="Summarizing" anchor="reactions_summarizing">
+        <p>To summarize &lt;reactions&gt; attachments, a fully-compliant pubsub service counts how many times each emoji is attached, ignoring duplicate from the same JID if any. If an emoji appears multiple times (from distinct bare JIDs), a 'count' attribute MUST be added to the &lt;reaction&gt; element with the number of time this reaction appear in all reactions as a value (if the same reaction appears several times for a single bare JID, it MUST be counted only once).</p>
         <p>In following example, all emojis are attached only once to the item, except the woman dancing one which appears 22 times and the ballet shoes one which appears twice.</p>
 
-  <example caption="Example of reaction Attachment Summary"><![CDATA[
+  <example caption="Example of reactions Attachment Summary"><![CDATA[
   <iq from='pubsub.example.net'
     id='attachment_5'
     to='juliet@capulet.lit/123'
@@ -271,11 +282,13 @@
       <items node='urn:xmpp:pubsub-attachments:summary:0/urn:xmpp:example:0'>
         <item id='ball-event-ab1e'>
           <summary xmlns='urn:xmpp:pubsub-attachments:summary:0'>
-            <reaction >
-              <multiple count="22">💃</multiple>
-              <multiple count="2">🩰</multiple>
-                🎉🥳🎈
-            </reaction>
+            <reactions>
+              <reaction count="22">💃</reaction>
+              <reaction count="2">🩰</reaction>
+	      <reaction>🎉</reaction>
+	      <reaction>🥳</reaction>
+	      <reaction>🎈</reaction>
+            </reactions>
           </summary>
         </item>
       </items>
@@ -290,7 +303,18 @@
 <section1 topic='Business Rules' anchor='rules'>
   <ul>
     <li>Similarly to "like" in commercial software, the "noticed" attachment can be used to analyse user's tastes, political view, religious beliefs, sexual orientation, etc. It is recommended that implementers post a prominent notice warning users of potential abuses.</li>
-    <li>Emoji pictures may differ widely on various platforms where they are displayed. This has already led to misunderstanding of reactions, as a slightly different picture can be interpreted in a completely different way from what the reaction author meant. Here again, a prominent notice in implementations warning user is recommended.</li>
+    <li>Emoji pictures may differ widely on various platforms where they are displayed. This has already led to misunderstanding of reactions, as a slightly different picture can be interpreted in a completely different way from what the reactions author meant. Here again, a prominent notice in implementations warning user is recommended.</li>
+    <li>As "reactions" attachment is similar to &xep0444; which is used for &MESSAGE; stanza, non &MESSAGE; related <link url="https://xmpp.org/extensions/xep-0444.html#rules">business rules from there</link> apply for this attachment too. Notably:
+    <p>
+      <em>
+        A &lt;reaction&gt; element SHOULD only contain Unicode codepoints that
+        can be displayed as a single emoji, as specified in the latest revision
+        of the <link url="http://www.unicode.org/reports/tr51/">Unicode Technical Standard #51</link> <note>Unicode Technical Standard #51 &lt;<link url="http://www.unicode.org/reports/tr51/">http://www.unicode.org/reports/tr51/</link>&gt;.</note>.
+    Receiving entities MAY ignore &lt;reaction&gt; elements that do not comply
+    with this specification.
+      </em>
+    </p>
+  </li>
   </ul>
 </section1>
 


### PR DESCRIPTION
Update reactions to be similar to XEP-0444.
No namespace bump as this is updated before council review to eventually
become an official XEP, and there are no implementation yet in the wild.