### PR TITLE
Add MUC service shutdown example

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -46,6 +46,12 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.34.5</version>
+    <date>2022-03-08</date>
+    <initials>NC</initials>
+    <remark><p>Add MUC service shut down example.</p></remark>
+  </revision>
+  <revision>
     <version>1.34.3</version>
     <date>2022-03-08</date>
     <initials>egp</initials>
@@ -4979,6 +4985,31 @@
      room). This is generally not advisable, as these types of disconnects may be frequent in the presence of poor network conditions
      and they are not linked to any user (e.g. moderator) action that the 307 code usually indicates. It is therefore recommended for the
      client to ignore the 307 code if a 333 status code is present.</p>
+  </section2>
+  <section2 topic='Service removes user because of service shut down' anchor='service-shutdown-kick'>
+    <p>When a MUC service shuts downs, it SHOULD inform its participant by sending presences containing the 332 status code</p>
+    <example caption='MUC service removes user because of service shutdown'><![CDATA[
+<presence
+    from='harfleur@chat.shakespeare.lit/pistol'
+    to='pistol@shakespeare.lit/client'
+    type='unavailable'>
+  <x xmlns='http://jabber.org/protocol/muc#user'>
+    <item affiliation='none' role='none' />
+    <status code='110'/>
+    <status code='332'/>
+  </x>
+</presence>
+<presence
+    from='harfleur@chat.shakespeare.lit/othello'
+    to='othello@shakespeare.lit/client'
+    type='unavailable'>
+  <x xmlns='http://jabber.org/protocol/muc#user'>
+    <item affiliation='none' role='none' />
+    <status code='110'/>
+    <status code='332'/>
+  </x>
+</presence>
+]]></example>
   </section2>
 </section1>
 


### PR DESCRIPTION
This is a minimal change discussed in jdev with @Zash. I think it is useful to have as many examples as possible.