### PR TITLE
XEP-0029: Use RFC 7622 instead of RFC 6122 to supersede

### DIFF
--- a/xep-0029.xml
+++ b/xep-0029.xml
@@ -7,7 +7,7 @@
 <xep>
     <header>
         <title>Definition of Jabber Identifiers (JIDs)</title>
-        <abstract>Note well: this document was superseded by RFC 3920, which in turn has been superseded by RFC 6122. This document defines the exact nature of a Jabber Identifier (JID).</abstract>
+        <abstract>Note well: this document was superseded by RFC 3920 and RFC 6122, which in turn have been superseded by RFC 7622. This document defines the exact nature of a Jabber Identifier (JID).</abstract>
         &LEGALNOTICE;
         <number>0029</number>
         <status>Retracted</status>
@@ -15,7 +15,7 @@
         <sig>Standards</sig>
         <dependencies/>
         <supersedes/>
-        <supersededby><spec>RFC 6122</spec></supersededby>
+        <supersededby><spec>RFC 7622</spec></supersededby>
         <shortname>N/A</shortname>
         <author>
             <firstname>Craig</firstname>
@@ -51,7 +51,7 @@
         </revision>
     </header>
     <section1 topic='Introduction'>
-        <p class='box'>Note: This document was superseded by &rfc3920;, which in turn has been superseded by &rfc6122;.</p>
+        <p class='box'>Note: This document was superseded by &rfc3920; and &rfc6122;, which in turn have been superseded by &rfc7622;.</p>
         <p>Jabber Identifiers (JIDs) uniquely identify individual entities in the Jabber network. To date, their syntax has been defined by convention, existing implementations, and available documentation. As it exists, certain characters that are allowed in JIDs cause ambiguity, and the lack of a size limit on resources defies database schemas and causes some trivial JID operations to require dynamic memory allocation. This document seeks to both define and improve the existing JID syntax. This document will not explain the general usage or nature of JIDs, instead focusing on syntax.</p>
     </section1>
     <section1 topic='JIDs'>


### PR DESCRIPTION
RFC 7622 obsoletes RFC 6122. It stands to reason that XEPs that are marked as being superseded by the former should be updated to be superseded by the latter.