### PR TITLE
XEP-0045 Remove references to using resourceparts when banning users.

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -47,6 +47,12 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.34.7</version>
+    <date>2024-07-09</date>
+    <initials>gk</initials>
+    <remark><p>Remove references to using resourceparts when banning users.</p></remark>
+  </revision>
+  <revision>
     <version>1.34.6</version>
     <date>2024-05-01</date>
     <initials>pep</initials>
@@ -3326,12 +3332,10 @@
     type='result'/>
 ]]></example>
     <p>The service MUST then remove the affected occupants (if they are in the room) and send updated presence (including the appropriate status code) from them to all the remaining occupants as described in the "Banning a User" use case. (The service MUST also remove each banned user's reserved nickname from the list of reserved roomnicks, if appropriate.)</p>
-    <p>When an entity is banned from a room, an implementation SHOULD match JIDs in the following order (these matching rules are the same as those defined for privacy lists in &xep0016;):</p>
+    <p>When an entity is banned from a room, an implementation SHOULD match JIDs in the following order:</p>
     <ol start='1'>
-      <li>&lt;user@domain/resource&gt; (only that resource matches)</li>
-      <li>&lt;user@domain&gt; (any resource matches)</li>
-      <li>&lt;domain/resource&gt; (only that resource matches)</li>
-      <li>&lt;domain&gt; (the domain itself matches, as does any user@domain or domain/resource)</li>
+      <li>&lt;user@domain&gt;</li>
+      <li>&lt;domain&gt; (the domain itself matches, as does any user@domain)</li>
     </ol>
     <p>Some administrators might wish to ban all users associated with a specific domain from all rooms hosted by a MUC service. Such functionality is a service-level feature and is therefore out of scope for this document; see <cite>XEP-0133</cite>.</p>
   </section2>


### PR DESCRIPTION
Elsewhere, the specifications dictate that the banlist is based on bare JIDs. Matching resourceparts contradicts this (and is removed by this commit).

This PR follows [this short discussion on the standards@xmpp.org maillinglist](https://mail.jabber.org/hyperkitty/list/standards@xmpp.org/message/CQXCV2DLCVP6RQRLJWR6HXV7E7SDIN5N/).