### PR TITLE
XEP-0133: Retract 'Get User Password' command

### DIFF
--- a/xep-0133.xml
+++ b/xep-0133.xml
@@ -22,6 +22,12 @@
   <shortname>admin</shortname>
   &stpeter;
   <revision>
+    <version>1.3</version>
+    <date>2024-01-04</date>
+    <initials>gdk</initials>
+    <remark>Removed use case 'Get User Password', which violates best-practices with regard to security.</remark>
+  </revision>
+  <revision>
     <version>1.2</version>
     <date>2017-07-15</date>
     <initials>XEP Editor: ssw</initials>
@@ -110,7 +116,7 @@
     <li>Disable User</li>
     <li>Re-Enable User</li>
     <li>End User Session</li>
-    <li>Get User Password</li>
+    <li>Get User Password (retracted)</li>
     <li>Change User Password</li>
     <li>Get User Roster</li>
     <li>Get User Last Login Time</li>
@@ -539,92 +545,8 @@
 </iq>
 ]]></example>
   </section2>
-  <section2 topic='Get User Password' anchor='get-user-password'>
-    <p>An administrator may need to retrieve a user's password. The command node for this use case SHOULD be "http://jabber.org/protocol/admin#get-user-password".</p>
-    <p>A sample protocol flow for this use case is shown below.</p>
-    <example caption='Admin Requests to Get a User&apos;s Password'><![CDATA[
-<iq from='bard@shakespeare.lit/globe'
-    id='get-user-password-1'
-    to='shakespeare.lit'
-    type='set'
-    xml:lang='en'>
-  <command xmlns='http://jabber.org/protocol/commands'
-           action='execute'
-           node='http://jabber.org/protocol/admin#get-user-password'/>
-</iq>
-]]></example>
-    <p>Unless an error occurs (see the <link url='#errors'>Error Handling</link> section below), the service SHOULD return the appropriate form.</p>
-    <example caption='Service Returns Get User Password Form to Admin'><![CDATA[
-<iq from='shakespeare.lit'
-    id='get-user-password-1'
-    to='bard@shakespeare.lit/globe'
-    type='result'
-    xml:lang='en'>
-  <command xmlns='http://jabber.org/protocol/commands'
-           node='http://jabber.org/protocol/admin#get-user-password'
-           sessionid='get-user-password:20040408T0337Z'
-           status='executing'>
-    <x xmlns='jabber:x:data' type='form'>
-      <title>Getting a User's Password</title>
-      <instructions>Fill out this form to get a user&apos;s password.</instructions>
-      <field type='hidden' var='FORM_TYPE'>
-        <value>http://jabber.org/protocol/admin</value>
-      </field>
-      <field label='The Jabber ID for which to retrieve the password'
-             type='jid-single'
-             var='accountjid'>
-        <required/>
-      </field>
-    </x>
-  </command>
-</iq>
-]]></example>
-    <p>Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
-    <example caption='Admin Submits Get User Password Form to Service'><![CDATA[
-<iq from='bard@shakespeare.lit/globe'
-    id='get-user-password-2'
-    to='shakespeare.lit'
-    type='set'
-    xml:lang='en'>
-  <command xmlns='http://jabber.org/protocol/commands'
-           node='http://jabber.org/protocol/admin#get-user-password'
-           sessionid='get-user-password:20040408T0337Z'>
-    <x xmlns='jabber:x:data' type='submit'>
-      <field type='hidden' var='FORM_TYPE'>
-        <value>http://jabber.org/protocol/admin</value>
-      </field>
-      <field var='accountjid'>
-        <value>juliet@shakespeare.lit</value>
-      </field>
-    </x>
-  </command>
-</iq>
-]]></example>
-    <p>Naturally, the data form included in the IQ result will include the user's password.</p>
-    <example caption='Service Informs Admin of Completion'><![CDATA[
-<iq from='shakespeare.lit'
-    id='get-user-password-2'
-    to='bard@shakespeare.lit/globe'
-    type='result'
-    xml:lang='en'>
-  <command xmlns='http://jabber.org/protocol/commands'
-           node='http://jabber.org/protocol/admin#get-user-password'
-           sessionid='get-user-password:20040408T0337Z'
-           status='completed'>
-    <x xmlns='jabber:x:data' type='result'>
-      <field type='hidden' var='FORM_TYPE'>
-        <value>http://jabber.org/protocol/admin</value>
-      </field>
-      <field var='accountjid'>
-        <value>juliet@shakespeare.lit</value>
-      </field>
-      <field var='password'>
-        <value>R0m30</value>
-      </field>
-    </x>
-  </command>
-</iq>
-]]></example>
+  <section2 topic='Get User Password (retracted)' anchor='get-user-password'>
+    <p>Up to and including revision 1.2 of this XEP, this section defined a command that could be used to retrieve a user's password. This implies that the implementation stores plaintext passwords, a practise that is a well-documented vulnerability<note>OWASP: Password Plaintext Storage &lt;<link url='https://owasp.org/www-community/vulnerabilities/Password_Plaintext_Storage'>https://owasp.org/www-community/vulnerabilities/Password_Plaintext_Storage</link>&gt;</note>. This command has therefore been retracted from this XEP. To retain section numbering, this text replaces the command definition that previously existed in this section.</p>
   </section2>
   <section2 topic='Change User Password' anchor='change-user-password'>
     <p>An administrator may need to change a user's password. The command node for this use case SHOULD be "http://jabber.org/protocol/admin#change-user-password".</p>

--- a/xep-0133.xml
+++ b/xep-0133.xml
@@ -23,7 +23,7 @@
   <shortname>admin</shortname>
   &stpeter;
   <revision>
-    <version>1.3</version>
+    <version>1.3.0</version>
     <date>2024-01-04</date>
     <initials>gdk</initials>
     <remark>Removed use case 'Get User Password', which violates best-practices with regard to security.</remark>

--- a/xep-0133.xml
+++ b/xep-0133.xml
@@ -13,6 +13,7 @@
   <status>Active</status>
   <type>Informational</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>RFC 6120</spec>
     <spec>XEP-0050</spec>


### PR DESCRIPTION
Retrieving a password implies storage of plaintext passwords. That's no longer an acceptable practice.