### PR TITLE
XEP-0231: clarify where to find hash algo names

### DIFF
--- a/xep-0231.xml
+++ b/xep-0231.xml
@@ -31,6 +31,12 @@
   &stpeter;
   &pavlix;
   <revision>
+    <version>1.1</version>
+    <date>2022-07-25</date>
+    <initials>ssw</initials>
+    <remark><p>Mention where to get textual names of hash functions.</p></remark>
+  </revision>
+  <revision>
     <version>1.0</version>
     <date>2008-09-03</date>
     <initials>psa</initials>
@@ -210,7 +216,7 @@
       </tr>
       <tr>
         <td>cid</td>
-        <td>A Content-ID that can be mapped to a cid: URL as specified in &rfc2111;. The 'cid' value SHOULD be of the form algo+hash@bob.xmpp.org, where the "algo" is the hashing algorithm used (e.g., "sha1" for the SHA-1 algorithm as specified in &rfc3174;) and the "hash" is the hex output of the algorithm applied to the binary data itself.</td>
+        <td>A Content-ID that can be mapped to a cid: URL as specified in &rfc2111;. The 'cid' value SHOULD be of the form algo+hash@bob.xmpp.org, where the "algo" is the hashing algorithm used (e.g., "sha1" for the SHA-1 algorithm as specified in &rfc3174;, for more information see the next section) and the "hash" is the hex output of the algorithm applied to the binary data itself.</td>
         <td>REQUIRED</td>
       </tr>
       <tr>
@@ -238,6 +244,15 @@
   vr4MkhoXe0rZigAAAABJRU5ErkJggg==
 </data>
 ]]></example>
+  </section2>
+
+  <section2 topic='Algorithm Names' anchor='algo'>
+    <p>
+      The value of the 'algo' parameter MUST be one of the values from the
+      &ianahashes; maintained by &IANA;, or one of the values
+      defined in &xep0300; unless the hash is SHA-1 in which case the label
+      "sha1" MUST be used for historical reasons.
+    </p>
   </section2>
 
 </section1>


### PR DESCRIPTION
This is a suggestion for where we can find hash names. Sadly, the existing name "sha1" does not match what other XEPs use ("sha-1"), so we make a special exception for historical reasons. This inconsistency can be fixed up in a future protocol.

Alternatively, we could say that only "sha1" is supported unless support for a new namespace, `urn:xmpp:bob#extended` or similar is advertised, but this seems like a lot of work on client devs when "just treat this like a special case and define new hash algorithms" probably doesn't require any more work at all if they didn't already support something that was previously unspecified like "sha256".