### PR TITLE
XEP-0045: Improve 'Service Removes Non-Member' example

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -47,6 +47,12 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.34.7</version>
+    <date>2024-09-11</date>
+    <initials>gk</initials>
+    <remark><p>Improved 'Service Removes Non-Member' example.</p></remark>
+  </revision>
+  <revision>
     <version>1.34.6</version>
     <date>2024-05-01</date>
     <initials>pep</initials>
@@ -3437,7 +3443,7 @@
 
 [ ... ]
 ]]></example>
-    <p>If the room is members-only, the service MUST remove the user from the room, including a status code of 321 to indicate that the user was removed because of an affiliation change, and inform all remaining occupants:</p>
+    <p>If the room is members-only, the service MUST remove the user from the room, including a status code of 321 to indicate that the user was removed because of an affiliation change, and inform all remaining occupants. The stanza MAY include an &lt;actor/&gt; element.</p>
     <example caption='Service Removes Non-Member'><![CDATA[
 <presence
     from='coven@chat.shakespeare.lit/thirdwitch'
@@ -3447,16 +3453,6 @@
     <item affiliation='none' role='none'>
       <actor nick='TheBard'/>
     </item>
-    <status code='321'/>
-  </x>
-</presence>
-
-<presence
-    from='coven@chat.shakespeare.lit/thirdwitch'
-    to='crone1@shakespeare.lit/desktop'>
-    type='unavailable'>
-  <x xmlns='http://jabber.org/protocol/muc#user'>
-    <item affiliation='none' role='none'/>
     <status code='321'/>
   </x>
 </presence>


### PR DESCRIPTION
The pre-existing example appears to show two mutually exclusive acceptable stanzas. This can be confused for a requirement to send two stanzas. In this commit, the example is improved by removing one of the variants. A small textual change has been applied to define the optionality of the 'actor' element.

This change has been discussed:
- on the [standards mailing list](https://mail.jabber.org/hyperkitty/list/standards@xmpp.org/thread/F3W7CHDTLHAYQORUVMU2BS64PVCYGJIK/).
- in the [XSF Discussion chat room](https://logs.xmpp.org/xsf/2024-07-10#2024-07-10-dd0e5a0694e9760b).