### PR TITLE
Pubsub Targeted Encryption: Fix wording and typos

### DIFF
--- a/inbox/pubsub-targeted-encryption.xml
+++ b/inbox/pubsub-targeted-encryption.xml
@@ -42,14 +42,14 @@
   <p>This is fine for most use cases, however it may be desirable to only encrypt a few items with properties such as Perfect Forward Secrecy. This specification describes a way on how to do that by adapting existing end-to-end encryption algorithms used in instant messaging to pubsub items. This may be used to implement restricted items (a feature known is some other software such as "aspects" or "circles") or for transient nodes.</p>
 </section1>
 <section1 topic='Requirements' anchor='reqs'>
-  <p>The design goal of this specification is do adapt simply existing e2e encryption algorithms used for messages to pubsub items.</p>
+  <p>The design goal of this specification is to simply adapt existing e2e encryption algorithms used for messages to pubsub items.</p>
 </section1>
 <section1 topic='Use Cases' anchor='usecases'>
 
   <section2 topic='Encrypting a Pubsub Item' anchor='encrypt'>
-    <p>Juliet holds a public blog using &xep0277;. However, she wants to publish a new items that should be visible only to some well targeted users. To do so she encrypt the payload in the same way as she encrypt messages with algorithm such as &xep0384;. She wrap the encrypted payload in an &lt;encrypted/&gt; element qualified by the 'urn:xmpp:pte:0' namespace which MUST have a 'by' attribute with its own bare jid as value, and which MUST have a 'type' attribute whose value is the namespace of the algorithm used.</p>
-    <p>She decides to use &xep0384; to encrypt her items, her client publish an item like this:</p>
-    <example caption="Juliet Publish a Targeted Encrypted Item"><![CDATA[
+    <p>Juliet holds a public blog using &xep0277;. However, she wants to publish a new items that should be visible only to some well targeted users. To do so she encrypts the payload in the same way as she encrypts messages with an e2e encryption algorithm such as &xep0384;. She wraps the encrypted payload in an &lt;encrypted/&gt; element qualified by the 'urn:xmpp:pte:0' namespace which MUST have a 'by' attribute with her own bare jid as value, and which MUST have a 'type' attribute whose value is the namespace of the algorithm used.</p>
+    <p>She decides to use &xep0384; to encrypt her items, her client publishes an item like this:</p>
+    <example caption="Juliet Publishes a Targeted Encrypted Item"><![CDATA[
 <iq xmlns="jabber:client" id="pte_1" type="set" from="juliet@capulet.lit/chamber" to="juliet@capulet.lit">
   <pubsub xmlns="http://jabber.org/protocol/pubsub">
     <items node="urn:xmpp:microblog:0">
@@ -74,11 +74,11 @@
 </section1>
 
 <section1 topic='Business Rules' anchor='rules'>
-  <p>The properties of the encryption algorithm applies. For instance in the case of &xep0384;, there Perfect Forward Secrecy, meaning that once an item has been decrypted once by a targeted entity, it can't be decrypted anymore. Client shoud then handle pubsub caching of the decrypted item when necessary.</p>
+  <p>The properties of the encryption algorithm apply. For instance, in the case of &xep0384;, there is the propery of Perfect Forward Secrecy, meaning that once an item has been decrypted once by a targeted entity, it can't be decrypted anymore. Clients should then handle pubsub caching of the decrypted item when necessary.</p>
 </section1>
 
 <section1 topic='Discovering Support' anchor='disco'>
-  <p>If a client supports the protocol specified in this XEP, it MUST advertise it by including the "urn:xmpp:pte:0" discovery feature in response to a &xep0030; information request, Then the supported encryption algorithms are announced as explained in their respective XEPs.</p>
+  <p>If a client supports the protocol specified in this XEP, it MUST advertise it by including the "urn:xmpp:pte:0" discovery feature in response to a &xep0030; information request, furthermore, the supported encryption algorithms are announced as explained in their respective XEPs.</p>
 
   <example caption="Service Discovery information request"><![CDATA[
 <iq type='get'


### PR DESCRIPTION
This PR adds some fixes for typos.
I'm not sure, what the process is for proposing patches for inbox'd XEPs, since those have not yet been accepted.
Let me know, if for example a new revision is needed.