### PR TITLE
XEP-0313: Fix MUC archive example

### DIFF
--- a/xep-0313.xml
+++ b/xep-0313.xml
@@ -31,6 +31,18 @@
   &mwild;
   &ksmith;
   <revision>
+    <version>1.1.1</version>
+    <date>2023-12-15</date>
+    <initials>egp</initials>
+    <remark>
+      <ul>
+        <li>Fix JID and affilitation of the first two witches in the MUC example.</li>
+        <li>Fix duplicated 'id' in MUC example.</li>
+        <li>Fix indentation in examples.</li>
+      </ul>
+    </remark>
+  </revision>
+  <revision>
     <version>1.1.0</version>
     <date>2023-03-09</date>
     <initials>mw</initials>
@@ -313,7 +325,9 @@
          from='romeo@montague.lit/orchard'
          type='chat'>
   <body>Call me but love, and I'll be new baptized; Henceforth I never will be Romeo.</body>
-  <stanza-id xmlns='urn:xmpp:sid:0' by='juliet@capulet.lit' id='28482-98726-73623' />
+  <stanza-id xmlns='urn:xmpp:sid:0'
+             by='juliet@capulet.lit'
+             id='28482-98726-73623' />
 </message>]]></example>
     <p>Note: Previous versions of this protocol did not specify any interaction with stanza-id, and clients MUST NOT interpret XEP-0359 IDs in messages as archive IDs unless the server advertises support for 'urn:xmpp:mam:2' specifically.</p>
   </section2>
@@ -636,9 +650,9 @@
     <forwarded xmlns='urn:xmpp:forward:0'>
       <delay xmlns='urn:xmpp:delay' stamp='2010-07-10T23:08:25Z'/>
       <message xmlns='jabber:client'
-        to='juliet@capulet.lit/balcony'
-        from='romeo@montague.lit/orchard'
-        type='chat'>
+               to='juliet@capulet.lit/balcony'
+               from='romeo@montague.lit/orchard'
+               type='chat'>
         <body>Call me but love, and I'll be new baptized; Henceforth I never will be Romeo.</body>
       </message>
     </forwarded>
@@ -650,9 +664,9 @@
     <forwarded xmlns='urn:xmpp:forward:0'>
       <delay xmlns='urn:xmpp:delay' stamp='2010-07-10T23:09:32Z'/>
       <message xmlns='jabber:client'
-         to='romeo@montague.lit/orchard'
-         from='juliet@capulet.lit/balcony'
-         type='chat' id='8a54s'>
+               to='romeo@montague.lit/orchard'
+               from='juliet@capulet.lit/balcony'
+               type='chat' id='8a54s'>
         <body>What man art thou that thus bescreen'd in night so stumblest on my counsel?</body>
       </message>
     </forwarded>
@@ -716,14 +730,14 @@
       <example caption='A page query using Result Set Management'><![CDATA[
 <iq type='set' id='q29303'>
   <query xmlns='urn:xmpp:mam:2'>
-      <x xmlns='jabber:x:data' type='submit'>
-        <field var='FORM_TYPE' type='hidden'><value>urn:xmpp:mam:2</value></field>
-        <field var='start'><value>2010-08-07T00:00:00Z</value></field>
-      </x>
-      <set xmlns='http://jabber.org/protocol/rsm'>
-         <max>10</max>
-         <after>09af3-cc343-b409f</after>
-      </set>
+    <x xmlns='jabber:x:data' type='submit'>
+      <field var='FORM_TYPE' type='hidden'><value>urn:xmpp:mam:2</value></field>
+      <field var='start'><value>2010-08-07T00:00:00Z</value></field>
+    </x>
+    <set xmlns='http://jabber.org/protocol/rsm'>
+      <max>10</max>
+      <after>09af3-cc343-b409f</after>
+    </set>
   </query>
 </iq>
 ]]></example>
@@ -734,7 +748,7 @@
 <iq type='error' id='q29303'>
   <error type='cancel'>
     <item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
-   </error>
+  </error>
 </iq>
 ]]></example>
     <p>When the results returned by the server are complete (that is: when they have not been limited by the maximum size of the result page (either as specified or enforced by the server)), the server MUST include a 'complete' attribute on the &lt;fin&gt; element, with a value of 'true'; this informs the client that it doesn't need to perform further paging to retreive the requested data. If it is not the last page of the result set, the server MUST either omit the 'complete' attribute, or give it a value of 'false'.</p>
@@ -757,14 +771,14 @@
       <example caption='A request for the last page in an archive'><![CDATA[
 <iq type='set' id='q29303'>
   <query xmlns='urn:xmpp:mam:2'>
-      <x xmlns='jabber:x:data' type='submit'>
-        <field var='FORM_TYPE' type='hidden'><value>urn:xmpp:mam:2</value></field>
-        <field var='start'><value>2010-08-07T00:00:00Z</value></field>
-      </x>
-      <set xmlns='http://jabber.org/protocol/rsm'>
-         <max>10</max>
-         <before/>
-      </set>
+    <x xmlns='jabber:x:data' type='submit'>
+      <field var='FORM_TYPE' type='hidden'><value>urn:xmpp:mam:2</value></field>
+      <field var='start'><value>2010-08-07T00:00:00Z</value></field>
+    </x>
+    <set xmlns='http://jabber.org/protocol/rsm'>
+      <max>10</max>
+      <before/>
+    </set>
   </query>
 </iq>
 ]]></example>
@@ -778,15 +792,15 @@
       <example caption='Requesting a page that is flipped'><![CDATA[
 <iq type='set' id='q29309'>
   <query xmlns='urn:xmpp:mam:2'>
-      <x xmlns='jabber:x:data' type='submit'>
-        <field var='FORM_TYPE' type='hidden'><value>urn:xmpp:mam:2</value></field>
-        <field var='start'><value>2010-08-07T00:00:00Z</value></field>
-      </x>
-      <set xmlns='http://jabber.org/protocol/rsm'>
-         <max>10</max>
-         <after>09af3-cc343-b409f</after>
-      </set>
-      <flip-page/>
+    <x xmlns='jabber:x:data' type='submit'>
+      <field var='FORM_TYPE' type='hidden'><value>urn:xmpp:mam:2</value></field>
+      <field var='start'><value>2010-08-07T00:00:00Z</value></field>
+    </x>
+    <set xmlns='http://jabber.org/protocol/rsm'>
+      <max>10</max>
+      <after>09af3-cc343-b409f</after>
+    </set>
+    <flip-page/>
   </query>
 </iq>
 ]]></example>
@@ -845,17 +859,17 @@
       <p>In the case of non-anonymous rooms or if the recipient of the MUC archive has the right to access the sender real JID at the time of the query, the archive message will use extended message information in an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with a 'jid' attribute specifying the occupant's full JID, as defined for non-anonymous room presence in &xep0045;. The archiving entity MUST strip any pre-existing &lt;x&gt; element from MUC messages (as MUC rooms are not required to do this).</p>
       <example caption='Server returns MUC messages'><![CDATA[
 <message id='iasd207' from='coven@chat.shakespeare.lit' to='hag66@shakespeare.lit/pda'>
-  <result xmlns='urn:xmpp:mam:2' queryid='g27' id='34482-21985-73620'>
+  <result xmlns='urn:xmpp:mam:2' queryid='g27' id='78527-06716-51603'>
     <forwarded xmlns='urn:xmpp:forward:0'>
       <delay xmlns='urn:xmpp:delay' stamp='2002-10-13T23:58:37Z'/>
       <message xmlns="jabber:client"
-        from='coven@chat.shakespeare.lit/firstwitch'
-        id='162BEBB1-F6DB-4D9A-9BD8-CFDCC801A0B2'
-        type='groupchat'>
+               from='coven@chat.shakespeare.lit/firstwitch'
+               id='162BEBB1-F6DB-4D9A-9BD8-CFDCC801A0B2'
+               type='groupchat'>
         <body>Thrice the brinded cat hath mew'd.</body>
         <x xmlns='http://jabber.org/protocol/muc#user'>
-          <item affiliation='none'
-                jid='witch1@shakespeare.lit'
+          <item affiliation='owner'
+                jid='crone1@shakespeare.lit'
                 role='participant' />
         </x>
       </message>
@@ -868,13 +882,13 @@
     <forwarded xmlns='urn:xmpp:forward:0'>
       <delay xmlns='urn:xmpp:delay' stamp='2002-10-13T23:58:43Z'/>
       <message xmlns="jabber:client"
-        from='coven@chat.shakespeare.lit/secondwitch'
-        id='90057840-30FD-4141-AA44-103EEDF218FC'
-        type='groupchat'>
+               from='coven@chat.shakespeare.lit/secondwitch'
+               id='90057840-30FD-4141-AA44-103EEDF218FC'
+               type='groupchat'>
         <body>Thrice and once the hedge-pig whined.</body>
         <x xmlns='http://jabber.org/protocol/muc#user'>
-          <item affiliation='none'
-                jid='witch2@shakespeare.lit'
+          <item affiliation='admin'
+                jid='wiccarocks@shakespeare.lit'
                 role='participant' />
         </x>
       </message>

--- a/xep-0313.xml
+++ b/xep-0313.xml
@@ -36,7 +36,7 @@
     <initials>egp</initials>
     <remark>
       <ul>
-        <li>Fix JID and affilitation of the first two witches in the MUC example.</li>
+        <li>Fix JID and affiliation of the first two witches in the MUC example.</li>
         <li>Fix duplicated 'id' in MUC example.</li>
         <li>Fix indentation in examples.</li>
       </ul>


### PR DESCRIPTION
It had duplicated ids, and the JIDs of the witches weren’t consistent with their definition in XEP-0045.

These issues were found while writing #1320.