### PR TITLE
xep-0223: Add origin checking to security considerations

### DIFF
--- a/xep-0223.xml
+++ b/xep-0223.xml
@@ -26,6 +26,12 @@
   <shortname>N/A</shortname>
   &stpeter;
   <revision>
+    <version>1.1.1</version>
+    <date>2023-03-23</date>
+    <initials>ka</initials>
+    <remark><p>Add notes about checking event origin (in reaction to CVE-2023-28686).</p></remark>
+  </revision>
+  <revision>
     <version>1.1</version>
     <date>2018-03-28</date>
     <initials>jwi</initials>
@@ -245,6 +251,7 @@
 
 <section1 topic='Security Considerations' anchor='security'>
   <p>Since private data is to be stored in a mechanism originally intended to <em>publish</em> data, it is REQUIRED for entities to ensure that the restrictive &lt;publish-options/&gt; will actually be honored by the server by performing the feature discovery procedure as specified in <link url='#support'>Determining Support</link>. If an entity using that procedure finds that the server does not support &lt;publish-options/&gt;, it MUST NOT store private data in PubSub, unless it can ensure privacy of the data with other means.</p>
+  <p>The configuration of a local pubsub node does not prevent an attacker or a contact with a misconfigured node from sending pubsub events with the same payload. Therefore clients MUST verify that the ‘from’ attribute on incoming event messages are either missing or equal that of their own account JID. </p>
   <p>The Security Considerations specified in <cite>XEP-0060</cite> and <cite>XEP-0163</cite> need to be taken into account.</p>
 </section1>
 

--- a/xep-0223.xml
+++ b/xep-0223.xml
@@ -251,7 +251,7 @@
 
 <section1 topic='Security Considerations' anchor='security'>
   <p>Since private data is to be stored in a mechanism originally intended to <em>publish</em> data, it is REQUIRED for entities to ensure that the restrictive &lt;publish-options/&gt; will actually be honored by the server by performing the feature discovery procedure as specified in <link url='#support'>Determining Support</link>. If an entity using that procedure finds that the server does not support &lt;publish-options/&gt;, it MUST NOT store private data in PubSub, unless it can ensure privacy of the data with other means.</p>
-  <p>The configuration of a local pubsub node does not prevent an attacker or a contact with a misconfigured node from sending pubsub events with the same payload. Therefore clients MUST verify that the ‘from’ attribute on incoming event messages are either missing or equal that of their own account JID. </p>
+  <p>The configuration of a local pubsub node does not prevent an attacker or a contact with a misconfigured node from sending pubsub events with the same payload. Therefore clients MUST verify that the ‘from’ attribute on incoming event messages is either absent or equal to their own account JID.</p>
   <p>The Security Considerations specified in <cite>XEP-0060</cite> and <cite>XEP-0163</cite> need to be taken into account.</p>
 </section1>
 


### PR DESCRIPTION
In reaction to [CVE-2023-28686](https://dino.im/security/cve-2023-28686/). While technically about XEP-0402, all uses following the XEP-0223 pattern should take heed.