### PR TITLE
xep-template: Require accessibility and privacy sections

### DIFF
--- a/xep-template.xml
+++ b/xep-template.xml
@@ -57,12 +57,15 @@
   <p>OPTIONAL.</p>
 </section1>
 <section1 topic='Accessibility Considerations' anchor='access'>
-  <p>OPTIONAL.</p>
+  <p>REQUIRED.</p>
 </section1>
 <section1 topic='Internationalization Considerations' anchor='i18n'>
   <p>OPTIONAL.</p>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
+  <p>REQUIRED.</p>
+</section1>
+<section1 topic='Privacy Considerations' anchor='privacy'>
   <p>REQUIRED.</p>
 </section1>
 <section1 topic='IANA Considerations' anchor='iana'>


### PR DESCRIPTION
The Privacy section is a new one, and Accessibility was previously optional.

Rationale for the new section: it makes sense to distinguish between security and privacy, even if there is an overlap.

Rationale for requiring both: not making accessibility and privacy part of the core things required for a XEP is bad in this day and age, even if I expect that most XEPs will not have much applicable on those topics. It will make sure the authors have to consider those aspects before submitting.