### PR TITLE
XEP 0461 improvements.

### DIFF
--- a/xep-0461.xml
+++ b/xep-0461.xml
@@ -15,6 +15,7 @@
     <status>Experimental</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies/>
     <supersedes/>
     <supersededby/>
@@ -30,6 +31,12 @@
       <email>xsf@larma.de</email>
       <jid>jabber@larma.de</jid>
     </author>
+    <revision>
+      <version>0.2.0</version>
+      <date>2022-12-09</date>
+      <initials>nc</initials>
+      <remark>Fix example character counting. Add disco feature. Relax the 'to' attribute constraints.</remark>
+    </revision>
   <revision>
     <version>0.1.0</version>
     <date>2022-01-25</date>
@@ -58,11 +65,38 @@
     </p>
   </section1>
 
+  <section1 topic='Discovering support' anchor='disco'>
+    <p>
+      If a client implements message replies, it MUST specify the 
+      'urn:xmpp:reply:0' feature in its service discovery information features
+      as specified in &xep0030; and the Entity Capabilities profile specified in &xep0115;.
+    </p>
+    <example caption='Client requests information about a chat partner&apos;s client'><![CDATA[
+  <iq type='get'
+      to='romeo@montague.lit/orchard'
+      from='juliet@capulet.lit/balcony'
+      id='info1'>
+    <query xmlns='http://jabber.org/protocol/disco#info'/>
+  </iq>]]></example>
+    <example caption='Partner&apos;s client advertises support for replies'><![CDATA[
+  <iq type='result'
+      to='juliet@capulet.lit/balcony'
+      from='romeo@montague.lit/orchard'
+      id='info1'>
+    <query xmlns='http://jabber.org/protocol/disco#info'>
+  ...
+      <feature var='urn:xmpp:reply:0'/>
+  ...
+    </query>
+  </iq>]]></example>
+  </section1>
+
   <section1 topic='Use Cases' anchor='usecases'>
     <p>
       To indicate that a message is a reply, a &lt;reply&gt; element in the urn:xmpp:reply:0 namespace is placed in the
-      message stanza. The &lt;reply&gt; element has a 'to' attribute containing the full jid of the author of the
-      referenced message and an 'id' attribute containing the id of the referenced message.
+      message stanza. The &lt;reply&gt; element SHOULD have a 'to' attribute containing the full jid of the author of the
+      referenced message and MUST have an 'id' attribute containing the id of the referenced message.
+      In a 1:1 chat context, a bare jid MAY be used instead of a full jid.
     </p>
     <example caption="Max replies to Anna's message"><![CDATA[
 <message to='max@example.com' from='anna@example.com/tablet' id='message-id1' type='chat'>
@@ -78,6 +112,8 @@
       <p>
         To provide a fallback for non-supporting clients, the sending client MAY include fallback text in the body and
         indicate it via Compatibility Fallback.
+        Note that the following example is formatted for readability and that the indentation, leading and trailing new lines
+        of the example body element should not be taken into account.
       </p>
       <example caption="Anna replies to a message and includes a fallback"><![CDATA[
 <message to='anna@example.com' id='message-id3' type='chat'>
@@ -88,7 +124,7 @@
   </body>
   <reply to='anna@example.com/laptop' id='message-id1' xmlns='urn:xmpp:reply:0' />
   <fallback xmlns='urn:xmpp:feature-fallback:0' for='urn:xmpp:reply:0'>
-    <body start="0" end="36" />
+    <body start="0" end="38" />
   </fallback>
 </message>]]></example>
 


### PR DESCRIPTION
I think there is no reason that this XEP shouldn't have its associated disco feature.

I am rather confident that direct messages have no reason to refer to the quoted author with a full JID and that a bare JID makes more sense in this context.

I am less confident about permitting no `to` attribute in general and must confess this is something that would make it is easier to comply to the spec for my gateway implementation, but maybe this is not a valid reason. @edhelas since you implemented it in movim, do you use the 'to' attribute? Any opinion on allowing its absence?