### PR TITLE
Makefile: remove .SILENT, make the targets loud

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-.SILENT:
-
 OUTDIR?=build
 REFSDIR?=$(OUTDIR)/refs
 EXAMPLESDIR?=$(OUTDIR)/examples


### PR DESCRIPTION
The Makefile was set globally to silent, which caused the failing commands to be *not* displayed. For example

```bash
flo@neo-pc xeps-xsf $ make html
make: *** [Makefile:112: build/xep-0001.html] Error 1
```

Removing this provides usefull information about which command failed:

```bash
flo@neo-pc xeps-xsf $ make html
xmllint --nonet --noout --noent --loaddtd --valid "xep-0001.xml" ! xmllint --nonet --noout --noent --loaddtd --xpath "//img/@src[not(starts-with(., 'data:'))]" xep-0001.xml 2>/dev/null && true make: *** [Makefile:110: build/xep-0001.html] Error 1
```