### PR TITLE
Fix auto triage permissions

### DIFF
--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -1,6 +1,6 @@
 name: Triage
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited
@@ -21,9 +21,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup master branch locally without switching current branch
-        run: git fetch origin master:master
-      - run: bash tools/github_auto_triage_pr.sh ${{ github.event.pull_request.number }}
+      - name: Copy trusted version of script
+        run: cp tools/github_auto_triage_pr.sh /tmp
+      - name: Setup PR branch locally
+        run: gh pr checkout ${{ github.event.pull_request.number }}
+      - run: bash /tmp/github_auto_triage_pr.sh ${{ github.event.pull_request.number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
Github won't allow write access on PRs from a fork for security reasons, unless you use the special pull_request_target trigger which then runs in the context of the target and not of the PR.

So we copy the trusted script from the target (master) to /tmp, then checkout the PR, then run the script from /tmp