### PR TITLE
XEP-0045: Presence sent to occupants of a destroyed room includes a `<destroy/>` element

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -47,6 +47,12 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.34.7</version>
+    <date>2024-07-13</date>
+    <initials>gk</initials>
+    <remark><p>Presence sent to occupants of a destroyed room includes a &lt;destroy/&gt; element.</p></remark>
+  </revision>
+  <revision>
     <version>1.34.6</version>
     <date>2024-05-01</date>
     <initials>pep</initials>
@@ -4897,7 +4903,7 @@
   </query>
 </iq>
 ]]></example>
-    <p>The service is responsible for removing all the occupants. It SHOULD NOT broadcast presence stanzas of type "unavailable" from all occupants, instead sending only one presence stanza of type "unavailable" to each occupant so that the user knows he or she has been removed from the room. If extended presence information specifying the JID of an alternate location and the reason for the room destruction was provided by the room owner, the presence stanza MUST include that information.</p>
+    <p>The service is responsible for removing all the occupants. It SHOULD NOT broadcast presence stanzas of type "unavailable" from all occupants, instead sending only one presence stanza of type "unavailable" to each occupant so that the user knows he or she has been removed from the room. The extended presence information of the stanza MUST include &lt;destroy/&gt; element. If extended information specifying the JID of an alternate location and/or the reason for the room destruction was provided by the room owner, the presence stanza MUST include that information.</p>
     <example caption='Service Removes Each Occupant'><![CDATA[
 <presence
     from='heath@chat.shakespeare.lit/firstwitch'


### PR DESCRIPTION
Even if no reason or alternate venue is provided, a `<destroy/>` element is needed to distinguish between other presence unavailable.