### PR TITLE
XEP-0045: Improved wording of status code purpose

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -47,6 +47,12 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.34.7</version>
+    <date>2024-07-10</date>
+    <initials>gk</initials>
+    <remark><p>Status code purpose no longer hints that recipient is the affected user</p></remark>
+  </revision>
+  <revision>
     <version>1.34.6</version>
     <date>2024-05-01</date>
     <initials>pep</initials>
@@ -5549,7 +5555,7 @@
   <stanza>presence</stanza>
   <context>Removal from room</context>
   <purpose>
-    Inform user that he or she has been banned from the room
+    A user has been banned from the room
   </purpose>
 </statuscode>
 <statuscode>
@@ -5565,7 +5571,7 @@
   <stanza>presence</stanza>
   <context>Removal from room</context>
   <purpose>
-    Inform user that he or she has been kicked from the room
+    A user has been kicked from the room
   </purpose>
 </statuscode>
 <statuscode>
@@ -5573,7 +5579,7 @@
   <stanza>presence</stanza>
   <context>Removal from room</context>
   <purpose>
-    Inform user that he or she is being removed from the room
+    A user is being removed from the room
     because of an affiliation change
   </purpose>
 </statuscode>
@@ -5582,7 +5588,7 @@
   <stanza>presence</stanza>
   <context>Removal from room</context>
   <purpose>
-    Inform user that he or she is being removed from the room
+    A user is being removed from the room
     because the room has been changed to members-only and the
     user is not a member
   </purpose>
@@ -5592,7 +5598,7 @@
   <stanza>presence</stanza>
   <context>Removal from room</context>
   <purpose>
-    Inform user that he or she is being removed from the room
+    A user is being removed from the room
     because the MUC service is being shut down
   </purpose>
 </statuscode>
@@ -5601,7 +5607,7 @@
   <stanza>presence</stanza>
   <context>Removal from room</context>
   <purpose>
-    Inform users that a user was removed because of an error reply (for example
+    A user was removed because of an error reply (for example
     when an s2s link fails between the MUC and the removed users server).
   </purpose>
 </statuscode>


### PR DESCRIPTION
Previously, the wording of the status code purpose incorrectly hinted that the user receiving the presence stanza with the status code is the user that is affected by the corresponding change. This is incorrect, as these status code are not only used in stanzas sent to the affected user. They are also used to inform remaining occupants of the room of the status change.