### PR TITLE
XEP-0054: Updated error cases to be compatible with RFC 6121

### DIFF
--- a/xep-0054.xml
+++ b/xep-0054.xml
@@ -13,6 +13,7 @@
   <status>Active</status>
   <type>Historical</type>
   <sig>Standards</sig>
+  <approver>Council</approver>
   <dependencies>
     <spec>XMPP Core</spec>
   </dependencies>
@@ -20,6 +21,12 @@
   <supersededby/>
   <shortname>vcard-temp</shortname>
   &stpeter;
+  <revision>
+    <version>1.3.0</version>
+    <date>2024-06-27</date>
+    <initials>gk</initials>
+    <remark><p>Updated error cases to be compatible with &xmppim;.</p></remark>
+  </revision>
   <revision>
     <version>1.2</version>
     <date>2008-07-16</date>
@@ -242,7 +249,8 @@
   </vCard>
 </iq>
 ]]></example>
-    <p>If no vCard exists or the user does not exist, the server MUST return a stanza error, which SHOULD be either &unavailable; or &notfound; (but the server MUST return the same error condition in both cases to help prevent directory harvesting attacks).</p>
+    <p>If no vCard exists or the user does not exist, the server MUST return a stanza error. The server MUST return the same error condition in both cases to help prevent directory harvesting attacks. &xmppim; dictates that &unavailable; MUST be used when the user account identified by the 'to' attribute of an IQ stanza does not exist. Hence, &unavailable; MUST be used in both cases.</p>
+    <p>Note: versions prior to 1.3 of this specification defined that either &unavailable; or &notfound; SHOULD be was used in these cases. For backwards-compatibility, applications SHOULD appropriately handle both errors.</p>
     <example caption="No vCard"><![CDATA[
 <iq id='v3'
     to='stpeter@jabber.org/roundabout'


### PR DESCRIPTION
In section 3.3 of XEP-0054 it is defined that the same error condition MUST be used in both a case:

- where a VCard request is addressed to an entity that does not exist, and;
- where a VCard request is addressed at an entity for which no VCard is available.

RFC 6121 section 8.5.1 defines:
> If the user account identified by the 'to' attribute does not exist, how the stanza is processed depends on the stanza type. For an IQ stanza, the server MUST return a `<service-unavailable/>` stanza error to the sender.

Prior to this change, both `<service-unavailable/>` and `<item-not-found/>` were offered as suitable conditions to be used in the error scenario defined in section 3.3. For this XEP to be more compatible with RFC 6121, only `<service-unavailable>` can be used.

This commit drops the `<item-not-found>` condition from the scenario, and elevates usage of <service-unavailabe> to a MUST. It adds a note on backwards compatibility.