### PR TITLE
XEP-0333: Change 'discover support' example

### DIFF
--- a/xep-0333.xml
+++ b/xep-0333.xml
@@ -31,6 +31,12 @@
     <jid>im@spencermacdonald.com</jid>
   </author>
   <revision>
+    <version>0.4.1</version>
+    <date>2023-07-19</date>
+    <initials>gdk</initials>
+    <remark>Changed discovery example to use client JIDs.</remark>
+  </revision>
+  <revision>
     <version>0.4</version>
     <date>2020-04-15</date>
     <initials>mw</initials>
@@ -129,9 +135,9 @@
 <section1 topic='Determining support' anchor='disco'>
 	<p>If an entity supports the Chat Markers protocol, it MUST report that by including a &xep0030;
 	 feature of "urn:xmpp:chat-markers:0" in response to disco#info requests:</p>
-<example caption='Client queries for server features'>
+<example caption='Client queries for features'>
 <![CDATA[
-<iq type='get' id='disco1' to='capulet.lit' from='juliet@capulet.lit/balcony'>
+<iq type='get' id='disco1' to='romeo@montague.lit/mobile' from='juliet@capulet.lit/balcony'>
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>
 ]]>
@@ -139,7 +145,7 @@
 
 <example caption='Entity responds with features'>
 <![CDATA[
-<iq type='result' id='disco1' from='capulet.lit' to='juliet@capulet.lit/balcony'>
+<iq type='result' id='disco1' from='romeo@montague.lit/mobile' to='juliet@capulet.lit/balcony'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     ...
     <feature var='urn:xmpp:chat-markers:0'/>


### PR DESCRIPTION
The 'discover support' example should not use a server/domain JID, as there's precious little for servers to support. Instead, a client JID is used.