### PR TITLE
CI: improve iteration over multiple changed files

### DIFF
--- a/.github/workflows/xep-validation.yml
+++ b/.github/workflows/xep-validation.yml
@@ -24,10 +24,12 @@ jobs:
 
       - name: Validate changed file(s)
         if: steps.changed-xeps.outputs.any_changed == 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-xeps.outputs.all_changed_files }}
         run: |
           sudo apt-get install -y libxml2-utils
           result=0
-          for xep in "${{ steps.changed-xeps.outputs.all_changed_files }}"; do
+          for xep in ${ALL_CHANGED_FILES}; do
             if ! tools/validate-xep0001-conformance.sh "$xep"; then
               result=1
             fi


### PR DESCRIPTION
The quotation made the list of files be interpreted as one very long filename.

Split off in a environment variable to better match the examples provided by tj-actions/changed-files