### PR TITLE
XEP-0045: Additional Ban List specifications

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -47,6 +47,12 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.34.7</version>
+    <date>2024-07-09</date>
+    <initials>gk</initials>
+    <remark><p>Explicitly disallow Ban List modifications that clash with 'Banning a User' conditions.</p></remark>
+  </revision>
+  <revision>
     <version>1.34.6</version>
     <date>2024-05-01</date>
     <initials>pep</initials>
@@ -3334,6 +3340,7 @@
       <li>&lt;domain&gt; (the domain itself matches, as does any user@domain or domain/resource)</li>
     </ol>
     <p>Some administrators might wish to ban all users associated with a specific domain from all rooms hosted by a MUC service. Such functionality is a service-level feature and is therefore out of scope for this document; see <cite>XEP-0133</cite>.</p>
+    <p>As specified in <link url='#ban'>Banning a User</link>, users cannot be banned under certain conditions. For example: admins and owners cannot ban themselves, and a user cannot be banned by an admin with a lower affiliation. When a request to modify the ban list includes one or more modifications that is prohibited by the definitions in <link url='#ban'>Banning a User</link>, then the service SHOULD NOT apply any of the requested changes and MUST deny the request using an error which SHOULD be either &conflict; or &notallowed;.</p>
   </section2>
 
   <section2 topic='Granting Membership' anchor='grantmember'>


### PR DESCRIPTION
Explicitly disallow Ban List modifications that clash with 'Banning a User' conditions.

This follows [a short discussion on the standards@xmpp.org mailinglist](https://mail.jabber.org/hyperkitty/list/standards@xmpp.org/message/CQXCV2DLCVP6RQRLJWR6HXV7E7SDIN5N/).