### PR TITLE
Add tag support in XEPs

### DIFF
--- a/tools/extract-metadata.py
+++ b/tools/extract-metadata.py
@@ -101,6 +101,12 @@ def extract_xep_metadata(document):
     else:
         last_call = None
 
+    tags = []
+    tags_elem = minidom_find_child(header, "tags")
+    if tags_elem is not None:
+        for child in minidom_children(tags_elem):
+            tags.append(minidom_get_text(child))
+
     return {
         "last_revision": {
             "version": last_revision_version,
@@ -113,6 +119,7 @@ def extract_xep_metadata(document):
         "sig": sig,
         "abstract": abstract,
         "shortname": shortname,
+        "tags": tags,
         "title": title,
         "approver": approver,
         "last_call": last_call,
@@ -136,6 +143,12 @@ def make_metadata_element(number, metadata, accepted, *, protoname=None):
 
     if metadata["shortname"] is not None:
         result.append(text_element("shortname", metadata["shortname"]))
+
+    if metadata["tags"]:
+        tags = etree.Element("tags")
+        for tag in metadata["tags"]:
+            tags.append(text_element("tag", tag))
+        result.append(tags)
 
     if metadata["last_revision"]["version"] is not None:
         last_revision = metadata["last_revision"]

--- a/xep-template.xml
+++ b/xep-template.xml
@@ -22,6 +22,9 @@
   <supersedes/>
   <supersededby/>
   <shortname>NOT_YET_ASSIGNED</shortname>
+  <tags>
+    <tag>template</tag>
+  </tags>
   <author>
     <firstname>Peter</firstname>
     <surname>Saint-Andre</surname>

--- a/xep.dtd
+++ b/xep.dtd
@@ -27,7 +27,7 @@ THE SOFTWARE.
 <!ELEMENT xep ( header, section1* ) >
 <!ATTLIST xep
           xmlns CDATA '' >
-<!ELEMENT header ( title, abstract, legal, number, status, lastcall*, interim*, type, sig, approver*, dependencies, supersedes, supersededby, shortname, schemaloc*, registry?, discuss?, expires?, author+, revision+, councilnote? ) >
+<!ELEMENT header ( title, abstract, legal, number, status, lastcall*, interim*, type, sig, approver*, dependencies, supersedes, supersededby, shortname, tags?, schemaloc*, registry?, discuss?, expires?, author+, revision+, councilnote?) >
 <!ELEMENT title (#PCDATA)* >
 <!ELEMENT abstract (#PCDATA)* >
 <!ELEMENT legal ( copyright, permissions, warranty, liability, conformance ) >
@@ -68,6 +68,8 @@ THE SOFTWARE.
 <!ELEMENT initials (#PCDATA)* >
 <!ELEMENT remark (#PCDATA | p | ul)* >
 <!ELEMENT councilnote (#PCDATA)* >
+<!ELEMENT tags ( tag* ) >
+<!ELEMENT tag (#PCDATA)* >
 <!ELEMENT section1 ( div | p | section2 | example | code | cve | ul | ol | dl | table )* >
 <!ATTLIST section1
           topic CDATA ''

--- a/xep.xsd
+++ b/xep.xsd
@@ -70,6 +70,7 @@ THE SOFTWARE.
         <xs:element ref='supersedes'/>
         <xs:element ref='supersededby'/>
         <xs:element name='shortname' type='xs:NCName'/>
+        <xs:element ref='tags' minOccurs='0'/>
         <xs:element ref='schemaloc' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element name='registry' minOccurs='0' type='empty'/>
         <xs:element name='discuss' minOccurs='0' type='xs:string'/>
@@ -193,6 +194,14 @@ THE SOFTWARE.
         <xs:element ref='table' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/>
       </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='tags'>
+    <xs:complexType>
+      <xs:sequence minOccurs='1' maxOccurs='unbounded'>
+        <xs:element name='tag' type='xs:string'/>
+      </xs:sequence>
     </xs:complexType>
   </xs:element>
 


### PR DESCRIPTION
This is but a first step to display tags wherever we think fits. It adds the possibility to add `<tags>` in XEP headers, and it extract this information into `xeplist.xml` that is used by other tools.