### PR TITLE
XEP-0153: Add missing EMAIL/USERID element in example

### DIFF
--- a/xep-0153.xml
+++ b/xep-0153.xml
@@ -27,6 +27,12 @@
   </schemaloc>
   &stpeter;
   <revision>
+    <version>1.1.1</version>
+    <date>2024-06-10</date>
+    <initials>egp</initials>
+    <remark><p>XEP-0054 says “Email addresses MUST be contained in a &lt;USERID&gt; element”.</p></remark>
+  </revision>
+  <revision>
     <version>1.1</version>
     <date>2018-02-26</date>
     <initials>jwi</initials>
@@ -103,7 +109,7 @@
     </ADR>
     <NICKNAME/>
     <N><GIVEN>Juliet</GIVEN><FAMILY>Capulet</FAMILY></N>
-    <EMAIL>jcapulet@shakespeare.lit</EMAIL>
+    <EMAIL><USERID>jcapulet@shakespeare.lit</USERID></EMAIL>
     <PHOTO>
       <TYPE>image/jpeg</TYPE>
       <BINVAL>
@@ -151,7 +157,7 @@
     </ADR>
     <NICKNAME/>
     <N><GIVEN>Juliet</GIVEN><FAMILY>Capulet</FAMILY></N>
-    <EMAIL>jcapulet@shakespeare.lit</EMAIL>
+    <EMAIL><USERID>jcapulet@shakespeare.lit</USERID></EMAIL>
     <PHOTO>
       <TYPE>image/jpeg</TYPE>
       <BINVAL>


### PR DESCRIPTION
The implementation notes in XEP-0054 say “Email addresses MUST be contained in a `<USERID>` element, not included as CDATA within the `<EMAIL/>` element.”