### PR TITLE
XEP-0060: Release version 1.26.0

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -51,6 +51,14 @@
   &stpeter;
   &ralphm;
   <revision>
+    <version>1.26.0</version>
+    <date>2023-09-07</date>
+    <initials>melvo</initials>
+    <remark>
+      <p>Add examples for publishing item without ID</p>
+    </remark>
+  </revision>
+  <revision>
     <version>1.25.0</version>
     <date>2023-03-22</date>
     <initials>mw, pep</initials>
@@ -2761,7 +2769,6 @@ And by opposing end them?
         <li>Depending on the node configuration, the &lt;publish/&gt; element MAY contain no &ITEM; elements or one &ITEM; element. <note>The inclusion of more than one &ITEM; element is no longer allowed, given the removal of batch publishing from version 1.13 of this specification.</note> <note>It is not necessary for a publication request to include a payload or even an &ITEM; element in order to trigger an event notification. For example, the result of publishing to a transient, notification-only node will be an event notification that does not include even an &ITEM; element. However, for the sake of convenience we refer to the act of publication as "publishing an item" (rather than, say, "triggering an event notification") even though a publication request will not always contain an &ITEM; element.</note></li>
         <li>The &lt;item/&gt; element provided by the publisher MAY possess an 'id' attribute, specifying a unique ItemID for the item. If an ItemID is not provided in the publish request, the pubsub service MUST generate one and MUST ensure that it is unique for that node.</li>
       </ul>
-      <p>An example follows.</p>
       <example caption='Publisher publishes an item with an ItemID'><![CDATA[
 <iq type='set'
     from='hamlet@denmark.lit/blogbot'
@@ -2790,6 +2797,34 @@ And by opposing end them?
   </pubsub>
 </iq>
 ]]></example>
+      <example caption='Publisher publishes an item without an ItemID'><![CDATA[
+<iq type='set'
+    from='hamlet@denmark.lit/blogbot'
+    to='pubsub.shakespeare.lit'
+    id='publish2'>
+  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+    <publish node='princely_musings'>
+      <item>
+        <entry xmlns='http://www.w3.org/2005/Atom'>
+          <title>Soliloquy</title>
+          <summary>
+To be, or not to be: that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles,
+And by opposing end them?
+          </summary>
+          <link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/>
+          <id>tag:denmark.lit,2003:entry-32397</id>
+          <published>2003-12-13T18:30:02Z</published>
+          <updated>2003-12-13T18:30:02Z</updated>
+        </entry>
+      </item>
+    </publish>
+  </pubsub>
+</iq>
+]]></example>
     </section3>
     <section3 topic='Success Case' anchor='publisher-publish-success'>
       <p>If the pubsub service can successfully process the request, it MUST inform the publisher of success. If the publish request did not include an ItemID, the IQ-result SHOULD include an empty &ITEM; element that specifies the ItemID of the published item.</p>
@@ -2798,6 +2833,16 @@ And by opposing end them?
     from='pubsub.shakespeare.lit'
     to='hamlet@denmark.lit/blogbot'
     id='publish1'>
+  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+    <publish node='princely_musings'/>
+  </pubsub>
+</iq>
+]]></example>
+      <example caption='Service replies with success and the ID of the new item'><![CDATA[
+<iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/blogbot'
+    id='publish2'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
     <publish node='princely_musings'>
       <item id='ae890ac52d0df67ed7cfdf51b644e901'/>


### PR DESCRIPTION
Fix and add examples for publishing items:

* Remove 'item' element specifying its ID from example response for publishing item with ID
* Add examples for publishing item without ID