### PR TITLE
Fix metadata conversion in markdown scripts

### DIFF
--- a/tools/2xep.lua
+++ b/tools/2xep.lua
@@ -115,7 +115,7 @@ function Doc(body, metadata, variables)
 					end
 					add("</remark>");
 				else
-					add(("<%s>%s</%s>"):format(field, tostring(sv), field));
+					add(tostring(sv));
 				end
 				add(string.format("</%s>", field));
 			end

--- a/tools/xep2md.lua
+++ b/tools/xep2md.lua
@@ -247,11 +247,21 @@ local header_schema = [[
 	supersededby , shortname , schemaloc* , registry? , discuss? ,
 	expires? , author+ , revision+ , councilnote?)
 ]];
-for field in header_schema:gmatch("%w+") do
-	events.add_handler(field.."#text", function (event)
-		meta[field] = event.text:match("%S.*%S");
-		return true;
-	end);
+for field, mod in header_schema:gmatch("(%w+)([*+?]?)") do
+	if mod == "" or mod == "?" then
+		events.add_handler(field .. "#text", function(event)
+			meta[field] = event.text:match("%S.*%S");
+			return true;
+		end);
+	elseif mod == "*" or mod == "+" then
+		events.add_handler(field .. "#text", function(event)
+			if not meta[field] then
+				meta[field] = {};
+			end
+			table.insert(meta[field], event.text:match("%S.*%S"));
+			return true;
+		end);
+	end
 end
 
 do


### PR DESCRIPTION
E.g. lastcall can exist more than once according to the schema, but only
one item was kept by `xep2md`.

Before:

```yaml
lastcall: 2017-11-15
```

After:

```yaml
lastcall:
- 2021-03-30
- 2017-11-15
```

In `2xep`  an extra wrapper element was added

```xml
<lastcall>
<lastcall>2017-11-15</lastcall>
</lastcall>
```

Correct is one element with text for each item

```xml
<lastcall>2017-11-15</lastcall>
```
