### PR TITLE
XEP-0045: Replace inappropriate RFC 2119 key word usage in §9.7.

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -47,6 +47,12 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.34.7</version>
+    <date>2024-07-12</date>
+    <initials>gk</initials>
+    <remark><p>Replace inappropriate RFC 2119 key word usage in §9.7.</p></remark>
+  </revision>  
+  <revision>
     <version>1.34.6</version>
     <date>2024-05-01</date>
     <initials>pep</initials>
@@ -3630,7 +3636,7 @@
   </section2>
 
   <section2 topic='Revoking Moderator Status' anchor='revokemod'>
-    <p>An admin might want to revoke a user's moderator status. An admin MAY revoke moderator status only from a user whose affiliation is "member" or "none" (i.e., not from an owner or admin). The status is revoked by changing the user's role to "participant":</p>
+    <p>An admin might want to revoke a user's moderator status. An admin is allowed to revoke moderator status only from a user whose affiliation is "member" or "none" (i.e., not from an owner or admin). The status is revoked by changing the user's role to "participant":</p>
     <example caption='Admin Revokes Moderator Status'><![CDATA[
 <iq from='crone1@shakespeare.lit/desktop'
     id='mod2'


### PR DESCRIPTION
The 'MAY' key word, per RFC 2119, is to be used to flag a 'truly optional' item. In this text, it seems to be used to restrict the item to certain characteristics intead. This is an improper use of the key word.

Further down the section, the scenario is further specified, using more appropriate key word usage.

For context: this was briefly discussed in [the XSF Discussion chat room](https://logs.xmpp.org/xsf/2024-07-12#2024-07-12-db3a9ab26a4fa17c).