### PR TITLE
XEP-0313: Add XEP-0136 to superseded specifications

### DIFF
--- a/xep-0313.xml
+++ b/xep-0313.xml
@@ -22,7 +22,7 @@
     <spec>XEP-0059</spec>
     <spec>XEP-0297</spec>
   </dependencies>
-  <supersedes/>
+  <supersedes><spec>XEP-0136</spec></supersedes>
   <supersededby/>
   <shortname>mam</shortname>
   <schemaloc>
@@ -30,6 +30,14 @@
   </schemaloc>
   &mwild;
   &ksmith;
+  <revision>
+    <version>1.1.1</version>
+    <date>2024-02-20</date>
+    <initials>gdk</initials>
+    <remark>
+      <p>Add XEP-0136 to superseded specifications</p>
+    </remark>
+  </revision>
   <revision>
     <version>1.1.0</version>
     <date>2023-03-09</date>


### PR DESCRIPTION
XEP-0136 already defines that it is superseded by XEP-0313.