### PR TITLE
XEP-0386: Add an XML Schema

### DIFF
--- a/xep-0386.xml
+++ b/xep-0386.xml
@@ -27,6 +27,12 @@
   &ksmithisode;
   &mwild;
   <revision>
+    <version>1.0.1</version>
+    <date>2024-07-02</date>
+    <initials>egp</initials>
+    <remark><p>Add an XML Schema.</p></remark>
+  </revision>
+  <revision>
     <version>1.0.0</version>
     <date>2024-04-04</date>
     <initials>XEP Editor (dg)</initials>
@@ -195,9 +201,66 @@
 <section1 topic='XMPP Registrar Considerations' anchor='registrar'>
   <p>The urn:xmpp:bind:0 namespace must be registered..</p>
 </section1>
-<!--<section1 topic='XML Schema' anchor='schema'>
-  <p>REQUIRED for protocol specifications.</p>
-</section1>-->
+<section1 topic='XML Schema' anchor='schema'>
+  <code><![CDATA[
+<?xml version='1.0' encoding='UTF-8'?>
+
+<xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:mam='urn:xmpp:mam:2'
+    xmlns='urn:xmpp:bind:0'
+    targetNamespace='urn:xmpp:bind:0'
+    elementFormDefault='qualified'>
+
+  <xs:annotation>
+    <xs:documentation>
+      The protocol documented by this schema is defined in
+      XEP-0386: https://xmpp.org/extensions/xep-0386.html
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:import namespace='urn:xmpp:mam:2'
+    schemaLocation='xep-0313.xsd'/>
+
+  <xs:element name='bind'>
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref='inline'/>
+        <xs:sequence>
+          <xs:element ref='tag' minOccurs='0'/>
+          <xs:any namespace='##other' minOccurs='0' maxOccurs='unbounded' processContents='lax'/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='inline'>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref='feature' maxOccurs='unbounded'/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='feature'>
+    <xs:complexType>
+      <xs:attribute name='var' type='xs:string'/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='tag' type='xs:string'/>
+
+  <xs:element name='bound'>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref='mam:metadata' minOccurs='0'/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>
+]]></code>
+</section1>
 <section1 topic='Acknowledgements' anchor='acknowledgements'>
   <p>Thanks to Daniel Gultsch, Philipp Hörist, Thilo Molitor and Andrzej Wójcik for their valuable support with feedback, suggestions and implementations.</p>
 </section1>


### PR DESCRIPTION
This has been tested against a mock XEP-0313 schema, because I couldn’t find it listed at [its URL](http://www.xmpp.org/schemas/archive-management.xsd).