### PR TITLE
Add license for bibliographic data (third attempt)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM xmppxsf/xeps-base:latest as build
 ARG NCORES=1
 ARG TARGETS="html inbox-html inbox-xml pdf xeplist refs xml"
 
-COPY *.xml xep.* *.css *.xsl *.js *.xsl Makefile /src/
+COPY *.xml xep.* *.css *.xsl *.js *.xsl Makefile refs-LICENSE /src/
 COPY resources/*.pdf /src/resources/
 COPY tools/*.py /src/tools/
 COPY inbox/*.xml inbox/*.ent inbox/*.dtd /src/inbox/

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,11 @@ inbox-xml: $(OUTDIR)/inbox $(proto_xep_xmls)
 .PHONY: pdf
 pdf: $(xep_pdfs)
 
+$(REFSDIR)/LICENSE: refs-LICENSE
+	cp $< $@
+
 .PHONY: refs
-refs: $(xep_refs)
+refs: $(xep_refs) $(REFSDIR)/LICENSE
 
 .PHONY: examples
 examples: $(xep_examples)

--- a/refs-LICENSE
+++ b/refs-LICENSE
@@ -1,0 +1,9 @@
+To the extent possible under law, the XMPP Standards Foundation (XSF)
+has waived all copyright and related or neighboring rights to XSF's
+bibliographic data.
+
+That is, the bibliographic data, which is also accessible via
+https://xmpp.org/extensions/refs/, is put in the public domain via
+CC0 1.0 [1].
+
+1: https://creativecommons.org/publicdomain/zero/1.0/


### PR DESCRIPTION
We were asked [1] to state that the XEP bibliographic data is openly available and free of charge if we want it to be consumed by third parties.

This weas previously merged as 747738804a2d ("Add license for bibliographic data"), but unfortunately later reverted in 59b2a5ca15c9 ("Revert "Add license for bibliographic data"", https://github.com/xsf/xeps/pull/1221). However, the fix for the broken docker build is trivial: simply also copy refs-LICENSE into the container. This commit does that.

Fixes #1219.

1: https://github.com/ietf-tools/bibxml-service/issues/302#issuecomment-1274686153