### PR TITLE
GitHub Actions: Update actions/checkout to v4

### DIFF
--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           packages: libxml2-utils
           version: cachetag1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Copy trusted version of script

--- a/.github/workflows/xep-validation.yml
+++ b/.github/workflows/xep-validation.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Validate any XEP changes
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
This fixes warnings about Node.js 16 deprecation