### PR TITLE
XEP-0133: Fix typo in example for Get User Last Login Time

### DIFF
--- a/xep-0133.xml
+++ b/xep-0133.xml
@@ -23,6 +23,12 @@
   <shortname>admin</shortname>
   &stpeter;
   <revision>
+    <version>1.3.1</version>
+    <date>2024-09-01</date>
+    <initials>dc</initials>
+    <remark>Fixed typo in example for Get User Last Login Time</remark>
+  </revision>
+  <revision>
     <version>1.3.0</version>
     <date>2024-01-04</date>
     <initials>gdk</initials>
@@ -736,7 +742,7 @@
   <section2 topic='Get User Last Login Time' anchor='get-user-lastlogin'>
     <p>An administrator may need to retrieve a user's last login time (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case SHOULD be "http://jabber.org/protocol/admin#get-user-lastlogin".</p>
     <p>A sample protocol flow for this use case is shown below.</p>
-    <example caption='Admin Requests to Get a User&apos;s Roster'><![CDATA[
+    <example caption='Admin Requests to Get a User&apos;s Last Login Time'><![CDATA[
 <iq from='bard@shakespeare.lit/globe'
     id='get-user-lastlogin-1'
     to='shakespeare.lit'


### PR DESCRIPTION
Examples are non-normative. Is the revision block necessary here?