### PR TITLE
XEP-0004: clarify rules for multi-item forms

### DIFF
--- a/xep-0004.xml
+++ b/xep-0004.xml
@@ -28,6 +28,12 @@
     &temas;
     &stpeter;
     <revision>
+      <version>2.13.1</version>
+      <date>2022-07-25</date>
+      <initials>ssw</initials>
+      <remark><p>Clarify elements allowed in multi-item data forms</p></remark>
+    </revision>
+    <revision>
       <version>2.13.0</version>
       <date>2022-01-21</date>
       <initials>melvo</initials>
@@ -318,9 +324,10 @@
       <li>One and only one &lt;reported/&gt; element, which can be understood as a "table header" describing the data to follow.</li>
       <li>Zero or more &lt;item/&gt; elements, which can be understood as "table cells" containing data (if any) that matches the request.</li>
     </ol>
-	<p>The &lt;reported/&gt; element MUST appear before any &lt;item/&gt; element inside the &lt;x/&gt; element.</p>
+  <p>The &lt;reported/&gt; element MUST appear before any &lt;item/&gt; element inside the &lt;x/&gt; element. Forms of this type MUST NOT contain any top-level fields other than &lt;reported/&gt; and &lt;item/&gt;.</p>
   <p class="box info">
     Older revisions of this XEP (before 2.12.0) did not contain an explicit requirement for the ordering between &lt;reported&gt; and &lt;item&gt;. Implementations are therefore encouraged to be flexible when processing incoming data, as there might still be implementations which do not implement a strict ordering when generating reports.
+    Similarly, revisions of this XEP before 2.13.1 were ambiguous about whether &lt;reported/&gt; and &lt;item/&gt; elements could co-exist with other top level elements such as &lt;field/&gt; and &lt;title/&gt; and various implementations are known to have handled this in different ways.
   </p>
     <p>The syntax is as follows:</p>
     <code><![CDATA[


### PR DESCRIPTION
After a discussion on the mailing list a few days ago no conclusion was reached other than "multi-item forms are confusing". I believe this was likely the original intent of the section, and it's likely the simplest solution for now so I've gone ahead and made changes to disallow elements other than "reported" and "items" in multi-item forms. Users who want to mix and match should write a new XEP defining a new field type such as "table" that can contain other fields.