### PR TITLE
XEP-0428: Change schema int types to xs:unsignedInt

### DIFF
--- a/xep-0428.xml
+++ b/xep-0428.xml
@@ -25,6 +25,12 @@
   &dcridland;
   &larma;
   <revision>
+    <version>0.3.0</version>
+    <date>2024-03-20</date>
+    <initials>lnj</initials>
+    <remark>Change integer type of region start and end attributes in schema to xs:unsignedInt.</remark>
+  </revision>
+  <revision>
     <version>0.2.0</version>
     <date>2022-07-17</date>
     <initials>lmw</initials>
@@ -138,8 +144,8 @@
     </xs:complexType>
   </xs:element>
   <xs:complexType name="region">
-    <xs:attribute name="start" type="xs:integer" />
-    <xs:attribute name="end" type="xs:integer" />
+    <xs:attribute name="start" type="xs:unsignedInt" />
+    <xs:attribute name="end" type="xs:unsignedInt" />
   </xs:complexType>
 </xs:schema>
       ]]>


### PR DESCRIPTION
The previous type was xs:integer, which allows for arbitrary large
integers, and also negative integers. Negative values do not make sense
when referencing characters and limiting the size of the integer to 32
bit is, I think, reasonable as that would still allow referencing in 4
GiB of text (and that should probably exceed any stanza size limit).
