### PR TITLE
XEP-0264: Restrict 'width' and 'height' to the 0..65535 range

### DIFF
--- a/xep-0264.xml
+++ b/xep-0264.xml
@@ -10,7 +10,7 @@
   <abstract>This specification defines a way for a client to supply a preview image for Jingle content.</abstract>
   &LEGALNOTICE;
   <number>0264</number>
-  <status>Deferred</status>
+  <status>Experimental</status>
   <type>Standards Track</type>
   <sig>Standards</sig>
   <approver>Council</approver>
@@ -29,6 +29,14 @@
     <jid>mlundblad@jabber.org</jid>
   </author>
   &lance;
+  <revision>
+    <version>0.4.2</version>
+    <date>2024-07-24</date>
+    <initials>egp</initials>
+    <remark>
+      <p>Restrict 'width' and 'height' to the 0..65535 range, instead of being unbounded integers.  This is in accordance to XEP-0084 and XEP-0221 for instance.</p>
+    </remark>
+  </revision>
   <revision>
     <version>0.4.1</version>
     <date>2022-09-05</date>
@@ -228,7 +236,7 @@ wish to not include a thumbnail.</p>
   <xs:annotation>
     <xs:documentation>
       The protocol documented by this schema is defined in
-      xxx
+      XEP-0264: http://www.xmpp.org/extensions/xep-0264.html
     </xs:documentation>
   </xs:annotation>
 
@@ -236,8 +244,8 @@ wish to not include a thumbnail.</p>
     <xs:complexType>
       <xs:attribute name='uri' type='xs:anyURI' use='required'/>
       <xs:attribute name='media-type' type='xs:string' use='optional'/>
-      <xs:attribute name='width' type='xs:integer' use='optional'/>
-      <xs:attribute name='height' type='xs:integer' use='optional'/>
+      <xs:attribute name='width' type='xs:unsignedShort' use='optional'/>
+      <xs:attribute name='height' type='xs:unsignedShort' use='optional'/>
     </xs:complexType>
   </xs:element>
 </xs:schema>


### PR DESCRIPTION
They were previously unbounded integers, aka `BigInt` in some languages. This change aligns them to what is currently allowed in XEP-0084 and XEP-0221 for instance.