### PR TITLE
Add color to output of XEP validation script

### DIFF
--- a/tools/validate-xep0001-conformance.sh
+++ b/tools/validate-xep0001-conformance.sh
@@ -14,15 +14,24 @@
 
 set -euo pipefail
 
+# ANSI color definitions
+ANSI_INFO='\033[1;94m';
+ANSI_PASS='\033[1;92m';
+ANSI_FAIL='\033[1;91m';
+ANSI_RESET='\033[0m';
+
 validation_result=0
+
+echo -e "Start validating file '$1'."
+echo ""
 
 # 1. Check DTD conformance against xep.dtd
 xep_dtd="xep.dtd"
 if xmllint --noout --dtdvalid "$xep_dtd" "$1"
 then
-  echo "[PASS] DTD conformance against xep.dtd"
+  echo -e "${ANSI_PASS}[PASS]${ANSI_RESET} DTD conformance against xep.dtd"
 else
-  echo "[FAIL] DTD conformance against xep.dtd"
+  echo -e "${ANSI_FAIL}[FAIL]${ANSI_RESET} DTD conformance against xep.dtd"
   validation_result=1;
 fi
 
@@ -39,54 +48,54 @@ processing_instructions=$(xmllint --xpath '/processing-instruction("xml-styleshe
 
 if echo "$file_name" | grep -Eq "^xep-[0-9]{4}.xml$"
 then
-  echo "[INFO] The filename ('$file_name') matches 'xep-[0-9]{4}.xml'."
+  echo -e "${ANSI_INFO}[INFO]${ANSI_RESET} The filename ('$file_name') matches 'xep-[0-9]{4}.xml'."
   # 2. If the filename matches xep-[0-9]{4}.xml, check:
   # 2.1 that the number in the filename equals /xep/header/number (XPath)
   if [ "$file_name" = "xep-$header_number.xml" ]
   then
-    echo "[PASS] The number in the filename ('$file_name') equals XPATH value /xep/header/number/text() ('$header_number')."
+    echo -e "${ANSI_PASS}[PASS]${ANSI_RESET} The number in the filename ('$file_name') equals XPATH value /xep/header/number/text() ('$header_number')."
   else
-    echo "[FAIL] The number in the filename ('$file_name') does not equals XPATH value /xep/header/number/text() ('$header_number') (but should)."
+    echo -e "${ANSI_FAIL}[FAIL]${ANSI_RESET} The number in the filename ('$file_name') does not equals XPATH value /xep/header/number/text() ('$header_number') (but should)."
     validation_result=1
   fi
 else
-  echo "[INFO] The filename ('$file_name') does not match 'xep-[0-9]{4}.xml'."
+  echo -e "${ANSI_INFO}[INFO]${ANSI_RESET} The filename ('$file_name') does not match 'xep-[0-9]{4}.xml'."
   # 3. If the filename does not match xep-[0-9]{4}.xml, check:
   # 3.1 That the /xep/header/status/text() (XPath) is ProtoXEP
   if [ "$header_status" = "ProtoXEP" ]
   then
-    echo "[PASS] XPATH value /xep/header/status/text() ('$header_status') equals 'ProtoXEP'."
+    echo -e "${ANSI_PASS}[PASS]${ANSI_RESET} XPATH value /xep/header/status/text() ('$header_status') equals 'ProtoXEP'."
   else
-    echo "[FAIL] XPATH value /xep/header/status/text() ('$header_status') does not equal 'ProtoXEP' (but should)."
+    echo -e "${ANSI_FAIL}[FAIL]${ANSI_RESET} XPATH value /xep/header/status/text() ('$header_status') does not equal 'ProtoXEP' (but should)."
     validation_result=1
   fi
 
   # 3.2 That the /xep/header/number/text() (XPath) is literally XXXX or xxxx
   if [ "$header_number" = "XXXX" ] || [ "$header_number" = "xxxx" ]
   then
-    echo "[PASS] XPATH value /xep/header/number/text() ('$header_status') equals 'XXXX' (case insensitive)."
+    echo -e "${ANSI_PASS}[PASS]${ANSI_RESET} XPATH value /xep/header/number/text() ('$header_status') equals '$header_number'."
   else
-    echo "[FAIL] XPATH value /xep/header/number/text() ('$header_status') does not equal 'XXXX' (but should)."
+    echo -e "${ANSI_FAIL}[FAIL]${ANSI_RESET} XPATH value /xep/header/number/text() ('$header_status') does not equal 'XXXX' or 'xxxx' (but should)."
     validation_result=1
   fi
 
   # 3.3 That the name does not start with xep-[0-9]
   if echo "$file_name" | grep -Eq "^xep-[0-9].*$"
   then
-    echo "[FAIL] The filename ('$file_name') starts with 'xep-[0-9]' (but should not)."
+    echo -e "${ANSI_FAIL}[FAIL]${ANSI_RESET} The filename ('$file_name') starts with 'xep-[0-9]' (but should not)."
     validation_result=1
   else
-    echo "[PASS] The filename ('$file_name') does not start with 'xep-[0-9]'."
+    echo -e "${ANSI_PASS}[PASS]${ANSI_RESET} The filename ('$file_name') does not start with 'xep-[0-9]'."
   fi
 fi
 
 # 4. Check that /xep/header/status/text() (XPath) is a defined status (see tools/xeplib.py for an enum)
 case $header_status in
   ProtoXEP | Experimental | Proposed | Draft | Active | Final | Retracted | Obsolete | Deferred | Rejected | Deprecated )
-    echo "[PASS] XPATH value /xep/header/status/text() ('$header_status') equals a defined status."
+    echo -e "${ANSI_PASS}[PASS]${ANSI_RESET} XPATH value /xep/header/status/text() ('$header_status') equals a defined status."
     ;;
   *)
-    echo "[FAIL] XPATH value /xep/header/status/text() ('$header_status') does not equals a defined status (but should)."
+    echo -e "${ANSI_FAIL}[FAIL]${ANSI_RESET} XPATH value /xep/header/status/text() ('$header_status') does not equals a defined status (but should)."
     validation_result=1
     ;;
 esac
@@ -99,10 +108,10 @@ case $file_name in
   'xep-0001.xml' | 'xep-0002.xml' | 'xep-0019.xml' | 'xep-0053.xml' | 'xep-0143.xml' | 'xep-0182.xml' | 'xep-0345.xml' | 'xep-0381.xml' | 'xep-0429.xml' | 'xep-0458.xml' )
     case $header_type in
       Historical | Humorous | Informational | Organizational | 'Standards Track' | 'Procedural' )
-        echo "[PASS] XPATH value /xep/header/type/text() ('$header_type') equals a defined type."
+        echo -e "${ANSI_PASS}[PASS]${ANSI_RESET} XPATH value /xep/header/type/text() ('$header_type') equals a defined type."
         ;;
       *)
-        echo "[FAIL] XPATH value /xep/header/type/text() ('$header_type') does not equals a defined type (but should)."
+        echo -e "${ANSI_FAIL}[FAIL]${ANSI_RESET} XPATH value /xep/header/type/text() ('$header_type') does not equals a defined type (but should)."
         validation_result=1
         ;;
     esac
@@ -110,10 +119,10 @@ case $file_name in
   'xep-0006.xml' | 'xep-0010.xml' | 'xep-0069.xml' | 'xep-0139.xml' )
     case $header_type in
       Historical | Humorous | Informational | Organizational | 'Standards Track' | 'SIG Formation' )
-        echo "[PASS] XPATH value /xep/header/type/text() ('$header_type') equals a defined type."
+        echo -e "${ANSI_PASS}[PASS]${ANSI_RESET} XPATH value /xep/header/type/text() ('$header_type') equals a defined type."
         ;;
       *)
-        echo "[FAIL] XPATH value /xep/header/type/text() ('$header_type') does not equals a defined type (but should)."
+        echo -e "${ANSI_FAIL}[FAIL]${ANSI_RESET} XPATH value /xep/header/type/text() ('$header_type') does not equals a defined type (but should)."
         validation_result=1
         ;;
     esac
@@ -121,10 +130,10 @@ case $file_name in
   'xep-0007.xml' )
     case $header_type in
       Historical | Humorous | Informational | Organizational | 'Standards Track' | 'SIG Proposal' )
-        echo "[PASS] XPATH value /xep/header/type/text() ('$header_type') equals a defined type."
+        echo -e "${ANSI_PASS}[PASS]${ANSI_RESET} XPATH value /xep/header/type/text() ('$header_type') equals a defined type."
         ;;
       *)
-        echo "[FAIL] XPATH value /xep/header/type/text() ('$header_type') does not equals a defined type (but should)."
+        echo -e "${ANSI_FAIL}[FAIL]${ANSI_RESET} XPATH value /xep/header/type/text() ('$header_type') does not equals a defined type (but should)."
         validation_result=1
         ;;
     esac
@@ -132,10 +141,10 @@ case $file_name in
   * )
     case $header_type in
       Historical | Humorous | Informational | Organizational | 'Standards Track' )
-        echo "[PASS] XPATH value /xep/header/type/text() ('$header_type') equals a defined type."
+        echo -e "${ANSI_PASS}[PASS]${ANSI_RESET} XPATH value /xep/header/type/text() ('$header_type') equals a defined type."
         ;;
       *)
-        echo "[FAIL] XPATH value /xep/header/type/text() ('$header_type') does not equals a defined type (but should)."
+        echo -e "${ANSI_FAIL}[FAIL]${ANSI_RESET} XPATH value /xep/header/type/text() ('$header_type') does not equals a defined type (but should)."
         validation_result=1
         ;;
     esac
@@ -145,10 +154,10 @@ esac
 # 6. Check that /xep/header/approver/text() (XPath) is either Board or Council
 case $header_approver in
   Board | Council )
-    echo "[PASS] XPATH value /xep/header/approver/text() ('$header_approver') equals either 'Board' or 'Council'."
+    echo -e "${ANSI_PASS}[PASS]${ANSI_RESET} XPATH value /xep/header/approver/text() ('$header_approver') equals either 'Board' or 'Council'."
     ;;
   *)
-    echo "[FAIL] XPATH value /xep/header/approver/text() ('$header_approver') does not equals 'Board' or 'Council' (but should)."
+    echo -e "${ANSI_FAIL}[FAIL]${ANSI_RESET} XPATH value /xep/header/approver/text() ('$header_approver') does not equals 'Board' or 'Council' (but should)."
     validation_result=1
     ;;
 esac
@@ -157,9 +166,9 @@ esac
 expected_revision_order=$(echo "$header_revisions" | tr " " "\n" | sort -Vr)
 if [ "$expected_revision_order" = "$header_revisions" ]
 then
-  echo "[PASS] Version numbers in the revision blocks are descending."
+  echo -e "${ANSI_PASS}[PASS]${ANSI_RESET} Version numbers in the revision blocks are descending."
 else
-  echo "[FAIL] Version numbers in the revision blocks are not ordered (descending from top to bottom in the document) (but should be)."
+  echo -e "${ANSI_FAIL}[FAIL]${ANSI_RESET} Version numbers in the revision blocks are not ordered (descending from top to bottom in the document) (but should be)."
   echo "       Order found : $(echo $header_revisions)" # funky $() nesting to remove newlines.
   echo "       Expected was: $(echo $expected_revision_order)"
   validation_result=1
@@ -170,28 +179,28 @@ if [ "$header_approver" = "Board" ]
 then
   if [ "$header_type" = "Standards Track" ]
   then
-    echo "[FAIL] XPATH value /xep/header/approver/text() ('$header_approver') is 'Board' but XPATH value /xep/header/type/text() is 'Standards Track' (it should not be)."
+    echo -e "${ANSI_FAIL}[FAIL]${ANSI_RESET} XPATH value /xep/header/approver/text() ('$header_approver') is 'Board' but XPATH value /xep/header/type/text() is 'Standards Track' (it should not be)."
     validation_result=1
   else
-    echo "[PASS] XPATH value /xep/header/approver/text() ('$header_approver') is 'Board' and XPATH value /xep/header/type/text() is not 'Standards Track'."
+    echo -e "${ANSI_PASS}[PASS]${ANSI_RESET} XPATH value /xep/header/approver/text() ('$header_approver') is 'Board' and XPATH value /xep/header/type/text() is not 'Standards Track'."
   fi
 fi
 
 # 9. Check that it uses the xep.xsl XML stylesheet.
 if echo "$processing_instructions" | grep -Eq "href=['\"]xep.xsl['\"]"
 then
-  echo "[PASS] xep.xsl XML stylesheet is used."
+  echo -e "${ANSI_PASS}[PASS]${ANSI_RESET} xep.xsl XML stylesheet is used."
 else
-  echo "[FAIL] xep.xsl XML stylesheet is not used (but should be)."
+  echo -e "${ANSI_FAIL}[FAIL]${ANSI_RESET} xep.xsl XML stylesheet is not used (but should be)."
   validation_result=1
 fi
 
 # 10. Check that it includes the correct legal notice (by checking for the entity reference)
 if grep -q "&LEGALNOTICE;" "$1"
 then
-  echo "[PASS] entity reference for the legal notice has been detected."
+  echo -e "${ANSI_PASS}[PASS]${ANSI_RESET} entity reference for the legal notice has been detected."
 else
-  echo "[FAIL] entity reference for the legal notice has not been detected (but it should have been)."
+  echo -e "${ANSI_FAIL}[FAIL]${ANSI_RESET} entity reference for the legal notice has not been detected (but it should have been)."
   validation_result=1
 fi
 


### PR DESCRIPTION
Github workflows tend to be verbose. This can make it difficult to determine why a failure occurs.

To help identify causes for validation failures, the output of the XEP-0001 conformance script should have a bit of color to highlight the important bits ([Github supports this](https://github.blog/2020-09-23-a-better-logs-experience-with-github-actions/#opening-the-door-to-a-more-colorful-experience)).

The output will depend on the terminal used to display the content, but will look somewhat like this:

![image](https://user-images.githubusercontent.com/4253898/208858670-3304848d-decb-40cc-98b7-9de36a652602.png)

It has:
- newlines before and after the results of each check
- a red-ish color for failed checks
- a green-ish color for passed checks
- a blue-ish color for informational messages