### PR TITLE
XEP-0402: Specify what clients should do if autojoin='0' in bookmark notifications

### DIFF
--- a/xep-0402.xml
+++ b/xep-0402.xml
@@ -30,6 +30,12 @@
         &dcridland;
         &jcbrand;
         <revision>
+          <version>1.2.0</version>
+          <date>2024-08-15</date>
+          <initials>mye</initials>
+          <remark><p>Encourage clients to immediately leave the room if they receive a bookmark notification with autojoin set to false</p></remark>
+        </revision>
+        <revision>
           <version>1.1.4</version>
           <date>2023-04-02</date>
           <initials>egp</initials>
@@ -374,6 +380,23 @@
         <conference xmlns=']]>&namespace;<![CDATA['
                     name='The Play&apos;s the Thing'
                     autojoin='1'>
+          <nick>JC</nick>
+        </conference>
+      </item>
+    </items>
+  </event>
+</message>
+]]></example>
+
+        <p>If the bookmark notification's 'autojoin' attribute is set to false, the client SHOULD leave the room immediately.</p>
+
+        <example caption='Client receives a bookmark notification with autojoin=&#39;false&#39; (its default value)'><![CDATA[
+<message from='juliet@capulet.lit' to='juliet@capulet.lit/balcony' type='headline' id='unjoined-room1'>
+  <event xmlns='http://jabber.org/protocol/pubsub#event'>
+    <items node=']]>&namespace;<![CDATA['>
+      <item id='theplay@conference.shakespeare.lit'>
+        <conference xmlns=']]>&namespace;<![CDATA['
+                    name='The Play&apos;s the Thing'>
           <nick>JC</nick>
         </conference>
       </item>


### PR DESCRIPTION
Currently, the XEP specifies what the client should do if autojoin='1' or if the bookmark is deleted, but it doesn't specify what to do if autojoin='0'

With this PR, we specify that case as well.

Note: multiple "modern" clients already implement the spec change in this PR.