### PR TITLE
ProtoXEP: PubSub Server Information

### DIFF
--- a/inbox/pubsub-server-info.xml
+++ b/inbox/pubsub-server-info.xml
@@ -73,7 +73,8 @@
 <serverinfo xmlns='urn:xmpp:serverinfo:0'>
   <domain name='shakespeare.lit'/>
 </serverinfo>]]></example>
-  <p>The optional 'federation' child element is used to denote remote XMPP domains with which the local domain is federating. Each of them are represented by an element named 'remote-domain'. The domain name of the peer in an attribute named 'name'. Optionally, each actual (e.g. TCP) connection from the local server to the peer is added as a 'connection' child-element to the 'remote-domain' element, that has an optional 'type' attribute, defining the directionality of the connection (one of 'incoming', 'outgoing' and 'bidi').</p>
+  <p>The optional 'federation' child element is used to denote remote XMPP domains with which the local domain is federating. Each of them are represented by an element named 'remote-domain'. The domain name of the peer in an optional attribute named 'name'. Optionally, each actual (e.g. TCP) connection from the local server to the peer is added as a 'connection' child-element to the 'remote-domain' element, that has an optional 'type' attribute, defining the directionality of the connection (one of 'incoming', 'outgoing' and 'bidi').</p>
+  <p>The name of a remote domain MUST only be included if the remote server advertises supporting for this XEP. This acts as an opt-in mechanism, to address the privacy concern defined in the <link url="#privacy">Privacy Considerations section</link> of this document.</p>
   <example caption="Data Format with Federated Domains"><![CDATA[
 <serverinfo xmlns="urn:xmpp:serverinfo:0">
   <domain name="shakespeare.lit">
@@ -88,7 +89,7 @@
     </federation>
   </domain>
 </serverinfo>]]></example>
-  <p>Additional data MAY be included as child-elements of the 'server-info' element or any of the 'domain' elements. Such data MUST be namespaced appropriately. The example below uses the 'query' element defined in &xep0092; to include information about the software application associated with the local server.</p>
+  <p>Additional data MAY be included as child-elements of the 'serverinfo' element or any of the 'domain' elements. Such data MUST be namespaced appropriately. The example below uses the 'query' element defined in &xep0092; to include information about the software application associated with the local server.</p>
   <example caption="Data Format with Software Version"><![CDATA[
 <serverinfo xmlns="urn:xmpp:serverinfo:0">
   <domain name="shakespeare.lit">
@@ -135,6 +136,9 @@
 </section1>
 <section1 topic="Implementation Notes" anchor="impl">
   <p>As certain information can be expected to be updated continuously and frequently, the server MAY choose to reduce the frequency of updates of the 'serverinfo' pub-sub node.</p>
+</section1>
+<section1 topic="Privacy Considerations" anchor="privacy">
+  <p>When multiple domains publish their connections to named remote domains, an information leak occurs: by collecting these public statistics, behavioral data of those remote domains can be deduced. To prevent undesired privacy-sensitive information leaks, a domain MUST NOT publish the name of a remote domain, unless that domain advertises support for this XEP.</p>
 </section1>
 <section1 topic="IANA Considerations" anchor="iana">
   <p>This document requires no interaction with the &IANA;</p>

--- a/inbox/pubsub-server-info.xml
+++ b/inbox/pubsub-server-info.xml
@@ -1,0 +1,206 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY % ents SYSTEM '../xep.ent'>
+  %ents;
+  ]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep xmlns="">
+<header>
+  <title>PubSub Server Information</title>
+  <abstract>This document defines a data format whereby basic information of an XMPP domain can be expressed and exposed over pub-sub.</abstract>
+  &LEGALNOTICE;
+  <number>xxxx</number>
+  <status>ProtoXEP</status>
+  <type>Standards Track</type>
+  <sig>Standards</sig>
+  <approver>Council</approver>
+  <dependencies/>
+  <supersedes/>
+  <supersededby/>
+  <shortname>serverinfo</shortname>
+  <author>
+    <firstname>Guus</firstname>
+    <surname>der Kinderen</surname>
+    <email>guus.der.kinderen@gmail.com</email>
+    <jid>guus.der.kinderen@igniterealtime.org</jid>
+  </author>
+  <revision>
+    <version>1.0.0</version>
+    <date>2023-12-19</date>
+    <initials>gdk</initials>
+    <remark>
+      <ul>
+        <li>Initial version.</li>
+      </ul>
+    </remark>
+  </revision>
+</header>
+<section1 topic="Introduction" anchor="intro">
+  <p>To facilitate discovery of information of individual domains in an XMPP-based network, this specification defines a data format to define basic information for individual XMPP domains. By leveraging &xep0060; this information can efficiently be shared with applications that compose an overview of the larger XMPP network.</p>
+</section1>
+  <section1 topic="Requirements" anchor="requirements">
+    <ul>
+      <li>Describe links between nodes in an XMPP-based network, by enumerating connections used for federation between XMPP domains.</li>
+      <li>An extensible data format, allowing additional data (such as that defined in &xep0092;) to be retrievable without requiring additional round-trips.</li>
+    </ul>
+  </section1>
+<section1 topic="Discovering Support" anchor="disco">
+  <p>Support is advertised by publishing a first-level leaf node using the name 'serverinfo' on a pub-sub service. An entity trying to discover support will, for a given domain name, use &xep0030; to identify a Publish-Subscribe service for the domain, and subsequently use service discovery to discover the node with name 'serverinfo' as defined in section 5.3 of &xep0060;.</p>
+    <example caption="Entity queries collection node for information"><![CDATA[
+<iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='info1'>
+  <query xmlns='http://jabber.org/protocol/disco#info'
+         node='serverinfo'/>
+</iq>]]></example>
+    <example caption="Service responds with identity of pubsub/leaf"><![CDATA[
+<iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='info1'>
+  <query xmlns='http://jabber.org/protocol/disco#info'
+         node='serverinfo'>
+    ...
+    <identity category='pubsub' type='leaf'/>
+    ...
+  </query>
+</iq>]]></example>
+</section1>
+<section1 topic="Data Format" anchor="impl">
+  <p>The data format uses an element named 'serverinfo' in the namespace 'urn:xmpp:serverinfo:0'. In its minimal form, it only defines the XMPP domain name in a child-element named 'domain'.</p>
+  <example caption="Minimal Data Format"><![CDATA[
+<serverinfo xmlns='urn:xmpp:serverinfo:0'>
+  <domain>shakespeare.lit</domain>
+</serverinfo>]]></example>
+  <p>The optional 'federation' child element is used to denote remote XMPP domains with which the local domain is federating. Each federated domain is added as a 'connection' child-element to the 'federation' element, that has an optional 'type' attribute, defining the directionality of the connection (one of 'incoming', 'outgoing' and 'both'). The domain name of the remote XMPP domain is added in a 'domain' child element.</p>
+  <example caption="Data Format with Federated Domains"><![CDATA[
+<serverinfo xmlns="urn:xmpp:serverinfo:0">
+  <domain>shakespeare.lit</domain>
+  <federation>
+    <connection type="incoming">
+      <domain>denmark.lit</domain>
+    </connection>
+    <connection type="both">
+      <domain>montague.net</domain>
+    </connection>
+    <connection type="outgoing">
+      <domain>capulet.com</domain>
+    </connection>
+  </federation>
+</serverinfo>]]></example>
+  <p>Additional data MAY be included in child-elements of the 'server-info' element. Such data MUST be namespaced appropriately. The example below uses the 'query' element defined in &xep0092; to include information about the software application associated with the local domain.</p>
+  <example caption="Data Format with Software Version"><![CDATA[
+<serverinfo xmlns="urn:xmpp:serverinfo:0">
+  <domain>shakespeare.lit</domain>
+  <federation>
+    <connection type="incoming">
+      <domain>denmark.lit</domain>
+    </connection>
+  </federation>
+  <query xmlns='jabber:iq:version'>
+    <name>Openfire</name>
+    <version>4.8.0</version>
+    <os>Windows 11</os>
+  </query>
+</serverinfo>]]></example>
+</section1>
+<section1 topic="Publication" anchor="impl">
+  <p>The data is to be published using a pub-sub node named 'serverinfo' that MUST be a first-level leaf node of a pub-sub service for the domain. It is RECOMMENDED that the leaf-node is configured to have an open access model and contain a maximum of 1 item.</p>
+  <example caption="Publish ServerInfo Item"><![CDATA[
+  <iq type='set'
+      from='william@shakespeare.lit/atwork'
+      to='pubsub.shakespeare.lit'
+      id='publish1'>
+    <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+      <publish node='serverinfo'>
+        <item id='current'>
+          <serverinfo xmlns="urn:xmpp:serverinfo:0">
+            <domain>shakespeare.lit</domain>
+            <federation>
+              <connection type="incoming">
+                <domain>denmark.lit</domain>
+              </connection>
+              <connection type="both">
+                <domain>montague.net</domain>
+              </connection>
+              <connection type="outgoing">
+                <domain>capulet.com</domain>
+              </connection>
+            </federation>
+          </serverinfo>
+        </item>
+      </publish>
+    </pubsub>
+  </iq>]]></example>
+</section1>
+<section1 topic="Implementation Notes" anchor="impl">
+  <p>As certain information can be expected to be updated continuously and frequently, the server MAY choose to reduce the frequency of updates of the 'serverinfo' pub-sub node.</p>
+</section1>
+<section1 topic="IANA Considerations" anchor="iana">
+  <p>This document requires no interaction with the &IANA;</p>
+</section1>
+<section1 topic="XMPP Registrar Considerations" anchor="registrar">
+  <section2 topic="Protocol Namespaces" anchor="registrar-ns">
+    <p>This specification defines the following XML namespaces:</p>
+    <ul>
+      <li>urn:xmpp:serverinfo:0</li>
+    </ul>
+    <p>Upon advancement of this specification from a status of Experimental to a status of Draft, the &REGISTRAR; shall add the foregoing namespace to the registry located at &NAMESPACES;, as described in Section 4 of &xep0053;.</p>
+  </section2>
+</section1>
+  <section1 topic='XML Schema' anchor='schema'>
+    <code><![CDATA[
+<?xml version='1.0' encoding='UTF-8'?>
+
+<xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='urn:xmpp:serverinfo:0'
+    xmlns='urn:xmpp:serverinfo:0'
+    elementFormDefault='qualified'>
+
+  <xs:annotation>
+    <xs:documentation>
+      The protocol documented by this schema is defined in
+      XEP-0XXX: http://www.xmpp.org/extensions/xep-0XXX.html
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="directionType" final="restriction" >
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="incoming" />
+      <xs:enumeration value="outgoing" />
+      <xs:enumeration value="both" />
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:element name="serverinfo">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element type="xs:string" name="domain"/>
+        <xs:element name="federation" use="optional">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="connection" maxOccurs="unbounded" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element type="xs:string" name="domain"/>
+                  </xs:sequence>
+                  <xs:attribute type="directionType" name="type" use="optional"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>
+]]></code>
+  </section1>
+  <section1 topic='Acknowledgements' anchor='acknowledgements'>
+    <p>Inspiration was taken from the (now defunct) 'server info' crawler by Thomas Leister. Many thanks to Dave Cridland, as well as 'zoidberg' from the Ignite Realtime community for helping to test the initial implementation of a graphing implementation based on this XEP.</p>
+  </section1>
+
+</xep>

--- a/inbox/pubsub-server-info.xml
+++ b/inbox/pubsub-server-info.xml
@@ -25,7 +25,7 @@
     <jid>guus.der.kinderen@igniterealtime.org</jid>
   </author>
   <revision>
-    <version>1.0.0</version>
+    <version>0.0.1</version>
     <date>2023-12-19</date>
     <initials>gdk</initials>
     <remark>

--- a/inbox/pubsub-server-info.xml
+++ b/inbox/pubsub-server-info.xml
@@ -46,7 +46,7 @@
   </section1>
 <section1 topic="Discovering Support" anchor="disco">
   <p>Domains supporting the publication of Server Information data, as described in this document, MUST advertise the fact by announcing a &xep0030; feature of 'urn:xmpp:serverinfo:0'. This signifies that an administrative entity approved the publication of data, which is important for the opt-in mechanism described in <link url="#privacy">Privacy Considerations section</link> of this document.</p>
-  <p>The pub-sub service address and node in which Server Information data is advertised SHOULD be specified using a &xep0128;. These pub-sub coordinates MUST be scoped using a FORM_TYPE of "http://jabber.org/network/serverinfo" (as already specified in XEP-0128) and data form fields registered for this purpose as defined in the <link url="#registrar">XMPP Registrar Considerations section</link> of this document.</p>
+  <p>The pub-sub service address and node in which Server Information data is advertised SHOULD be specified using a &xep0128;. These pub-sub coordinates MUST be scoped using a FORM_TYPE of "http://jabber.org/network/serverinfo" (as specified in XEP-0157) and data form fields registered for this purpose as defined in the <link url="#registrar">XMPP Registrar Considerations section</link> of this document.</p>
   <p>When the 'urn:xmpp:serverinfo:0' feature but no corresponding Service Discovery Extension is advertised, the node that is used will be a first-level leaf node using the name 'serverinfo' on the first pub-sub service advertised through service discovery.</p>
   <example caption="Service Discovery information request"><![CDATA[
 <iq type='get'

--- a/inbox/pubsub-server-info.xml
+++ b/inbox/pubsub-server-info.xml
@@ -45,8 +45,40 @@
     </ul>
   </section1>
 <section1 topic="Discovering Support" anchor="disco">
-  <p>Support is advertised by publishing a first-level leaf node using the name 'serverinfo' on a pub-sub service. An entity trying to discover support will, for a given domain name, use &xep0030; to identify a Publish-Subscribe service for the domain, and subsequently use service discovery to discover the node with name 'serverinfo' as defined in section 5.3 of &xep0060;.</p>
-    <example caption="Entity queries collection node for information"><![CDATA[
+  <p>Domains supporting the publication of Server Information data, as described in this document, MUST advertise the fact by announcing a &xep0030; feature of 'urn:xmpp:serverinfo:0'. This signifies that an administrative entity approved the publication of data, which is important for the opt-in mechanism described in <link url="#privacy">Privacy Considerations section</link> of this document.</p>
+  <p>The pub-sub service address and node in which Server Information data is advertised SHOULD be specified using a &xep0128;. These pub-sub coordinates MUST be scoped using a FORM_TYPE of "http://jabber.org/network/serverinfo" (as already specified in XEP-0128) and data form fields registered for this purpose as defined in the <link url="#registrar">XMPP Registrar Considerations section</link> of this document.</p>
+  <p>When the 'urn:xmpp:serverinfo:0' feature but no corresponding Service Discovery Extension is advertised, the node that is used will be a first-level leaf node using the name 'serverinfo' on the first pub-sub service advertised through service discovery.</p>
+  <example caption="Service Discovery information request"><![CDATA[
+<iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='shakespeare.lit'
+    id='disco1'>
+  <query xmlns='http://jabber.org/protocol/disco#info'/>
+</iq>]]></example>
+  <example caption="Service Discovery information response"><![CDATA[
+<iq type='result'
+  from='shakespeare.lit'
+  to='francisco@denmark.lit/barracks'
+  id='disco1'>
+  <query xmlns='http://jabber.org/protocol/disco#info'>
+    ...
+    <feature var='urn:xmpp:serverinfo:0'/>
+    ...
+    <x xmlns='jabber:x:data' type='result'>
+      <field var='FORM_TYPE' type='hidden'>
+        <value>http://jabber.org/network/serverinfo</value>
+      </field>
+      <field var='serverinfo-pubsub-service'>
+        <value>pubsub.shakespeare.lit</value>
+      </field>      
+      <field var='serverinfo-pubsub-node'>
+        <value>serverinfo</value>
+      </field>      
+    </x>
+  </query>
+</iq>]]></example>
+  <p>The node MUST reference a first-level leaf node on a pub-sub service.</p>
+    <example caption="Entity queries root node for information"><![CDATA[
 <iq type='get'
     from='francisco@denmark.lit/barracks'
     to='pubsub.shakespeare.lit'
@@ -138,19 +170,39 @@
   <p>As certain information can be expected to be updated continuously and frequently, the server MAY choose to reduce the frequency of updates of the 'serverinfo' pub-sub node.</p>
 </section1>
 <section1 topic="Privacy Considerations" anchor="privacy">
-  <p>When multiple domains publish their connections to named remote domains, an information leak occurs: by collecting these public statistics, behavioral data of those remote domains can be deduced. To prevent undesired privacy-sensitive information leaks, a domain MUST NOT publish the name of a remote domain, unless that domain advertises support for this XEP.</p>
-</section1>
-<section1 topic="IANA Considerations" anchor="iana">
-  <p>This document requires no interaction with the &IANA;</p>
+  <p>When multiple domains publish their connections to named remote domains, an information leak occurs: by collecting these public statistics, behavioral data of those remote domains can be deduced. To prevent undesired privacy-sensitive information leaks, a domain MUST NOT publish the name of a remote domain, unless that domain advertises support for this XEP, as defined in the <link url="#disco">Discovering Support section</link> of this document.</p>
+  <p>This way, the service discovery mechanism doubles as an opt-in mechanism. Domains that advertise support for this XEP allow other domains to reference them by domain-name in the data that they publish. The mere presence of an applicable pub-sub node MUST NOT be used for Service Discovery purposes, as under common service configuration, non-administrative users are allowed to create such nodes.</p>
 </section1>
 <section1 topic="XMPP Registrar Considerations" anchor="registrar">
+  <p>Upon advancement of this specification from a status of Experimental to a status of Draft, the &REGISTRAR; shall include the following information in its registries.</p>
   <section2 topic="Protocol Namespaces" anchor="registrar-ns">
     <p>This specification defines the following XML namespaces:</p>
     <ul>
       <li>urn:xmpp:serverinfo:0</li>
     </ul>
-    <p>Upon advancement of this specification from a status of Experimental to a status of Draft, the &REGISTRAR; shall add the foregoing namespace to the registry located at &NAMESPACES;, as described in Section 4 of &xep0053;.</p>
+    <p>The &REGISTRAR; shall add the foregoing namespace to the registry located at &NAMESPACES;, as described in Section 4 of &xep0053;.</p>
   </section2>
+  <section2 topic='Field Standardization' anchor='registrar-formtype'>
+    <p>&xep0068; defines a process for standardizing the fields used within Data Forms qualified by a particular namespace, and <cite>XEP-0128</cite> describes how to use field standardization in the context of service discovery. This section registers fields for server information scoped by the "http://jabber.org/network/serverinfo" FORM_TYPE.</p>
+    <code caption='Registry Submission'><![CDATA[
+<form_type>
+  <name>http://jabber.org/network/serverinfo</name>
+  <doc>XEP-0XXX</doc>
+  <desc>
+    Forms advertising the coordinates of a pub-sub service and node for publication of Server Information data.
+  </desc>
+  <field
+      var='serverinfo-pubsub-service'
+      type='list-multi'
+      label='The address of a pub-sub service that hosts a node on which Server Information data is published.'/>
+  <field
+      var='serverinfo-pubsub-node'
+      type='list-multi'
+      label='A nodeId on which Server Information data is published.'/>
+</form_type>
+]]></code>
+    <p>Note that the FORM_TYPE used by &xep0157; is purposefully re-used by this XEP, to circumvent the restriction of having at most one XMPP Standards Foundation defined FORM_TYPE for a service discovery identity, as defined in &xep0128;. When a service supports both features, the data in both forms SHOULD be merged into one form.</p>
+  </section2>  
 </section1>
   <section1 topic='XML Schema' anchor='schema'>
     <code><![CDATA[
@@ -217,7 +269,7 @@
 ]]></code>
   </section1>
   <section1 topic='Acknowledgements' anchor='acknowledgements'>
-    <p>Inspiration was taken from the (now defunct) 'server info' crawler by Thomas Leister. Many thanks to Dave Cridland, as well as 'zoidberg' and 'chewie' from the Ignite Realtime community for helping to test the initial implementation of a graphing implementation based on this XEP and to Florian Schmaus, Matthew Wild and Jonas Schäfer for their feedback on the earliest drafts of this document.</p>
+    <p>Inspiration was taken from the (now defunct) 'server info' crawler by Thomas Leister. Many thanks to Dave Cridland, as well as 'zoidberg' and 'chewie' from the Ignite Realtime community for helping to test the initial implementation of a graphing implementation based on this XEP and to Florian Schmaus, Matthew Wild, Jonas Schäfer and Kevin Smith for their feedback on the earliest drafts of this document.</p>
   </section1>
 
 </xep>

--- a/inbox/pubsub-server-info.xml
+++ b/inbox/pubsub-server-info.xml
@@ -68,36 +68,36 @@
 </iq>]]></example>
 </section1>
 <section1 topic="Data Format" anchor="impl">
-  <p>The data format uses an element named 'serverinfo' in the namespace 'urn:xmpp:serverinfo:0'. In its minimal form, it only defines the XMPP domain name in a child-element named 'domain'.</p>
+  <p>The data format uses an element named 'serverinfo' in the namespace 'urn:xmpp:serverinfo:0'. In its minimal form, it defines each XMPP domain name served by the local server in an attribute named 'name'.</p>
   <example caption="Minimal Data Format"><![CDATA[
 <serverinfo xmlns='urn:xmpp:serverinfo:0'>
-  <domain>shakespeare.lit</domain>
+  <domain name='shakespeare.lit'/>
 </serverinfo>]]></example>
-  <p>The optional 'federation' child element is used to denote remote XMPP domains with which the local domain is federating. Each actual (eg TCP) connection to a federated domain is added as a 'connection' child-element to the 'federation' element, that has an optional 'type' attribute, defining the directionality of the connection (one of 'incoming', 'outgoing' and 'bidi'). The domain name of the remote XMPP domain is added in a 'domain' child element.</p>
+  <p>The optional 'federation' child element is used to denote remote XMPP domains with which the local domain is federating. Each of them are represented by an element named 'remote-domain'. The domain name of the peer in an attribute named 'name'. Optionally, each actual (e.g. TCP) connection from the local server to the peer is added as a 'connection' child-element to the 'remote-domain' element, that has an optional 'type' attribute, defining the directionality of the connection (one of 'incoming', 'outgoing' and 'bidi').</p>
   <example caption="Data Format with Federated Domains"><![CDATA[
 <serverinfo xmlns="urn:xmpp:serverinfo:0">
-  <domain>shakespeare.lit</domain>
-  <federation>
-    <connection type="incoming">
-      <domain>denmark.lit</domain>
-    </connection>
-    <connection type="bidi">
-      <domain>montague.net</domain>
-    </connection>
-    <connection type="outgoing">
-      <domain>capulet.com</domain>
-    </connection>
-  </federation>
+  <domain name="shakespeare.lit">
+    <federation>
+      <remote-domain name='denmark.li'>
+        <connection type="incoming"/>
+        <connection type="outgoing"/>
+      </remote-domain>
+      <remote-domain name='montague.net'>
+        <connection type="bidi"/>
+      </remote-domain>
+    </federation>
+  </domain>
 </serverinfo>]]></example>
-  <p>Additional data MAY be included in child-elements of the 'server-info' element. Such data MUST be namespaced appropriately. The example below uses the 'query' element defined in &xep0092; to include information about the software application associated with the local domain.</p>
+  <p>Additional data MAY be included as child-elements of the 'server-info' element or any of the 'domain' elements. Such data MUST be namespaced appropriately. The example below uses the 'query' element defined in &xep0092; to include information about the software application associated with the local server.</p>
   <example caption="Data Format with Software Version"><![CDATA[
 <serverinfo xmlns="urn:xmpp:serverinfo:0">
-  <domain>shakespeare.lit</domain>
-  <federation>
-    <connection type="incoming">
-      <domain>denmark.lit</domain>
-    </connection>
-  </federation>
+  <domain name="shakespeare.lit">
+    <federation>
+      <remote-domain name='montague.net'>
+        <connection type="bidi"/>
+      </remote-domain>
+    </federation>
+  </domain>
   <query xmlns='jabber:iq:version'>
     <name>Openfire</name>
     <version>4.8.0</version>
@@ -116,18 +116,17 @@
       <publish node='serverinfo'>
         <item id='current'>
           <serverinfo xmlns="urn:xmpp:serverinfo:0">
-            <domain>shakespeare.lit</domain>
-            <federation>
-              <connection type="incoming">
-                <domain>denmark.lit</domain>
-              </connection>
-              <connection type="bidi">
-                <domain>montague.net</domain>
-              </connection>
-              <connection type="outgoing">
-                <domain>capulet.com</domain>
-              </connection>
-            </federation>
+            <domain name="shakespeare.lit">
+              <federation>
+                <remote-domain name='denmark.li'>
+                  <connection type="incoming"/>
+                  <connection type="outgoing"/>
+                </remote-domain>
+                <remote-domain name='montague.net'>
+                  <connection type="bidi"/>
+                </remote-domain>
+              </federation>
+            </domain>
           </serverinfo>
         </item>
       </publish>
@@ -165,6 +164,8 @@
       XEP-0XXX: http://www.xmpp.org/extensions/xep-0XXX.html
     </xs:documentation>
   </xs:annotation>
+  
+  <xs:element name="serverinfo" type="urn:serverinfoType" xmlns:urn="urn:xmpp:serverinfo:0"/>
 
   <xs:simpleType name="directionType" final="restriction" >
     <xs:restriction base="xs:string">
@@ -174,33 +175,45 @@
     </xs:restriction>
   </xs:simpleType>
   
-  <xs:element name="serverinfo">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element type="xs:string" name="domain"/>
-        <xs:element name="federation" use="optional">
-          <xs:complexType>
-            <xs:sequence>
-              <xs:element name="connection" maxOccurs="unbounded" minOccurs="0">
-                <xs:complexType>
-                  <xs:sequence>
-                    <xs:element type="xs:string" name="domain"/>
-                  </xs:sequence>
-                  <xs:attribute type="directionType" name="type" use="optional"/>
-                </xs:complexType>
-              </xs:element>
-            </xs:sequence>
-          </xs:complexType>
-        </xs:element>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
+  <xs:complexType name="connectionType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="directionType" name="type" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="remote-domainType">
+    <xs:sequence>
+      <xs:element type="urn:connectionType" name="connection" maxOccurs="unbounded" minOccurs="0" xmlns:urn="urn:xmpp:serverinfo:0"/>
+    </xs:sequence>
+    <xs:attribute type="xs:string" name="name" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="federationType">
+    <xs:sequence>
+      <xs:element type="urn:remote-domainType" name="remote-domain" maxOccurs="unbounded" minOccurs="0" xmlns:urn="urn:xmpp:serverinfo:0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="domainType">
+    <xs:sequence>
+      <xs:element type="urn:federationType" name="federation" xmlns:urn="urn:xmpp:serverinfo:0"/>
+    </xs:sequence>
+    <xs:attribute type="xs:string" name="name"/>
+  </xs:complexType>
+
+  <xs:complexType name="serverinfoType">
+    <xs:sequence>
+      <xs:element type="urn:domainType" name="domain" xmlns:urn="urn:xmpp:serverinfo:0"/>
+    </xs:sequence>
+  </xs:complexType>
 
 </xs:schema>
 ]]></code>
   </section1>
   <section1 topic='Acknowledgements' anchor='acknowledgements'>
-    <p>Inspiration was taken from the (now defunct) 'server info' crawler by Thomas Leister. Many thanks to Dave Cridland, as well as 'zoidberg' from the Ignite Realtime community for helping to test the initial implementation of a graphing implementation based on this XEP.</p>
+    <p>Inspiration was taken from the (now defunct) 'server info' crawler by Thomas Leister. Many thanks to Dave Cridland, as well as 'zoidberg' and 'chewie' from the Ignite Realtime community for helping to test the initial implementation of a graphing implementation based on this XEP and to Florian Schmaus, Matthew Wild and Jonas Schäfer for their feedback on the earliest drafts of this document.</p>
   </section1>
 
 </xep>

--- a/inbox/pubsub-server-info.xml
+++ b/inbox/pubsub-server-info.xml
@@ -73,7 +73,7 @@
 <serverinfo xmlns='urn:xmpp:serverinfo:0'>
   <domain>shakespeare.lit</domain>
 </serverinfo>]]></example>
-  <p>The optional 'federation' child element is used to denote remote XMPP domains with which the local domain is federating. Each federated domain is added as a 'connection' child-element to the 'federation' element, that has an optional 'type' attribute, defining the directionality of the connection (one of 'incoming', 'outgoing' and 'both'). The domain name of the remote XMPP domain is added in a 'domain' child element.</p>
+  <p>The optional 'federation' child element is used to denote remote XMPP domains with which the local domain is federating. Each actual (eg TCP) connection to a federated domain is added as a 'connection' child-element to the 'federation' element, that has an optional 'type' attribute, defining the directionality of the connection (one of 'incoming', 'outgoing' and 'bidi'). The domain name of the remote XMPP domain is added in a 'domain' child element.</p>
   <example caption="Data Format with Federated Domains"><![CDATA[
 <serverinfo xmlns="urn:xmpp:serverinfo:0">
   <domain>shakespeare.lit</domain>
@@ -81,7 +81,7 @@
     <connection type="incoming">
       <domain>denmark.lit</domain>
     </connection>
-    <connection type="both">
+    <connection type="bidi">
       <domain>montague.net</domain>
     </connection>
     <connection type="outgoing">
@@ -121,7 +121,7 @@
               <connection type="incoming">
                 <domain>denmark.lit</domain>
               </connection>
-              <connection type="both">
+              <connection type="bidi">
                 <domain>montague.net</domain>
               </connection>
               <connection type="outgoing">
@@ -170,7 +170,7 @@
     <xs:restriction base="xs:string">
       <xs:enumeration value="incoming" />
       <xs:enumeration value="outgoing" />
-      <xs:enumeration value="both" />
+      <xs:enumeration value="bidi" />
     </xs:restriction>
   </xs:simpleType>
   

--- a/inbox/pubsub-server-info.xml
+++ b/inbox/pubsub-server-info.xml
@@ -106,7 +106,7 @@
   <domain name='shakespeare.lit'/>
 </serverinfo>]]></example>
   <p>The optional 'federation' child element is used to denote remote XMPP domains with which the local domain is federating. Each of them are represented by an element named 'remote-domain'. The domain name of the peer in an optional attribute named 'name'. Optionally, each actual (e.g. TCP) connection from the local server to the peer is added as a 'connection' child-element to the 'remote-domain' element, that has an optional 'type' attribute, defining the directionality of the connection (one of 'incoming', 'outgoing' and 'bidi').</p>
-  <p>The name of a remote domain MUST only be included if the remote server advertises supporting for this XEP. This acts as an opt-in mechanism, to address the privacy concern defined in the <link url="#privacy">Privacy Considerations section</link> of this document.</p>
+  <p>The name of a remote domain MUST only be included if the remote server advertises support for this XEP. This acts as an opt-in mechanism, to address the privacy concern defined in the <link url="#privacy">Privacy Considerations section</link> of this document.</p>
   <example caption="Data Format with Federated Domains"><![CDATA[
 <serverinfo xmlns="urn:xmpp:serverinfo:0">
   <domain name="shakespeare.lit">

--- a/inbox/pubsub-server-info.xml
+++ b/inbox/pubsub-server-info.xml
@@ -46,7 +46,7 @@
   </section1>
 <section1 topic="Discovering Support" anchor="disco">
   <p>Domains supporting the publication of Server Information data, as described in this document, MUST advertise the fact by announcing a &xep0030; feature of 'urn:xmpp:serverinfo:0'. This signifies that an administrative entity approved the publication of data, which is important for the opt-in mechanism described in <link url="#privacy">Privacy Considerations section</link> of this document.</p>
-  <p>The pub-sub service address and node in which Server Information data is advertised SHOULD be specified using a &xep0128;. These pub-sub coordinates MUST be scoped using a FORM_TYPE of "http://jabber.org/network/serverinfo" (as specified in XEP-0157) and data form fields registered for this purpose as defined in the <link url="#registrar">XMPP Registrar Considerations section</link> of this document.</p>
+  <p>The pub-sub service address and node in which Server Information data is advertised SHOULD be specified using a &xep0128;, using an URI as specified in section 12.22 of XEP-0060. These pub-sub coordinates MUST be scoped using a FORM_TYPE of "http://jabber.org/network/serverinfo" (as specified in XEP-0157) and data form field registered for this purpose as defined in the <link url="#registrar">XMPP Registrar Considerations section</link> of this document.</p>
   <p>When the 'urn:xmpp:serverinfo:0' feature but no corresponding Service Discovery Extension is advertised, the node that is used will be a first-level leaf node using the name 'serverinfo' on the first pub-sub service advertised through service discovery.</p>
   <example caption="Service Discovery information request"><![CDATA[
 <iq type='get'
@@ -68,11 +68,8 @@
       <field var='FORM_TYPE' type='hidden'>
         <value>http://jabber.org/network/serverinfo</value>
       </field>
-      <field var='serverinfo-pubsub-service'>
-        <value>pubsub.shakespeare.lit</value>
-      </field>      
       <field var='serverinfo-pubsub-node'>
-        <value>serverinfo</value>
+        <value>xmpp:pubsub.shakespeare.lit?;node=serverinfo</value>
       </field>      
     </x>
   </query>
@@ -192,13 +189,9 @@
     Forms advertising the coordinates of a pub-sub service and node for publication of Server Information data.
   </desc>
   <field
-      var='serverinfo-pubsub-service'
-      type='list-multi'
-      label='The address of a pub-sub service that hosts a node on which Server Information data is published.'/>
-  <field
       var='serverinfo-pubsub-node'
-      type='list-multi'
-      label='A nodeId on which Server Information data is published.'/>
+      type='text-single'
+      label='An URI (per XEP-0060 section 12.22) identifying the pub-sub node on which Server Information data is published.'/>
 </form_type>
 ]]></code>
     <p>Note that the FORM_TYPE used by &xep0157; is purposefully re-used by this XEP, to circumvent the restriction of having at most one XMPP Standards Foundation defined FORM_TYPE for a service discovery identity, as defined in &xep0128;. When a service supports both features, the data in both forms SHOULD be merged into one form.</p>

--- a/inbox/pubsub-server-info.xml
+++ b/inbox/pubsub-server-info.xml
@@ -78,7 +78,7 @@
 <serverinfo xmlns="urn:xmpp:serverinfo:0">
   <domain name="shakespeare.lit">
     <federation>
-      <remote-domain name='denmark.li'>
+      <remote-domain name='denmark.lit'>
         <connection type="incoming"/>
         <connection type="outgoing"/>
       </remote-domain>
@@ -118,7 +118,7 @@
           <serverinfo xmlns="urn:xmpp:serverinfo:0">
             <domain name="shakespeare.lit">
               <federation>
-                <remote-domain name='denmark.li'>
+                <remote-domain name='denmark.lit'>
                   <connection type="incoming"/>
                   <connection type="outgoing"/>
                 </remote-domain>


### PR DESCRIPTION
This defines a data format and a pub-sub based way of distributing data that describes an XMPP domain and its connections to federated domains.

My direct purpose of drafting this specification is to document the data format used to populate the XMPP network graph that, at the time of writing, is hosted at https://xmppnetwork.goodbytes.im/