### PR TITLE
Small fixes for 0424

### DIFF
--- a/xep-0424.xml
+++ b/xep-0424.xml
@@ -133,7 +133,7 @@
   <example caption="The client sends out a retraction message"><![CDATA[
 <message type='chat' to='lord@capulet.example' id='retract-message-1'>
   <retract id="origin-id-1" xmlns='urn:xmpp:message-retract:1'/>
-  <fallback xmlns="urn:xmpp:fallback:0"/>
+  <fallback xmlns="urn:xmpp:fallback:0" for='urn:xmpp:message-retract:1'/>
   <body>This person attempted to retract a previous message, but it's unsupported by your client.</body>
   <store xmlns="urn:xmpp:hints"/>
 </message>]]></example>

--- a/xep-0424.xml
+++ b/xep-0424.xml
@@ -27,6 +27,17 @@
   &lance;
   &jcbrand;
   <revision>
+    <version>0.4.1</version>
+    <date>2024-02-24</date>
+    <initials>nc</initials>
+    <remark>
+        <ul>
+          <li>Fix schema.</li>
+          <li>Add missing for attribute in fallback element (Example 4).</li>
+        </ul>
+    </remark>
+  </revision>
+  <revision>
     <version>0.4.0</version>
     <date>2023-02-19</date>
     <initials>jcb</initials>

--- a/xep-0424.xml
+++ b/xep-0424.xml
@@ -254,9 +254,9 @@
     <xs:complexType>
       <xs:simpleContent>
         <xs:extension base='xs:string'>
-          <xs:attribute name='by' type='xs:string' use='required'/>
-          <xs:attribute name='from' type='xs:string' use='optional'/>
-          <xs:attribute name='stamp' type='xs:dateTime' use='required'/>
+          <xs:attribute name='by' type='xs:string' use='optional'/>
+          <xs:attribute name='id' type='xs:string' use='required'/>
+          <xs:attribute name='stamp' type='xs:dateTime' use='optional'/>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>


### PR DESCRIPTION
Fixes the schema of the `<retracted>` element:

- The is no 'from' attribute
- There is a mandatory 'id' attribute
- 'by' and 'stamp' are not mandatory

Add a fallback for attribute in Example 4.