### PR TITLE
XEP-0045: Allow non-owners to retrieve owner and admin lists in non-anonymous rooms

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -47,6 +47,12 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.35.0</version>
+    <date>2024-08-14</date>
+    <initials>gk</initials>
+    <remark><p>Allow non-owners to retrieve owner and admin lists in non-anonymous rooms.</p></remark>
+  </revision>
+  <revision>
     <version>1.34.6</version>
     <date>2024-05-01</date>
     <initials>pep</initials>
@@ -4634,7 +4640,7 @@
   </query>
 </iq>
 ]]></example>
-    <p>If the &lt;user@host&gt; of the 'from' address does not match the bare JID of a room owner, the service MUST return a &forbidden; error to the sender.</p>
+    <p>If the &lt;user@host&gt; of the 'from' address does not match the bare JID of a room owner, the service MUST return a &forbidden; error to the sender in semi-anonymous rooms. In non-anonymous rooms, the service MAY process the request.</p>
     <p>Otherwise, the service MUST then return the owner list to the owner; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for any owner that is currently an occupant:</p>
     <example caption='Service Sends Owner List to Owner'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -4659,7 +4665,7 @@
   </query>
 </iq>
 ]]></example>
-    <p>Only owners shall be allowed to modify the owner list. If a non-owner attempts to view or modify the owner list, the service MUST deny the request and return a &forbidden; error to the sender:</p>
+    <p>Only owners shall be allowed to modify the owner list. If a non-owner attempts to modify the owner list, the service MUST deny the request and return a &forbidden; error to the sender:</p>
     <example caption='Service Returns Error on Attempt by Non-Owner to Modify Owner List'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='ownertest'
@@ -4823,7 +4829,7 @@
   </query>
 </iq>
 ]]></example>
-    <p>If the &lt;user@host&gt; of the 'from' address does not match the bare JID of a room owner, the service MUST return a &forbidden; error to the sender.</p>
+    <p>If the &lt;user@host&gt; of the 'from' address does not match the bare JID of a room owner, the service MUST return a &forbidden; error to the sender in semi-anonymous rooms. In non-anonymous rooms, the service MAY process the request.</p>
     <p>Otherwise, the service MUST then return the admin list to the owner; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for any admin that is currently an occupant:</p>
     <example caption='Service Sends Admin List to Owner'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
@@ -4855,7 +4861,7 @@
   </query>
 </iq>
 ]]></example>
-    <p>Only owners shall be allowed to modify the admin list. If a non-owner attempts to view or modify the admin list, the service MUST deny the request and return a &forbidden; error to the sender.</p>
+    <p>Only owners shall be allowed to modify the admin list. If a non-owner attempts to modify the admin list, the service MUST deny the request and return a &forbidden; error to the sender.</p>
     <example caption='Service Returns Error on Attempt by Non-Owner to Modify Admin List'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'
     id='admintest'

--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -50,7 +50,12 @@
     <version>1.35.0</version>
     <date>2024-08-14</date>
     <initials>gk</initials>
-    <remark><p>Allow non-owners to retrieve owner and admin lists in non-anonymous rooms.</p></remark>
+    <remark>
+      <ul>
+        <li>Allow non-owners to retrieve owner and admin lists in non-anonymous rooms.</li>
+        <li>Members should be allowed to retrieve the member list only in non-anonymous rooms.</li>
+      </ul>
+    </remark>
   </revision>
   <revision>
     <version>1.34.6</version>
@@ -992,7 +997,7 @@
           <td>N/A</td>
         </tr>
         <tr>
-          <td>Retrieve Member List</td>
+          <td>Retrieve Member List***</td>
           <td>No</td>
           <td>No</td>
           <td>Yes</td>
@@ -1066,6 +1071,7 @@
       </table>
       <p>* As a default, an unaffiliated user enters a moderated room as a visitor, and enters an open room as a participant. A member enters a room as a participant. An admin or owner enters a room as a moderator.</p>
       <p>** As noted, a moderator SHOULD NOT be allowed to revoke moderation privileges from someone with a higher affiliation than themselves (i.e., an unaffiliated moderator SHOULD NOT be allowed to revoke moderation privileges from an admin or an owner, and an admin SHOULD NOT be allowed to revoke moderation privileges from an owner).</p>
+      <p>*** When a room is configured to be semi-anonymous, there clearly is an intent to hide JIDs. In such rooms, members SHOULD NOT be allowed to retrieve the member list (as that list MUST contain the JID of each member).</p>
     </section3>
 
     <section3 topic='Changing Affiliations' anchor='affil-change'>
@@ -3485,7 +3491,7 @@
   </query>
 </iq>
 ]]></example>
-    <p>Note: A service SHOULD also return the member list to any occupant in a members-only room; i.e., it SHOULD NOT generate a &forbidden; error when a member in the room requests the member list. This functionality can assist clients in showing all the existing members even if some of them are not in the room, e.g. to help a member determine if another user should be invited. A service SHOULD also allow any member to retrieve the member list even if not yet an occupant.</p>
+    <p>Note: If the room is non-anonymous, a service SHOULD also return the member list to any occupant in a members-only room; i.e., it SHOULD NOT generate a &forbidden; error when a member in such a room requests the member list. This functionality can assist clients in showing all the existing members even if some of them are not in the room, e.g. to help a member determine if another user should be invited. If the room is non-anonymous, a service SHOULD also allow any member to retrieve the member list even if not yet an occupant.</p>
     <p>The service MUST then return the full member list to the admin qualified by the 'http://jabber.org/protocol/muc#admin' namespace; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for each member that is currently an occupant.</p>
     <example caption='Service Sends Member List to Admin'><![CDATA[
 <iq from='coven@chat.shakespeare.lit'


### PR DESCRIPTION
In non-anonymous rooms, there's little point in withholding the functionality, as JIDs are visible anyway.

This was briefly discussed in the XSF Standards chat room: https://logs.xmpp.org/xsf/2024-08-14#2024-08-14-f8bc35378ee61874