### PR TITLE
XEP-0045: Remove conflicting keyword in §7.2.2

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -47,6 +47,12 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.34.6</version>
+    <date>2024-05-01</date>
+    <initials>pep</initials>
+    <remark><p>Remove contradicting keyword on sending subject in §7.2.2.</p></remark>
+  </revision>
+  <revision>
     <version>1.34.5</version>
     <date>2022-12-01</date>
     <initials>NC</initials>
@@ -1543,7 +1549,7 @@
 </presence>
 ]]></example>
       <p>Note: The order of the presence stanzas sent to the new occupant is important. The service MUST first send the complete list of the existing occupants to the new occupant and only then send the new occupant's own presence to the new occupant. This helps the client know when it has received the complete "room roster". For tracking purposes, the room might also reflect the original 'id' value if provided in the presence stanza sent by the user.</p>
-      <p>After sending the presence broadcast (and only after doing so), the service MAY then send discussion history, the room subject, live messages, presence updates, and other in-room traffic.</p>
+      <p>After sending the presence broadcast (and only after doing so), the service can then send discussion history, the room subject, live messages, presence updates, and other in-room traffic.</p>
     </section3>
 
     <section3 topic='Non-Anonymous Rooms' anchor='enter-nonanon'>


### PR DESCRIPTION
§7.2.15 is a section dedicated to the room subject and specifies it as a MUST, which conflicted here with the MAY.