### PR TITLE
XEP-0313 v1.1.0: Clarify a couple of edge cases

### DIFF
--- a/xep-0313.xml
+++ b/xep-0313.xml
@@ -15,6 +15,7 @@
   <lastcall>2017-11-15</lastcall>
   <type>Standards Track</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0030</spec>
@@ -29,6 +30,17 @@
   </schemaloc>
   &mwild;
   &ksmith;
+  <revision>
+    <version>1.1.0</version>
+    <date>2023-03-09</date>
+    <initials>mw</initials>
+    <remark>
+      <ul>
+        <li>Clarify archive metadata response in the case of an empty archive.</li>
+        <li>Clarify query response in the case of no matching results.</li>
+      </ul>
+    </remark>
+  </revision>
   <revision>
     <version>1.0.1</version>
     <date>2022-02-16</date>
@@ -373,6 +385,10 @@
     consistent with the format defined in &xep0068;. Servers MUST NOT mark any fields in the form as
     being required (i.e. with the data forms &lt;required/&gt; element), regardless of whether they are
     defined in this document or elsewhere.</p>
+
+    <p>Except where explicitly noted below (i.e. 'Limiting results by id'), a query is still considered successful even
+    if the archive is empty or if no messages match the filter criteria - such queries simply return no results.</p>
+
     <section3 topic='Filtering by JID' anchor='filter-jid'>
       <p>If a 'with' field is present in the form, it contains a JID against which to match messages. The
       server MUST only return messages if they match the supplied JID. A message in a user's archive matches if the JID matches either the to or from of the message. An item in a MUC archive matches if the publisher of the item matches the JID; note that this should only be available to entities that would already have been allowed to know the publisher of the events (e.g. this could not be used by a visitor to a semi-anonymous MUC).</p>
@@ -803,8 +819,9 @@
 </iq>
 ]]></example>
 
-  <p>The server response includes a &lt;metadata/&gt; element containing information about the archive. This element MUST include &lt;start/&gt; and &lt;end/&gt;
+  <p>The server response includes a &lt;metadata/&gt; element containing information about the archive. If the archive is not empty, this element MUST include &lt;start/&gt; and &lt;end/&gt;
      elements, which each have an 'id' and XEP-0082 formatted 'timestamp of the first and last messages in the archive respectively.</p>
+  <p>If the archive is empty, the server MUST instead send an empty &lt;metadata/&gt; element.</p>
 </section1>
 
 <section1 topic='Business Rules' anchor='business_rules'>


### PR DESCRIPTION
These were [initially reported](https://logs.xmpp.org/jdev/2023-01-16?p=h#2023-01-16-3eedf318e3ba95f6) by @truenicoco.

Corresponding [mailing list thread here](https://mail.jabber.org/pipermail/standards/2023-March/039209.html).

The largest issue is that the XEP says a server MUST include `<start>` and `<end>` elements in the archive's `<metadata>`. However, if the archive is empty, this is clearly impossible. We checked Prosody's implementation, and it sends an empty `<metadata>` element in this case. I think this is the sensible solution (the only other one that came up is returning an error).

This adds a MUST to a draft spec, which I don't do lightly - however I think it is reasonable given that implementations didn't really have many other options, and it benefits interoperability to be consistent about this case.

The second change is just a clarification of what was hopefully already the common interpretation of the current spec. Namely, if no messages match a query, it should return successfully with no results (rather than, for example, returning an 'item-not-found' error).

Note that this does not override the 'item-not-found' error that was already specified if a non-existent id is provided to one of the filters that accepts an id. That error is necessary to preserve a client's ability to detect gaps in their archive synchronization (e.g. if the id they are querying from is no longer present in the archive).