### PR TITLE
XEP-0353: Update XML schema and fix typo

### DIFF
--- a/xep-0353.xml
+++ b/xep-0353.xml
@@ -28,6 +28,14 @@
   &stpeter;
   &tmolitor;
   <revision>
+    <version>0.6.1</version>
+    <date>2023-04-18</date>
+    <initials>taiBsu</initials>
+    <remark>
+      Replace deprecated "accept" with "proceed" in XML schema
+    </remark>
+  </revision>
+  <revision>
     <version>0.6.0</version>
     <date>2022-01-29</date>
     <initials>tm</initials>
@@ -497,7 +505,7 @@
     </xs:complexType>
   </xs:element>
 
-  <xs:element name='accept'>
+  <xs:element name='proceed'>
     <xs:complexType>
       <xs:simpleContent>
         <xs:extension base='empty'>

--- a/xep-0353.xml
+++ b/xep-0353.xml
@@ -32,7 +32,11 @@
     <date>2023-04-18</date>
     <initials>taiBsu</initials>
     <remark>
-      Replace deprecated "accept" with "proceed" in XML schema
+      <ul>
+      	<li>Replace deprecated "accept" with "proceed" in XML schema
+      	<li>Fix typo in Example 9
+      	<li>Add "ringing" element to XML schema
+      </ul>
     </remark>
   </revision>
   <revision>
@@ -280,7 +284,7 @@
       <success/>
       <text>Success</text>
     </reason>
-  </finish
+  </finish>
   <store xmlns="urn:xmpp:hints"/>
 </message>
 ]]></example>
@@ -502,6 +506,16 @@
         <xs:any namespace='##other' minOccurs='1' maxOccurs='unbounded'/>
       </xs:sequence>
       <xs:attribute name='id' type='xs:string' use='required'/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='ringing'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='empty'>
+          <xs:attribute name='id' type='xs:string' use='required'/>
+        </xs:extension>
+      </xs:simpleContent>
     </xs:complexType>
   </xs:element>
 


### PR DESCRIPTION
- Fix: Replace deprecated "accept" with "proceed" in XML schema
- Fix: Typo in Example 9 (`</finish`)
- Update: Add 'ringing' element to XML schema