### PR TITLE
XEP-0045: Notification of role and affiliation changes

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -1124,6 +1124,57 @@
 
   </section2>
 
+  <section2 topic='Notifications of Changes' anchor='change-notif'>
+    <p>When the role or affiliation of a user is changed, notifications of such a change uses stanzas that include an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child, with the 'role' and/or 'affiliation' attribute set to a value of new role or affiliation.</p>
+    <p>If the user is in the room, the service MUST send updated presence from this individual's &OCCUPANTJID; to all occupants, indicating the change in affiliation or role, by including such an &lt;x/&gt; element.</p>
+    <example caption="Service Sends Notice of Owner Status to All Occupants (User is in Room)"><![CDATA[
+<presence
+    from='coven@chat.shakespeare.lit/hecate'
+    to='crone1@shakespeare.lit/desktop'>
+  <x xmlns='http://jabber.org/protocol/muc#user'>
+    <item affiliation='owner'
+          jid='hecate@shakespeare.lit'
+          role='moderator'/>
+  </x>
+</presence>
+]]></example>
+    <example caption="Service Sends Notice of Membership to All Occupants (User is in Room)"><![CDATA[
+<presence
+    from='coven@chat.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'>
+  <x xmlns='http://jabber.org/protocol/muc#user'>
+    <item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/>
+  </x>
+</presence>
+]]></example>
+    <p>If the user is <em>not</em> in the room, the service MAY send a message from the room itself to the room occupants, indicating the change in affiliation or role, by including such an &lt;x/&gt; element. As roles not necessarily persist across a user's visits to the room, the value of the 'role' attribute may differ from the equivalent notification sent when the affected is present in the room (as described above).</p>
+    <example caption="Service Sends Notice of Owner Status to All Occupants (User not in Room)"><![CDATA[
+<message
+    from='chat.shakespeare.lit'
+    id='86007d69-7694-4204-8210-375f21d99a5a'
+    to='crone1@shakespeare.lit/desktop'>
+  <x xmlns='http://jabber.org/protocol/muc#user'>
+    <item affiliation='owner'
+          jid='hecate@shakespeare.lit'
+          role='moderator'/>
+  </x>
+</message>
+]]></example>
+    <example caption="Service Sends Notice of Membership to All Occupants (User not in Room)"><![CDATA[
+<message
+    from='chat.shakespeare.lit'
+    id='176ee5a6-66f1-4088-89be-cc57fee43cab'
+    to='crone1@shakespeare.lit/desktop'>
+  <x xmlns='http://jabber.org/protocol/muc#user'>
+    <item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='none'/>
+  </x>
+</message>
+]]></example>
+  </section2>
 </section1>
 
 <section1 topic='Entity Use Cases' anchor='entity'>
@@ -2966,7 +3017,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>The service MUST then send updated presence from this individual's &OCCUPANTJID; to all occupants, indicating the addition of voice privileges by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "participant".</p>
+    <p>The service MUST then send to all occupants a notification indicating the addition of voice privileges, as described under <link url='#change-notif'>Notifications of Changes</link>, using the 'role' attribute set to a value of "participant".</p>
     <example caption="Service Sends Notice of Voice to All Occupants"><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/thirdwitch'
@@ -3018,7 +3069,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>The service MUST then send updated presence from this individual to all occupants, indicating the removal of voice privileges by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "visitor".</p>
+    <p>The service MUST then send to all occupants a notification indicating the removal of voice privileges, as described under <link url='#change-notif'>Notifications of Changes</link>, using the 'role' attribute set to a value of "visitor".</p>
     <example caption="Service Notes Loss of Voice"><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/thirdwitch'
@@ -3106,7 +3157,7 @@
     to='bard@shakespeare.lit/globe'
     type='result'/>
 ]]></example>
-    <p>The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in voice privileges by sending the appropriate extended presence stanzas as described in the foregoing use cases.</p>
+    <p>The service MUST then send to all occupants a notification indicating changes in voice privilege for any affected individual, as described under <link url='#change-notif'>Notifications of Changes</link> as described in the foregoing use cases.</p>
     <p>As noted, voice privileges cannot be revoked from a room owner or room admin, nor from any user with a higher affiliation than the moderator making the request. If a room admin attempts to revoke voice privileges from such a user by modifying the voice list, the service MUST deny the request and return a &notallowed; error to the sender:</p>
     <example caption='Service Returns Error on Attempt to Revoke Voice from an Admin, Owner, or User with a Higher Affiliation'><![CDATA[
 <iq from='goodfolk@chat.shakespeare.lit'
@@ -3184,7 +3235,7 @@
   </x>
 </message>
 ]]></example>
-    <p>If a moderator approves the voice request, the service shall grant voice to the occupant and send a presence update as described in the <link url='#grantvoice'>Granting Voice to a Visitor</link> section of this document.</p>
+    <p>If a moderator approves the voice request, the service shall grant voice to the occupant and send notifications as described in the <link url='#grantvoice'>Granting Voice to a Visitor</link> section of this document.</p>
   </section2>
 
 </section1>
@@ -3378,7 +3429,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of membership by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "member".</p>
+    <p>The service MUST then send to all occupants a notification indicating the granting of membership, as described under <link url='#change-notif'>Notifications of Changes</link>, using the 'affiliation' attribute set to a value of "member".</p>
     <example caption="Service Sends Notice of Membership to All Occupants"><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/thirdwitch'
@@ -3429,7 +3480,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the loss of membership by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "none".</p>
+    <p>The service MUST then send to all occupants a notification indicating the loss of membership, as described under <link url='#change-notif'>Notifications of Changes</link>, using the 'affiliation' attribute set to a value of "none".</p>
     <example caption="Service Notes Loss of Membership"><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/thirdwitch'
@@ -3523,7 +3574,7 @@
 ]]></example>
     <p>The service MUST change the affiliation of any affected user. If the user has been removed from the member list, the service MUST change the user's affiliation from "member" to "none". If the user has been added to the member list, the service MUST change the user's affiliation to "member".</p>
     <p>If a removed member is currently in a members-only room, the service SHOULD kick the occupant by changing the removed member's role to "none" and send appropriate presence to the removed member as previously described. The service MUST subsequently refuse entry to the user.</p>
-    <p>For all room types, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "none".</p>
+    <p>For all room types, the service MUST then send to all occupants a notification indicating the change in affiliation, as described under <link url='#change-notif'>Notifications of Changes</link>, using the 'affiliation' attribute set to a value of "none".</p>
     <example caption="Service Sends Notice of Loss of Membership to All Occupants"><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/thirdwitch'
@@ -3569,7 +3620,7 @@
 </message>
 ]]></example>
     <p>Invitations sent through an open room MUST NOT trigger the addition of the invitee to the member list.</p>
-    <p>If a user is added to the member list of an open room and the user is in the room, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "member".</p>
+    <p>If a user is added to the member list of an open room, the service MUST then send to all occupants a notification indicating the change in affiliation, as described under <link url='#change-notif'>Notifications of Changes</link>, using the 'affiliation' attribute set to a value of "member".</p>
     <example caption="Service Sends Notice of Membership to All Occupants"><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/hecate'
@@ -3619,7 +3670,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the addition of moderator status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "moderator".</p>
+    <p>The service MUST then send to all occupants a notification indicating the addition of moderator status, as described under <link url='#change-notif'>Notifications of Changes</link>, using the 'role' attribute set to a value of "moderator".</p>
     <example caption="Service Sends Notice of Moderator Status to All Occupants"><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/thirdwitch'
@@ -3669,7 +3720,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the removal of moderator status by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "participant".</p>
+    <p>The service MUST then send to all occupants a notification indicating the removal of moderator status, as described under <link url='#change-notif'>Notifications of Changes</link>, using the 'role' attribute set to a value of "participant".</p>
     <example caption="Service Notes Loss of Moderator Status"><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/thirdwitch'
@@ -3743,7 +3794,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>For any affected individual that is in the room, the service MUST then send updated presence to all occupants, indicating the change in moderator status by sending the appropriate extended presence stanzas as described in the foregoing use cases.</p>
+    <p>For any affected user, the service MUST then send to all occupants a notification indicating the change of moderator status, as described under <link url='#change-notif'>Notifications of Changes</link>, using the appropriate 'role' attribute value as described in the foregoing use cases.</p>
     <p>As noted, moderator status cannot be revoked from a room owner or room admin. If a room admin attempts to revoke moderator status from such a user by modifying the moderator list, the service MUST deny the request and return a &notallowed; error to the sender:</p>
     <example caption='Service Returns Error on Attempt to Revoke Moderator Status from an Admin or Owner'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -4544,7 +4595,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of owner status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "owner" and the 'role' attribute set to an appropriate value given the affiliation and room type ("moderator" is recommended).</p>
+    <p>The service MUST then send to all occupants a notification indicating the granting of owner status, as described under <link url='#change-notif'>Notifications of Changes</link>, using the 'affiliation' attribute set to a value of "owner" and the 'role' attribute set to an appropriate value given the affiliation and room type ("moderator" is recommended).</p>
     <example caption="Service Sends Notice of Owner Status to All Occupants"><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/hecate'
@@ -4555,21 +4606,6 @@
           role='moderator'/>
   </x>
 </presence>
-
-[ ... ]
-]]></example>
-    <p>If the user is not in the room, the service MAY send a message from the room itself to the room occupants, indicating the granting of owner status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "owner".</p>
-    <example caption="Service Sends Notice of Owner Status to All Occupants"><![CDATA[
-<message
-    from='chat.shakespeare.lit'
-    id='22B0F570-526A-4F22-BDE3-52EC3BB18371'
-    to='crone1@shakespeare.lit/desktop'>
-  <x xmlns='http://jabber.org/protocol/muc#user'>
-    <item affiliation='owner'
-          jid='hecate@shakespeare.lit'
-          role='none'/>
-  </x>
-</message>
 
 [ ... ]
 ]]></example>
@@ -4612,7 +4648,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the loss of owner status by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value other than "owner" and the 'role' attribute set to an appropriate value:</p>
+    <p>The service MUST then send to all occupants a notification indicating the loss of owner status, as described under <link url='#change-notif'>Notifications of Changes</link>, using the 'affiliation' attribute set to a value other than "owner" and the 'role' attribute set to an appropriate value:</p>
     <example caption="Service Notes Loss of Owner Affiliation"><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/secondwitch'
@@ -4684,7 +4720,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>The service MUST also send presence notifications related to any affiliation changes that result from modifying the owner list as previously described.</p>
+    <p>The service MUST then send to all occupants a notification related to any affiliation changes that result from modifying the owner list as previously described.</p>
   </section2>
 
   <section2 topic='Granting Admin Status' anchor='grantadmin'>
@@ -4721,7 +4757,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of admin status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "admin" and the 'role' attribute set to an appropriate value given the affiliation and room type (typically "moderator").</p>
+    <p>The service MUST then send to all occupants a notification indicating the granting of admin status, as described under <link url='#change-notif'>Notifications of Changes</link>, using the 'affiliation' attribute set to a value of "admin" and the 'role' attribute set to an appropriate value given the affiliation and room type (typically "moderator").</p>
     <example caption="Service Sends Notice of Admin Status to All Occupants"><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/secondwitch'
@@ -4732,21 +4768,6 @@
           role='moderator'/>
   </x>
 </presence>
-
-[ ... ]
-]]></example>
-    <p>If the user is not in the room, the service MAY send a message from the room itself to the room occupants, indicating the granting of admin status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "admin".</p>
-    <example caption="Service Sends Notice of Admin Status to All Occupants"><![CDATA[
-<message
-    from='chat.shakespeare.lit'
-    id='C75B919A-30B3-4233-AE89-6E9834E26929'
-    to='crone1@shakespeare.lit/desktop'>
-  <x xmlns='http://jabber.org/protocol/muc#user'>
-    <item affiliation='admin'
-          jid='wiccarocks@shakespeare.lit'
-          role='none'/>
-  </x>
-</message>
 
 [ ... ]
 ]]></example>
@@ -4786,7 +4807,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the loss of admin status by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value other than "admin" or "owner" and the 'role' attribute set to an appropriate value given the affiliation level and the room type (typically "participant").</p>
+    <p>The service MUST then send to all occupants a notification indicating the loss of admin status, as described under <link url='#change-notif'>Notifications of Changes</link>, using the 'affiliation' attribute set to a value other than "admin" or "owner" and the 'role' attribute set to an appropriate value given the affiliation level and the room type (typically "participant").</p>
     <example caption="Service Notes Loss of Admin Affiliation"><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/secondwitch'
@@ -4797,21 +4818,6 @@
           role='participant'/>
   </x>
 </presence>
-
-[ ... ]
-]]></example>
-    <p>If the user is not in the room, the service MAY send a message from the room itself to the room occupants, indicating the loss of admin status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value other than "admin".</p>
-    <example caption="Service Notes Loss of Admin Affiliation"><![CDATA[
-<message
-    from='chat.shakespeare.lit'
-    id='2CF9013B-E8A8-42A1-9633-85AD7CA12F40'
-    to='crone1@shakespeare.lit/desktop'>
-  <x xmlns='http://jabber.org/protocol/muc#user'>
-    <item affiliation='none'
-          jid='wiccarocks@shakespeare.lit'
-          role='none'/>
-  </x>
-</message>
 
 [ ... ]
 ]]></example>
@@ -4879,7 +4885,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>The service MUST also send presence notifications related to any affiliation changes that result from modifying the admin list as previously described.</p>
+    <p>The service MUST also send notifications related to any affiliation changes that result from modifying the admin list as previously described.</p>
   </section2>
 
   <section2 topic='Destroying a Room' anchor='destroyroom'>

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -47,6 +47,12 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.34.7</version>
+    <date>2024-07-05</date>
+    <initials>gk</initials>
+    <remark><p>Improve consistency of role and affiliation change notifications</p></remark>
+  </revision>
+  <revision>
     <version>1.34.6</version>
     <date>2024-05-01</date>
     <initials>pep</initials>
@@ -3423,7 +3429,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>The service MUST then send updated presence from this individual to all occupants, indicating the loss of membership by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "none".</p>
+    <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the loss of membership by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "none".</p>
     <example caption="Service Notes Loss of Membership"><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/thirdwitch'
@@ -3613,7 +3619,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>The service MUST then send updated presence from this individual to all occupants, indicating the addition of moderator status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "moderator".</p>
+    <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the addition of moderator status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "moderator".</p>
     <example caption="Service Sends Notice of Moderator Status to All Occupants"><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/thirdwitch'
@@ -3663,7 +3669,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>The service MUST then send updated presence from this individual to all occupants, indicating the removal of moderator status by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "participant".</p>
+    <p>If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the removal of moderator status by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "participant".</p>
     <example caption="Service Notes Loss of Moderator Status"><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/thirdwitch'
@@ -3737,7 +3743,7 @@
     to='crone1@shakespeare.lit/desktop'
     type='result'/>
 ]]></example>
-    <p>The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in moderator status by sending the appropriate extended presence stanzas as described in the foregoing use cases.</p>
+    <p>For any affected individual that is in the room, the service MUST then send updated presence to all occupants, indicating the change in moderator status by sending the appropriate extended presence stanzas as described in the foregoing use cases.</p>
     <p>As noted, moderator status cannot be revoked from a room owner or room admin. If a room admin attempts to revoke moderator status from such a user by modifying the moderator list, the service MUST deny the request and return a &notallowed; error to the sender:</p>
     <example caption='Service Returns Error on Attempt to Revoke Moderator Status from an Admin or Owner'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -4565,7 +4565,7 @@
     id='22B0F570-526A-4F22-BDE3-52EC3BB18371'
     to='crone1@shakespeare.lit/desktop'>
   <x xmlns='http://jabber.org/protocol/muc#user'>
-    <item affiliation='member'
+    <item affiliation='owner'
           jid='hecate@shakespeare.lit'
           role='none'/>
   </x>


### PR DESCRIPTION
The mechanisms in which occupants are notified of a role or affiliation change is quite similar throughout the specification, but is not consistently documented. The changes herein are an attempt to improve consistency.

The first two commits are rather small. They intend to make smaller improvements.

The last commit introduces a new section, and adds references from other sections that deal with sending notifications of role and/or affiliation changes.