### PR TITLE
XEP-0272: Release version 0.1.2

### DIFF
--- a/xep-0272.xml
+++ b/xep-0272.xml
@@ -38,6 +38,12 @@
     <jid>dafydd.harries@collabora.co.uk</jid>
   </author>
   <revision>
+    <version>0.1.2</version>
+    <date>2022-08-06</date>
+    <initials>melvo</initials>
+    <remark>Fix typos / grammar / examples and use 'Muji' instead of 'muji' consistently</remark>
+  </revision>
+  <revision>
     <version>0.1.1</version>
     <date>2018-11-03</date>
     <initials>pep</initials>
@@ -92,9 +98,9 @@
 <section1 topic='Joining a Conference' anchor='joining'>
   <p>
     Joining a conference is done in two stages. The first step is to
-    declare that preparations are being done to either join or start a muji
+    declare that preparations are being done to either join or start a Muji
     session inside the MUC. This is indicated by the client sending a presence
-    stanza to the MUC with a preparing element in muji section.
+    stanza to the MUC with a preparing element in the Muji section.
   </p>
 
   <code><![CDATA[
@@ -125,7 +131,7 @@
     ver="48QdBuXRCJFb8qIzgy1FOHSGO0U="
     hash="sha-1" />
   <muji xmlns='http://telepathy.freedesktop.org/muji'>
-    <content name='video'>
+    <content creator='initiator' name='video'>
       <description xmlns='urn:xmpp:jingle:apps:rtp:0' media='video'>
         <payload-type id='97' name='theora' clockrate='90000'/>
       </description>
@@ -144,7 +150,7 @@
   When a client adds a payload ID to a content description, it MUST have the
   same codec name and receiving parameters as the corresponding entries in
   other participants' payload maps for that content. For instance, if Alice
-  defines a payload type with ID 98, codec Speex and a a clock rate of 8000
+  defines a payload type with ID 98, codec Speex and a clock rate of 8000
   for a content called “voice0”, then Bob must define payload type 98
   identically or not at all for that content.
   </p>
@@ -187,8 +193,8 @@
 
 <section1 topic='Adding a Content Type' anchor='addcontent'>
   <p>
-    Adding a stream follows a process similar to the joining a conference. As a
-    first step an updated presence stanza MUST be send which contains a
+    Adding a stream follows a process similar to the joining of a conference. As a
+    first step, an updated presence stanza MUST be sent which contains a
     preparing element as part of the Muji section.
   </p>
 
@@ -218,7 +224,7 @@
   </p>
 
   <p>
-    Afterwards the client should add the new content to the muji section of its
+    Afterwards the client should add the new content to the Muji section of its
     presence and add the content to all the Jingle sessions it had with
     participants it shared the content with.
   </p>
@@ -231,7 +237,7 @@
         ver="48QdBuXRCJFb8qIzgy1FOHSGO0U="
         hash="sha-1" />
       <muji xmlns='http://telepathy.freedesktop.org/muji'>
-        <content name='video'>
+        <content creator='initiator' name='video'>
           <description xmlns='urn:xmpp:jingle:apps:rtp:0' media='video'>
             <payload-type id='97' name='theora' clockrate='90000'/>
           </description>
@@ -249,8 +255,8 @@
 
 <section1 topic='Removing a Content Type' anchor='removecontent'>
   <p>
-  To remove a content type the participant SHOULD first sent an updated presence
-  without the content in its muji section. Afterwards it MUST the content from
+  To remove a content type, the participant SHOULD first send an updated presence
+  without the content in its Muji section. Afterwards, it MUST remove the content from
   all the Jingle sessions it has open.
   </p>
 </section1>


### PR DESCRIPTION
Fix typos / grammar / examples and use 'Muji' instead of 'muji' consistently