### PR TITLE
advance XEP-0458 to Active

### DIFF
--- a/xep-0458.xml
+++ b/xep-0458.xml
@@ -23,7 +23,7 @@
 		&dcridland;
 		&stpeter;
   <revision>
-    <version>1.0</version>
+    <version>1.0.0</version>
     <date>2024-01-15</date>
     <initials>psa</initials>
     <remark><p>Changed status to Active per Board vote on 2024-01-05.</p></remark>


### PR DESCRIPTION
This PR advances XEP-0458 to Active per the Board vote on January 5, 2024.

@Kev - let me know if changes are needed for proper advancement.