### PR TITLE
XEP-0480: Fix SCRAM upgrade description and XML schema

### DIFF
--- a/xep-0480.xml
+++ b/xep-0480.xml
@@ -24,6 +24,12 @@
   <shortname>sut</shortname>
   &tmolitor;
   <revision>
+    <version>0.2.0</version>
+    <date>2024-12-01</date>
+    <initials>tm</initials>
+    <remark>Fix SCRAM upgrade description and XML schema.</remark>
+  </revision>
+  <revision>
     <version>0.1.0</version>
     <date>2023-05-04</date>
     <initials>XEP Editor: ks</initials>
@@ -195,8 +201,8 @@
 </section1>
 
 <section1 topic="SCRAM upgrade tasks" anchor="scram">
-  <p>For upgrades of SCRAM mechanisms as defined in &rfc5802;, the server has to provide the needed data for the client to calculate the SaltedPassword as defined in this RFC (or some RFC updating it), namely the iteration count and salt. To do so the server sends a &lt;salt/> element namespaced to "urn:xmpp:scram-upgrade:0" containing the salt and an attribute named "iteration" containing the iteration count as defined in that RFC, omitting the "s=" and "i=" prefix. The &lt;salt/> element is contained within a &lt;task-data/> wrapper element as defined in &xep0388;.</p>
-  <p>The client then calculates the SaltedPassword and sends back its base64 encoded value inside a &lt;hash/> element namespaced to "urn:xmpp:scram-upgrade:0". The &lt;hash/> element is contained within a &lt;task-data/> wrapper element as defined in &xep0388;.</p>
+  <p>For upgrades of SCRAM mechanisms as defined in &rfc5802;, the server has to provide the needed data for the client to calculate the SaltedPassword as defined in this RFC (or some RFC updating it), namely the iteration count and salt. To do so the server sends a &lt;salt/> element namespaced to "urn:xmpp:scram-upgrade:0" containing the base64 encoded salt (omitting the "s=" prefix, see &rfc5802; for the concrete definition of valid salts) and an attribute named "iterations" containing the iteration count as defined in that RFC (omitting the "i=" prefix). The &lt;salt/> element is contained within a &lt;task-data/> wrapper element as defined in &xep0388; and MUST NOT be empty.</p>
+  <p>The client then calculates the &rfc5802; SaltedPassword and sends back its base64 encoded value inside a &lt;hash/> element namespaced to "urn:xmpp:scram-upgrade:0". The &lt;hash/> element MUST NOT be empty and is contained within a &lt;task-data/> wrapper element as defined in &xep0388;.</p>
   <p>The name of the upgrade task MUST NOT conain the "-PLUS" suffix, because channel-binding is not relevant for upgrade tasks.</p>
   <example caption="SCRAM hash upgrade task for SCRAM-SHA-256 after successful SCRAM-SHA-1-PLUS authentication"><![CDATA[
   <!-- Client sending stream header -->
@@ -270,7 +276,7 @@
   -->
   <task-data xmlns='urn:xmpp:sasl:2'>
     <salt xmlns='urn:xmpp:scram-upgrade:0' iterations='4096'>
-      A_SXCRXQ6sek8bf_Z
+      QV9TWENSWFE2c2VrOGJmX1o=
     </salt>
   </task-data>
 
@@ -330,12 +336,13 @@
            xmlns="urn:xmpp:scram-upgrade:0"
            elementFormDefault="qualified">
 
-  <xs:element name="parameters">
+  <xs:element name="salt">
     <xs:complexType>
-      <xs:sequence>
-        <xs:element name="salt" type="base64Data" minOccurs="1" maxOccurs="1"/>
-        <xs:element name="iterations" type="iterationCount" minOccurs="1" maxOccurs="1"/>
-      </xs:sequence>
+      <xs:simpleContent>
+        <xs:extension base="base64Data">
+          <xs:attribute name="iterations" type="iterationCount" use="required"/>
+        </xs:extension>
+      </xs:simpleContent>
     </xs:complexType>
   </xs:element>
 
@@ -347,7 +354,8 @@
 
   <xs:simpleType name="iterationCount">
     <xs:restriction base="xs:integer">
-      <xs:minInclusive value="1"/>
+      <!-- see minimum value defined in scram rfc! -->
+      <xs:minInclusive value="4096"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
The xml schema had an error (element versus attribute) and the text and example was missing base64 encoding of the salt.