### PR TITLE
XEP-0294: Release version 1.1.2

### DIFF
--- a/xep-0294.xml
+++ b/xep-0294.xml
@@ -34,6 +34,12 @@
     <jid>olivier.crete@collabora.co.uk</jid>
   </author>
   <revision>
+    <version>1.1.2</version>
+    <date>2022-08-27</date>
+    <initials>melvo</initials>
+    <remark>Fix example description and attribute name of 'parameter' element as specified by XML schema</remark>
+  </revision>
+  <revision>
     <version>1.1.1</version>
     <date>2021-10-23</date>
     <initials>egp</initials>
@@ -122,7 +128,7 @@
 
   <p>Any type of RTP Header Extension that requires extra
   parameters in the a=b form can embed &lt;parameter/&gt; elements to
-  describe it. Any other form of parameter can be stored as the 'key' attribute in a parameter element with an empty value.</p>
+  describe it. Any other form of parameter can be stored as the 'name' attribute in a parameter element with an empty value.</p>
 
   <p>This specification defines a new element, &lt;extmap-allow-mixed/&gt;,
   that can be inserted in the &lt;description/&gt; element of a
@@ -211,7 +217,7 @@
   defined in <cite>RFC 8285</cite>. Note that a session-level line might need to be mapped
   to all &lt;description/&gt; elements.</p>
 
-  <p>Example conversion of a incomplete sample fragment of a SDP taken from <cite>RFC 8285</cite> section 7 into equivalent XMPP:</p>
+  <p>Example conversion of an incomplete SDP sample fragment taken from <cite>RFC 8285</cite> section 7 into equivalent XMPP:</p>
 <example caption='SDP fragment'><![CDATA[
 m=video
 a=sendrecv


### PR DESCRIPTION
Fix example description and attribute name of 'parameter' element as specified by XML schema