### PR TITLE
Add Council as approver to all Standards Track XEPs where it was missing

### DIFF
--- a/xep-0004.xml
+++ b/xep-0004.xml
@@ -13,6 +13,7 @@
     <status>Final</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies>
       <spec>XMPP Core</spec>
     </dependencies>

--- a/xep-0009.xml
+++ b/xep-0009.xml
@@ -13,6 +13,7 @@
   <status>Final</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XML-RPC</spec>

--- a/xep-0012.xml
+++ b/xep-0012.xml
@@ -13,6 +13,7 @@
   <status>Final</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0013.xml
+++ b/xep-0013.xml
@@ -13,6 +13,7 @@
   <status>Deprecated</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0014.xml
+++ b/xep-0014.xml
@@ -13,6 +13,7 @@
   <status>Rejected</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0015.xml
+++ b/xep-0015.xml
@@ -13,6 +13,7 @@
     <status>Rejected</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies>
       <spec>XMPP Core</spec>
     </dependencies>

--- a/xep-0016.xml
+++ b/xep-0016.xml
@@ -13,6 +13,7 @@
   <status>Deprecated</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0020.xml
+++ b/xep-0020.xml
@@ -13,6 +13,7 @@
   <status>Deprecated</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0004</spec>

--- a/xep-0021.xml
+++ b/xep-0021.xml
@@ -15,6 +15,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby><spec>XEP-0060</spec></supersededby>

--- a/xep-0024.xml
+++ b/xep-0024.xml
@@ -13,6 +13,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby><spec>XEP-0060</spec></supersededby>

--- a/xep-0026.xml
+++ b/xep-0026.xml
@@ -13,6 +13,7 @@
 	<status>Retracted</status>
 	<type>Standards Track</type>
 	<sig>Standards</sig>
+	<approver>Council</approver>
 	<dependencies/>
 	<supersedes/>
 	<supersededby><spec>XMPP Core</spec></supersededby>

--- a/xep-0029.xml
+++ b/xep-0029.xml
@@ -13,6 +13,7 @@
         <status>Retracted</status>
         <type>Standards Track</type>
         <sig>Standards</sig>
+        <approver>Council</approver>
         <dependencies/>
         <supersedes/>
         <supersededby><spec>RFC 7622</spec></supersededby>

--- a/xep-0030.xml
+++ b/xep-0030.xml
@@ -14,6 +14,7 @@
     <interim/>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies>
       <spec>XMPP Core</spec>
     </dependencies>

--- a/xep-0031.xml
+++ b/xep-0031.xml
@@ -25,6 +25,7 @@ apply cryptographic protection to selected conversation data.
 <status>Deferred</status>
 <type>Standards Track</type>
 <sig>Standards</sig>
+<approver>Council</approver>
 <dependencies/>
 <supersedes/>
 <supersededby/>

--- a/xep-0032.xml
+++ b/xep-0032.xml
@@ -13,6 +13,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby><spec>RFC 5122</spec></supersededby>

--- a/xep-0033.xml
+++ b/xep-0033.xml
@@ -13,6 +13,7 @@
         <status>Draft</status>
         <type>Standards Track</type>
         <sig>Standards</sig>
+        <approver>Council</approver>
         <dependencies>
             <spec>XMPP Core</spec>
             <spec>XEP-0030</spec>

--- a/xep-0034.xml
+++ b/xep-0034.xml
@@ -15,6 +15,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby><spec>XMPP Core</spec></supersededby>

--- a/xep-0035.xml
+++ b/xep-0035.xml
@@ -15,6 +15,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby><spec>XMPP Core</spec></supersededby>

--- a/xep-0036.xml
+++ b/xep-0036.xml
@@ -13,6 +13,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby><spec>XEP-0060</spec></supersededby>

--- a/xep-0037.xml
+++ b/xep-0037.xml
@@ -13,6 +13,7 @@
   <status>Rejected</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby/>

--- a/xep-0038.xml
+++ b/xep-0038.xml
@@ -13,6 +13,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby>

--- a/xep-0039.xml
+++ b/xep-0039.xml
@@ -13,6 +13,7 @@
     <status>Deferred</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies><spec>XEP-0053</spec></dependencies>
     <supersedes/>
     <supersededby/>

--- a/xep-0040.xml
+++ b/xep-0040.xml
@@ -13,6 +13,7 @@
       <status>Retracted</status>
       <type>Standards Track</type>
       <sig>Standards</sig>
+      <approver>Council</approver>
       <dependencies/>
       <supersedes/>
       <supersededby><spec>XEP-0060</spec></supersededby>

--- a/xep-0041.xml
+++ b/xep-0041.xml
@@ -13,6 +13,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0020</spec>

--- a/xep-0042.xml
+++ b/xep-0042.xml
@@ -13,6 +13,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XEP-0004 (OPTIONAL)</spec>
     <spec>XEP-0011 (RECOMMENDED)</spec>

--- a/xep-0043.xml
+++ b/xep-0043.xml
@@ -13,6 +13,7 @@
     <status>Retracted</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies/>
     <supersedes/>
     <supersededby/>

--- a/xep-0044.xml
+++ b/xep-0044.xml
@@ -15,6 +15,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby/>

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -15,6 +15,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0046.xml
+++ b/xep-0046.xml
@@ -13,6 +13,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby><spec>XEP-0065</spec></supersededby>

--- a/xep-0047.xml
+++ b/xep-0047.xml
@@ -13,6 +13,7 @@
   <status>Final</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0048.xml
+++ b/xep-0048.xml
@@ -13,6 +13,7 @@
   <status>Deprecated</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0060</spec>

--- a/xep-0050.xml
+++ b/xep-0050.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0004</spec>

--- a/xep-0051.xml
+++ b/xep-0051.xml
@@ -13,6 +13,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby>

--- a/xep-0052.xml
+++ b/xep-0052.xml
@@ -13,6 +13,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0056.xml
+++ b/xep-0056.xml
@@ -13,6 +13,7 @@
 <status>Deferred</status>
 <type>Standards Track</type>
 <sig>Standards</sig>
+<approver>Council</approver>
 <dependencies/>
 <supersedes/>
 <supersededby/>

--- a/xep-0057.xml
+++ b/xep-0057.xml
@@ -13,6 +13,7 @@
     <status>Retracted</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies/>
     <supersedes/>
     <supersededby/>

--- a/xep-0058.xml
+++ b/xep-0058.xml
@@ -13,6 +13,7 @@
     <status>Deferred</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies/>
     <supersedes/>
     <supersededby/>

--- a/xep-0059.xml
+++ b/xep-0059.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -16,6 +16,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0004</spec>

--- a/xep-0065.xml
+++ b/xep-0065.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>RFC 1928</spec>

--- a/xep-0066.xml
+++ b/xep-0066.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0067.xml
+++ b/xep-0067.xml
@@ -13,6 +13,7 @@
     <status>Deferred</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies><spec>XEP-0060</spec></dependencies>
     <supersedes/>
     <supersededby/>

--- a/xep-0070.xml
+++ b/xep-0070.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>RFC 2616</spec>

--- a/xep-0071.xml
+++ b/xep-0071.xml
@@ -13,6 +13,7 @@
   <status>Deprecated</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0072.xml
+++ b/xep-0072.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>SOAP 1.2</spec>

--- a/xep-0073.xml
+++ b/xep-0073.xml
@@ -13,6 +13,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0074.xml
+++ b/xep-0074.xml
@@ -13,6 +13,7 @@
     <status>Retracted</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies><spec>XEP-0030</spec></dependencies>
     <supersedes/>
     <supersededby/>

--- a/xep-0075.xml
+++ b/xep-0075.xml
@@ -17,6 +17,7 @@
     <status>Deferred</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies/>
     <supersedes/>
     <supersededby/>

--- a/xep-0077.xml
+++ b/xep-0077.xml
@@ -13,6 +13,7 @@
   <status>Final</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0078.xml
+++ b/xep-0078.xml
@@ -13,6 +13,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>RFC 3174</spec>

--- a/xep-0079.xml
+++ b/xep-0079.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0030</spec>

--- a/xep-0080.xml
+++ b/xep-0080.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0163</spec>

--- a/xep-0081.xml
+++ b/xep-0081.xml
@@ -13,6 +13,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0084.xml
+++ b/xep-0084.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0030</spec>

--- a/xep-0085.xml
+++ b/xep-0085.xml
@@ -13,6 +13,7 @@
   <status>Final</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0087.xml
+++ b/xep-0087.xml
@@ -13,6 +13,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies><spec>XEP-0030</spec></dependencies>
   <supersedes/>
   <supersededby><spec>XEP-0095</spec></supersededby>

--- a/xep-0089.xml
+++ b/xep-0089.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby/>

--- a/xep-0092.xml
+++ b/xep-0092.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0095.xml
+++ b/xep-0095.xml
@@ -13,6 +13,7 @@
   <status>Deprecated</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0030</spec>

--- a/xep-0096.xml
+++ b/xep-0096.xml
@@ -13,6 +13,7 @@
   <status>Deprecated</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0095</spec>

--- a/xep-0097.xml
+++ b/xep-0097.xml
@@ -13,6 +13,7 @@
     <status>Deferred</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies><spec>XEP-0030</spec></dependencies>
     <supersedes/>
     <supersededby/>

--- a/xep-0098.xml
+++ b/xep-0098.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby/>

--- a/xep-0099.xml
+++ b/xep-0099.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby/>

--- a/xep-0101.xml
+++ b/xep-0101.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>RFC 2616</spec>

--- a/xep-0102.xml
+++ b/xep-0102.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby/>

--- a/xep-0103.xml
+++ b/xep-0103.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0095</spec>

--- a/xep-0104.xml
+++ b/xep-0104.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>RFC 3986</spec>

--- a/xep-0105.xml
+++ b/xep-0105.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XEP-0095</spec>
     <spec>XEP-0096</spec>

--- a/xep-0106.xml
+++ b/xep-0106.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0030</spec>

--- a/xep-0107.xml
+++ b/xep-0107.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0163</spec>

--- a/xep-0108.xml
+++ b/xep-0108.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0163</spec>

--- a/xep-0109.xml
+++ b/xep-0109.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XEP-0060</spec>
     <spec>XEP-0163</spec>

--- a/xep-0110.xml
+++ b/xep-0110.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies/>
   <supersedes/>
   <supersededby/>

--- a/xep-0111.xml
+++ b/xep-0111.xml
@@ -13,6 +13,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>RFC 2327</spec>

--- a/xep-0112.xml
+++ b/xep-0112.xml
@@ -13,6 +13,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0060</spec>

--- a/xep-0115.xml
+++ b/xep-0115.xml
@@ -14,6 +14,7 @@
     <status>Draft</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies>
       <spec>XMPP Core</spec>
       <spec>XMPP IM</spec>

--- a/xep-0116.xml
+++ b/xep-0116.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0117.xml
+++ b/xep-0117.xml
@@ -13,6 +13,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0118.xml
+++ b/xep-0118.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0163</spec>

--- a/xep-0119.xml
+++ b/xep-0119.xml
@@ -13,6 +13,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0120.xml
+++ b/xep-0120.xml
@@ -16,6 +16,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies><spec>XMPP Core</spec></dependencies>
   <supersedes/>
   <supersededby/>

--- a/xep-0122.xml
+++ b/xep-0122.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0004</spec>

--- a/xep-0123.xml
+++ b/xep-0123.xml
@@ -16,6 +16,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0129.xml
+++ b/xep-0129.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>RFC 2518</spec>

--- a/xep-0131.xml
+++ b/xep-0131.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0030</spec>

--- a/xep-0135.xml
+++ b/xep-0135.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0030</spec>

--- a/xep-0136.xml
+++ b/xep-0136.xml
@@ -13,6 +13,7 @@
   <status>Deprecated</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0004</spec>

--- a/xep-0137.xml
+++ b/xep-0137.xml
@@ -13,6 +13,7 @@
   <status>Deprecated</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0030</spec>

--- a/xep-0138.xml
+++ b/xep-0138.xml
@@ -13,6 +13,7 @@
     <status>Obsolete</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies>
       <spec>XMPP Core</spec>
     </dependencies>

--- a/xep-0141.xml
+++ b/xep-0141.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0004</spec>

--- a/xep-0142.xml
+++ b/xep-0142.xml
@@ -13,6 +13,7 @@
         <status>Deferred</status>
         <type>Standards Track</type>
         <sig>Standards</sig>
+        <approver>Council</approver>
         <dependencies>
           <spec>XMPP Core</spec>
           <spec>XEP-0030</spec>

--- a/xep-0144.xml
+++ b/xep-0144.xml
@@ -14,6 +14,7 @@
   <interim/>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0151.xml
+++ b/xep-0151.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0045</spec>

--- a/xep-0158.xml
+++ b/xep-0158.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0159.xml
+++ b/xep-0159.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0186.xml
+++ b/xep-0186.xml
@@ -15,6 +15,7 @@
   <lastcall>2017-12-12</lastcall>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0187.xml
+++ b/xep-0187.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0189.xml
+++ b/xep-0189.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0060</spec>

--- a/xep-0191.xml
+++ b/xep-0191.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0192.xml
+++ b/xep-0192.xml
@@ -13,6 +13,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0193.xml
+++ b/xep-0193.xml
@@ -13,6 +13,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0194.xml
+++ b/xep-0194.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0195.xml
+++ b/xep-0195.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0196.xml
+++ b/xep-0196.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0197.xml
+++ b/xep-0197.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0198.xml
+++ b/xep-0198.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0200.xml
+++ b/xep-0200.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0210.xml
+++ b/xep-0210.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0211.xml
+++ b/xep-0211.xml
@@ -13,6 +13,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0212.xml
+++ b/xep-0212.xml
@@ -13,6 +13,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0213.xml
+++ b/xep-0213.xml
@@ -13,6 +13,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XEP-0211</spec>
     <spec>XEP-0016</spec>

--- a/xep-0216.xml
+++ b/xep-0216.xml
@@ -13,6 +13,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XEP-0212</spec>
     <spec>XEP-0016</spec>

--- a/xep-0217.xml
+++ b/xep-0217.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0219.xml
+++ b/xep-0219.xml
@@ -13,6 +13,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0221.xml
+++ b/xep-0221.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0004</spec>

--- a/xep-0229.xml
+++ b/xep-0229.xml
@@ -13,6 +13,7 @@
     <status>Obsolete</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies>
       <spec>XMPP Core</spec>
       <spec>XEP-0138</spec>

--- a/xep-0234.xml
+++ b/xep-0234.xml
@@ -14,6 +14,7 @@
   <lastcall>2017-12-12</lastcall>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0166</spec>

--- a/xep-0241.xml
+++ b/xep-0241.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0136</spec>

--- a/xep-0242.xml
+++ b/xep-0242.xml
@@ -13,6 +13,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0243.xml
+++ b/xep-0243.xml
@@ -13,6 +13,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0247.xml
+++ b/xep-0247.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0047</spec>

--- a/xep-0256.xml
+++ b/xep-0256.xml
@@ -13,6 +13,7 @@
   <status>Deprecated</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0257.xml
+++ b/xep-0257.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0178</spec>

--- a/xep-0260.xml
+++ b/xep-0260.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0030</spec>

--- a/xep-0261.xml
+++ b/xep-0261.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0047</spec>

--- a/xep-0270.xml
+++ b/xep-0270.xml
@@ -15,6 +15,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0281.xml
+++ b/xep-0281.xml
@@ -15,6 +15,7 @@
   <status>Retracted</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XEP-0045</spec>
     <spec>XEP-0030</spec>

--- a/xep-0291.xml
+++ b/xep-0291.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0297.xml
+++ b/xep-0297.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0302.xml
+++ b/xep-0302.xml
@@ -13,6 +13,7 @@
   <status>Obsolete</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>RFC 6120</spec>
     <spec>RFC 6121</spec>

--- a/xep-0303.xml
+++ b/xep-0303.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0305.xml
+++ b/xep-0305.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>RFC 5077</spec>
     <spec>RFC 6120</spec>

--- a/xep-0306.xml
+++ b/xep-0306.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>RFC 6120</spec>
     <spec>XEP-0045</spec>

--- a/xep-0307.xml
+++ b/xep-0307.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0045</spec>

--- a/xep-0313.xml
+++ b/xep-0313.xml
@@ -15,6 +15,7 @@
   <lastcall>2017-11-15</lastcall>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0030</spec>

--- a/xep-0315.xml
+++ b/xep-0315.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0004</spec>

--- a/xep-0319.xml
+++ b/xep-0319.xml
@@ -13,6 +13,7 @@
   <status>Draft</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0328.xml
+++ b/xep-0328.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XMPP IM</spec>

--- a/xep-0350.xml
+++ b/xep-0350.xml
@@ -13,6 +13,7 @@
     <status>Deferred</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies>
       <spec>XMPP Core</spec>
       <spec>XEP-0004</spec>

--- a/xep-0357.xml
+++ b/xep-0357.xml
@@ -15,6 +15,7 @@
         <lastcall>2018-11-03</lastcall>
         <type>Standards Track</type>
         <sig>Standards</sig>
+        <approver>Council</approver>
         <dependencies>
             <spec>XMPP Core</spec>
             <spec>XMPP IM</spec>

--- a/xep-0358.xml
+++ b/xep-0358.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0030</spec>

--- a/xep-0375.xml
+++ b/xep-0375.xml
@@ -15,6 +15,7 @@
     <status>Retracted</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies>
       <spec>RFC 6120</spec>
       <spec>RFC 6121</spec>

--- a/xep-0387.xml
+++ b/xep-0387.xml
@@ -23,6 +23,7 @@
     <lastcall>2017-11-15</lastcall>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies>
       <spec>RFC 6120</spec>
       <spec>RFC 6121</spec>

--- a/xep-0388.xml
+++ b/xep-0388.xml
@@ -13,6 +13,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0412.xml
+++ b/xep-0412.xml
@@ -22,6 +22,7 @@
     <lastcall>2019-02-29</lastcall>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies>
       <spec>RFC 6120</spec>
       <spec>RFC 6121</spec>

--- a/xep-0423.xml
+++ b/xep-0423.xml
@@ -25,6 +25,7 @@
     <status>Obsolete</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies>
       <spec>RFC 6120</spec>
       <spec>RFC 6121</spec>

--- a/xep-0427.xml
+++ b/xep-0427.xml
@@ -15,6 +15,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0422</spec>

--- a/xep-0428.xml
+++ b/xep-0428.xml
@@ -15,6 +15,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0430.xml
+++ b/xep-0430.xml
@@ -15,6 +15,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0313</spec>

--- a/xep-0431.xml
+++ b/xep-0431.xml
@@ -15,6 +15,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0313</spec>

--- a/xep-0432.xml
+++ b/xep-0432.xml
@@ -17,6 +17,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0335</spec>

--- a/xep-0439.xml
+++ b/xep-0439.xml
@@ -15,6 +15,7 @@
   <status>Deferred</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>

--- a/xep-0441.xml
+++ b/xep-0441.xml
@@ -13,6 +13,7 @@
   <status>Experimental</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0030</spec>

--- a/xep-0442.xml
+++ b/xep-0442.xml
@@ -13,6 +13,7 @@
   <status>Experimental</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0030</spec>

--- a/xep-0443.xml
+++ b/xep-0443.xml
@@ -26,6 +26,7 @@
     <lastcall>2020-11-03</lastcall>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies>
       <spec>RFC 6120</spec>
       <spec>RFC 6121</spec>

--- a/xep-0459.xml
+++ b/xep-0459.xml
@@ -26,6 +26,7 @@
     <lastcall>2021-09-21</lastcall>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies>
       <spec>RFC 6120</spec>
       <spec>RFC 6121</spec>

--- a/xep-0461.xml
+++ b/xep-0461.xml
@@ -15,6 +15,7 @@
     <status>Experimental</status>
     <type>Standards Track</type>
     <sig>Standards</sig>
+    <approver>Council</approver>
     <dependencies/>
     <supersedes/>
     <supersededby/>


### PR DESCRIPTION
```
# find all missing approvers
comm -12 <(grep -Lo '<approver>.*</approver>' xep-0* | sort -u) <(ls xep-0* | sort -u) > xepsmissing_approver.txt
# inspect types
cat xepsmissing_approver.txt | xargs grep -ho '<type>.*</type>' | sort -u > xepsmissing_uniquetypes.txt
# add council as approver to all with type Standards Track
cat xepsmissing_approver.txt | xargs grep -lo '<type>Standards Track</type>' | xargs sed -ri 's@^(.*)<sig>(.+)</sig>@\1<sig>\2</sig>\n\1<approver>Council</approver>@'
```

For clarification I think this should be considered a "tooling change" and no versions or anything bumped, this triggered it:
https://github.com/xsf/xeps/pull/1255#discussion_r1082096252