### PR TITLE
Revert "Add license for bibliographic data"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,11 +76,8 @@ inbox-xml: $(OUTDIR)/inbox $(proto_xep_xmls)
 .PHONY: pdf
 pdf: $(xep_pdfs)
 
-$(REFSDIR)/LICENSE: refs-LICENSE
-	cp $< $@
-
 .PHONY: refs
-refs: $(xep_refs) $(REFSDIR)/LICENSE
+refs: $(xep_refs)
 
 .PHONY: examples
 examples: $(xep_examples)

--- a/refs-LICENSE
+++ b/refs-LICENSE
@@ -1,9 +1,0 @@
-To the extent possible under law, the XMPP Standards Foundation (XSF)
-has waived all copyright and related or neighboring rights to XSF's
-bibliographic data.
-
-That is, the bibliographic data, which is also accessible via
-https://xmpp.org/extensions/refs/, is put in the public domain via
-CC0 1.0 [1].
-
-1: https://creativecommons.org/publicdomain/zero/1.0/


### PR DESCRIPTION
Reverts xsf/xeps#1220

It breaks the docker build and I don't have the time to investigate it right now.