### PR TITLE
XEP-0483: Use XEP-0482 to send meeting URL to invitees

### DIFF
--- a/xep-0483.xml
+++ b/xep-0483.xml
@@ -29,7 +29,17 @@
     <surname>der Kinderen</surname>
     <email>guus.der.kinderen@gmail.com</email>
     <jid>guus.der.kinderen@igniterealtime.org</jid>
-  </author>
+  </author>  
+  <revision>
+    <version>0.2.0</version>
+    <date>2023-12-12</date>
+    <initials>do</initials>
+    <remark>
+      <ul>
+        <li>Use XEP-0482 to send the meeting link to another party</li>
+      </ul>
+    </remark>	  
+  </revision>   
   <revision>
     <version>0.1.0</version>
     <date>2023-12-11</date>
@@ -38,6 +48,7 @@
       <ul>
         <li>Promoted to Experimental.</li>
       </ul>
+    </remark>
   </revision>
   <revision>
     <version>0.0.3</version>
@@ -84,9 +95,23 @@
   </revision>
 </header>
 <section1 topic="Introduction" anchor="intro">
-  <p>XMPP protocol extensions already defines a method for initiating peer-to-peer media sessions such as &xep0166; however due to its very nature of being peer-to-peer it does not work very well in scenarios with online meetings. It also does not work alongside offline storage, MUC history and &xep0313;.</p>
-  <p>Using a web browser to manually request a URL from an HTTP server and sharing the link has been a workaround for this for a long time now. While users have a variety of services to choose from, the downside of this manual approach is that an XMPP client can not automate this process on behalf of the user since these services don’t share a common API.</p>
-  <p>This XEP defines an approach to request initiation of an online meeting via an HTTP server and receive a URL can be used to join and invite others to the meeting.</p>
+  <p>XMPP protocol extensions already defines a method for initiating peer-to-peer media sessions such as &xep0166; however due to its very nature of being peer-to-peer it presents a few challenges in scenarios with online meetings that depend on a central Selective Forwarding Unit (SFU) or a Multipoint Control Unit (MCU) to host the meeting..</p>
+  <p>Using a web browser to manually request a meeting URL from an HTTP server and sharing the link has been a workaround for this for a long time now. While users have a variety of services to choose from, the downside of this manual approach is that an XMPP client can not automate this process on behalf of the user since these services don’t share a common API.</p>
+  <p>This XEP defines an approach to request initiation of an online meeting via an HTTP server and receive a URL can be used to join and invite others to the meeting. It has two main features:</p>
+  <ol>
+	  <li>An IQ-based protocol to request a meeting link from a server.</li>
+	  <li>An element that can be added to a message stanza for sending the received meeting link to another party</li>
+  </ol>
+  <p>
+  The second feature is achieved by using &xep0482;, which describes
+  call invites using Jingle and external URIs. The XEP mentions how a web URLs can be used as external URI to join a call. For completeness, an example is repeated here to explicitly show how meeting invitations should be sent to invitees.
+  </p>
+  <p>
+	&xep0482; has other call mangement features, like announcing call join and
+	leave on the XMPP side. These are relevant for online meetings when the website behind the URL is opened
+	in a frame or similar inside the XMPP client. The meeting host xmpp client can track meeting participants and know when users leave the meeting without having to depend on APIs provided by the meeting service provider which may present cross-domain challenges.
+	For completeness, examples are also repeated in this XEP to explicity show their application for online meeting invitations.
+  </p>
 </section1>
 <section1 topic="Requirements" anchor="reqs">
   <ul>
@@ -178,23 +203,26 @@
   <query xmlns='urn:xmpp:http:online-meetings:0'
          type='jitsi'>
     <desc>Meeting room for Open Standards discussion</desc>
+  </query>	
 </iq>]]></example>
-  <p>The XMPP server responds with one or two child elements: a 'initiate' element that contains a URL to be used to create and configure the meeting, and an 'invite' element that contains a URL suitable to invite others into the meeting.</p>
+  <p>The XMPP server responds with one or two child elements: a 'initiate' element that contains a URL to be used to create and configure the meeting, and an 'invite' element as specified by &xep0482; to invite others into the meeting.</p>
   <p>In the URLs that it returns, the server MAY specify a web-based protocol handler if available and registered by the user. Otherwise, standard HTTPS protocol will be specified. In any case, the fully resolved URL provided by the host MUST provide Transport Layer Security (&rfc5246;). The HTTPS URL MUST adhere to &rfc3986;. Non ASCII characters MUST be percent-encoded.</p>
-  <example caption="The server responds with an out of band URI specifying the jitsi web-based protocol handler"><![CDATA[
+  <example caption="The server responds with an out of band URI specifying a registered jitsi web-based protocol handler"><![CDATA[
 <iq from='montague.tld'
     to='romeo@montague.tld/garden'
     id='initiate_03'
     type='result'>
   <query xmlns='urn:xmpp:http:online-meetings:0'>
     <initiate type='jitsi'>
-      <url>web+jitsi:https://meet.jit.si/OpenStandardsMuchGreatness</url>
+      <url>web+jitsi:OpenStandardsMuchGreatness</url>
       <desc>Meeting room for Open Standards discussion</desc>
     </initiate>
-    <invite type='jitsi'>
-      <url>web+jitsi:https://meet.jit.si/OpenStandardsMuchGreatness</url>
-      <desc>Meeting room for Open Standards discussion</desc>
-    </invite>
+    <invite xmlns='urn:xmpp:call-invites:0'>
+	  <external uri='web+jitsi:OpenStandardsMuchGreatness' />
+	  <meeting xmlns='urn:xmpp:http:online-meetings:0' 
+               type='jitsi' 
+               desc='Meeting room for Open Standards discussion' />
+    </invite>  	
   </query>
 </iq>]]></example>
   <example caption="The server responds with an out of band URI using standard HTTPS"><![CDATA[
@@ -207,10 +235,12 @@
       <url>https://meet.jit.si/OpenStandardsMuchGreatness</url>
       <desc>Meeting room for Open Standards discussion</desc>
     </initiate>
-    <invite type='jitsi'>
-      <url>https://meet.jit.si/OpenStandardsMuchGreatness</url>
-      <desc>Meeting room for Open Standards discussion</desc>
-    </invite>
+    <invite xmlns='urn:xmpp:call-invites:0'>
+	  <external uri='https://meet.jit.si/OpenStandardsMuchGreatness' />
+	  <meeting xmlns='urn:xmpp:http:online-meetings:0' 
+               type='jitsi' 
+               desc='Meeting room for Open Standards discussion' />
+    </invite>  
   </query>
 </iq>]]></example>
   <p>The XMPP server MAY be tightly integrated with the Meeting Provider and facilitate registration, configuration and association of a web-based protocol handler, but the protocol to implement such integration is out of scope of this document.</p>
@@ -272,25 +302,82 @@
 </iq>]]></example>
 </section1>
 <section1 topic="Meeting Invitation" anchor="meeting-invitation">
-  <p>After the requesting entity has successfully initiated a meeting, it MAY invite other entities to join the meeting. It does so by sending invitees a message stanza containing an 'invite' child element, qualified by the online-meetings namespace, as was sent by the server in response to the initiation request.</p>
-  <p>To allow users of clients that do not support this XEP to receive the invitation, a &xep0066; element and/or a 'body' element containing the meeting details MAY be included.</p>
-  <example caption="User sends meeting invitation"><![CDATA[
+  <p>After the requesting entity has successfully initiated a meeting, it MAY invite other entities to join the meeting using the 'invite' element it received to propose the meeting</p>
+  <p>To allow users of clients that do not support &xep0482; to receive the invitation, a &xep0066; element and/or a 'body' element containing the meeting details MAY be included.</p>	
+  <p>There is no further XMPP communication required between the server and the requesting entity for participants to join the meeting. The actual online meeting engagement with the provided URL is out of scope of this document.</p>
+
+  <section2 topic="Proposing a meeting" anchor="meeting-proposal">  
+    <p>
+	Invitees are sent a message containing an &lt;invite&gt; element in the urn:xmpp:call-invites:0
+	namespace. For online meetings, the audio video attributes should default to "true". 
+	</p><p>
+	The &lt;invite&gt; element contains sub-elements &lt;external&gt; and &lt;meeting&gt; to provide the meeting URL and the identity of the meeting service provider.
+    </p>	<example caption="User sends meeting invitation"><![CDATA[
 <message
+    id='invite_01'
     from='romeo@montague.tld/garden'
     to='juliet@capulet.example/balcony'>
-  <invite xmlns='urn:xmpp:http:online-meetings:0'
-          type='jitsi'>
-    <url>https://meet.jit.si/OpenStandardsMuchGreatness</url>
-    <desc>Meeting room for Open Standards discussion</desc>
-  </invite>
+  <invite xmlns='urn:xmpp:call-invites:0'>
+    <external uri='https://meet.jit.si/OpenStandardsMuchGreatness' />
+    <meeting xmlns='urn:xmpp:http:online-meetings:0' 
+             type='jitsi' 
+             desc='Meeting room for Open Standards discussion' />
+  </invite>  
   <x xmlns='jabber:x:oob'>
     <url>https://meet.jit.si/OpenStandardsMuchGreatness</url>
     <desc>Meeting room for Open Standards discussion</desc>
   </x>
   <body>You are invited to join 'Meeting room for Open Standards discussion' at https://meet.jit.si/OpenStandardsMuchGreatness</body>
 </message>]]></example>
-  <p>There is no further XMPP communication required between the server and the client for the client to join the meeting. The actual online meeting engagement with the provided URL is out of scope of this document.</p>
-</section1>
+  </section2>
+    <section2 topic="Retracting a meeting invitation"  anchor="meeting-retraction">
+      <p>
+        A meeting invitation can be retracted by sending a message containing a &lt;retract&gt; element with an 'id' attribute
+        containing the id of the invite message qualified by the urn:xmpp:call-invites:0 namespace.
+      </p>
+      <example caption="Retracting a meeting"><![CDATA[
+<message to='juliet@capulet.example/balcony'>
+  <retract id='invite_01' xmlns='urn:xmpp:call-invites:0' />
+</message>]]></example>
+    </section2>
+    <section2 topic="Accepting a meeting invitation"  anchor="meeting-acceptance">
+      <p>
+        A meeting invitation can be accepted by sending a message containing an &lt;accept&gt; element with an 'id' attribute
+        containing the id of the invite message and qualified by the urn:xmpp:call-invites:0 namespace.
+        The &lt;external&gt; and &lt;meeting&gt; elements from the invitation are placed in the &lt;accept&gt; element as specified in &xep0482;.
+      </p>
+      <example caption="Accepting a meeting invitation"><![CDATA[
+<message to='romeo@montague.tld/garden'>
+  <accept id='invite_01' xmlns='urn:xmpp:call-invites:0'>
+    <external uri='https://meet.jit.si/OpenStandardsMuchGreatness' />
+    <meeting type='jitsi' desc='Meeting room for Open Standards discussion' />
+  </accept>
+</message>]]></example>
+      <p>
+        After the &lt;accept&gt; was sent, the accepting client handles the URI. The exact behaviour of opening the URI is implementation specific and can be determined from the type attribute of the &lt;meeting&gt; element.
+      </p>
+    </section2>
+    <section2 topic="Rejection a meeting invitation"  anchor="meeting-rejection">
+      <p>
+        A meeting invitation can be rejected by sending a message containing a &lt;reject&gt; element with an 'id' attribute
+        containing the id of the invite message and qualified by the urn:xmpp:call-invites:0 namespace.
+      </p>
+      <example caption="Rejecting a meeting invitation"><![CDATA[
+<message to='romeo@montague.tld/garden'>
+  <reject id='invite_01' xmlns='urn:xmpp:call-invites:0' />
+</message>]]></example>
+    </section2>
+    <section2 topic="Leaving a meeting"  anchor="meeting-exit">
+      <p>
+        When a meeting participant leaves a meeting, it sends a message containing a &lt;left&gt; element with an 'id' attribute
+        containing the id of the invite message and qualified by the urn:xmpp:call-invites:0 namespace.
+      </p>
+      <example caption="Leaving a meeting"><![CDATA[
+<message to='romeo@montague.tld/garden'>
+  <left id='invite_01' xmlns='urn:xmpp:call-invites:0' />
+</message>]]></example>
+    </section2>  
+ </section1>
 <section1 topic="Implementation Notes" anchor="impl">
   <p>The server SHOULD choose an appropriate timeout for the validity of the URL. Since there is no reason for a client to wait between requesting the URL and joining the meeting via the URL before dispatching invitations, relatively low timeout values of around 300s are RECOMMENDED.</p>
 </section1>


### PR DESCRIPTION
This PR is in response to [this request](https://www.mail-archive.com/standards@xmpp.org/msg23624.html)

>Hi,
>This XEP has two parts:
>1. An IQ-based protocol to request a meeting link from a server.
>2. An additional element to add to a message to send the meeting link
to another party
>
>The second feature is already available via XEP-0482, which describes
call invites using Jingle and external URIs. The XEP already mentions
weblinks to join the call as an example for such external URIs.
As XEP-0482 has a bunch of other features, like announcing join and
leave on the XMPP side (works especially great if the website is opened
in a frame or similar inside the XMPP client, as the XMPP client then
even knows when the user left the call) or the ability to additionally
announce dial-in tel:-URIs (which some Jitsi instances also support and
may be very useful for mobile clients).
>
>Therefore, I'm proposing to remove the second part from the XEP (or
better: replace it with how to use XEP-0482 for this purpose).
>
>If it is desirable to have a way to signal that the URL is a jitsi URL,
I propose to instead have that as an additional element in the XEP-0482
<invite> (which it mentions as a possible extension point
"Specifications that describe further ways to join a call define their
own sub-elements to the <invite> element"). This element (e.g. <jitsi
xmlns='urn:xmpp:http:online-meetings:0' url='<url>'/>) would be
additional to the <external> element, so that receiving clients that
don't understand this proposed XEP, but do understand XEP-0482 will
still have a reasonably good UX, just nothing jitsi specific. Replace
jitsi in this paragraph with any other online meeting tool as you see
fit.
>
>Marvin