### PR TITLE
XEP-0045: Explicitly use bare JIDs when operating on affiliations.

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -47,6 +47,12 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.34.7</version>
+    <date>2024-08-14</date>
+    <initials>gk</initials>
+    <remark><p>Explicitly use bare JIDs when operating on affiliations.</p></remark>
+  </revision>
+  <revision>
     <version>1.34.6</version>
     <date>2024-05-01</date>
     <initials>pep</initials>
@@ -4531,6 +4537,7 @@
   </query>
 </iq>
 ]]></example>
+    <p>As <link url='#affil'>affiliations are granted, revoked, and maintained based on the user's bare JID</link>, the requesting entity SHOULD use the bare JID of the user in the request. When processing a request that identifies a user by its full JID, a service SHOULD use the bare JID representation.</p>
     <p>The service MUST add the user to the owner list and then inform the owner of success:</p>
     <example caption='Service Informs Owner of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -4596,6 +4603,7 @@
   </query>
 </iq>
 ]]></example>
+    <p>As <link url='#affil'>affiliations are granted, revoked, and maintained based on the user's bare JID</link>, the requesting entity SHOULD use the bare JID of the user in the request. When processing a request that identifies a user by its full JID, a service SHOULD use the bare JID representation.</p>
     <p>A service MUST NOT allow an owner to revoke his or her own owner status if there are no other owners; if an owner attempts to do this, the service MUST return a &conflict; error to the owner. However, a service SHOULD allow an owner to revoke his or her own owner status if there are other owners.</p>
     <p>If an implementation does not allow one owner to revoke another user's owner status, the implementation MUST return a &notauthorized; error to the owner who made the request.</p>
     <p>Note: Allowing an owner to remove another user's owner status can compromise the control model for room management; therefore this feature is OPTIONAL, and implementations are encouraged to support owner removal through an interface that is open only to individuals with service-wide admin status.</p>
@@ -4647,7 +4655,7 @@
   </query>
 </iq>
 ]]></example>
-    <p>The owner can then modify the owner list if desired. In order to do so, the owner MUST send the changed items (i.e., only the "delta") back to the service; <note>This is different from the behavior of room configuration, wherein the "muc#roomconfig_roomowners" field specifies the full list of room owners, not the delta.</note> each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than affiliations such as owner):</p>
+    <p>The owner can then modify the owner list if desired. In order to do so, the owner MUST send the changed items (i.e., only the "delta") back to the service; <note>This is different from the behavior of room configuration, wherein the "muc#roomconfig_roomowners" field specifies the full list of room owners, not the delta.</note> each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than affiliations such as owner). As <link url='#affil'>affiliations are granted, revoked, and maintained based on the user's bare JID</link>, the requesting entity SHOULD use the bare JID of users in the request. When processing a request that identifies a user by its full JID, a service SHOULD use the bare JID representation.</p>
     <example caption='Owner Sends Modified Owner List to Service'><![CDATA[
 <iq from='bard@shakespeare.lit/globe'
     id='owner4'
@@ -4708,6 +4716,7 @@
   </query>
 </iq>
 ]]></example>
+    <p>As <link url='#affil'>affiliations are granted, revoked, and maintained based on the user's bare JID</link>, the requesting entity SHOULD use the bare JID of the user in the request. When processing a request that identifies a user by its full JID, a service SHOULD use the bare JID representation.</p>
     <p>The service MUST add the user to the admin list and then inform the owner of success:</p>
     <example caption='Service Informs Owner of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -4773,6 +4782,7 @@
   </query>
 </iq>
 ]]></example>
+    <p>As <link url='#affil'>affiliations are granted, revoked, and maintained based on the user's bare JID</link>, the requesting entity SHOULD use the bare JID of the user in the request. When processing a request that identifies a user by its full JID, a service SHOULD use the bare JID representation.</p>
     <p>The service MUST remove the user from the admin list and then inform the owner of success:</p>
     <example caption='Service Informs Owner of Success'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -4839,7 +4849,7 @@
   </query>
 </iq>
 ]]></example>
-    <p>The owner can then modify the admin list if desired. In order to do so, the owner MUST send the changed items (i.e., only the "delta") back to the service; <note>This is different from the behavior of room configuration, wherein the "muc#roomconfig_roomadmins" field specifies the full list of room admins, not the delta.</note> each item MUST include the 'affiliation' attribute (normally set to a value of "admin" or "none") and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than affiliations such as owner).</p>
+    <p>The owner can then modify the admin list if desired. In order to do so, the owner MUST send the changed items (i.e., only the "delta") back to the service; <note>This is different from the behavior of room configuration, wherein the "muc#roomconfig_roomadmins" field specifies the full list of room admins, not the delta.</note> each item MUST include the 'affiliation' attribute (normally set to a value of "admin" or "none") and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than affiliations such as owner). As <link url='#affil'>affiliations are granted, revoked, and maintained based on the user's bare JID</link>, the requesting entity SHOULD use the bare JID of users in the request. When processing a request that identifies a user by its full JID, a service SHOULD use the bare JID representation.</p>
     <example caption='Owner Sends Modified Admin List to Service'><![CDATA[
 <iq from='bard@shakespeare.lit/globe'
     id='admin4'


### PR DESCRIPTION
Section 5.2 defines that affiliations are granted, revoked, and maintained based on the user's bare JID. This commit adds a reference to this definition where affiliations are used (in section 10), and adds a SHOULD to downcast to a bare JID when a request provides a full JID.

This was briefly discussed in the discussion room of the XMPP Standards Foundation ([logs](https://logs.xmpp.org/xsf/2024-08-14#2024-08-14-eb42d4651b7b01d3)).