### PR TITLE
New ProtoXEP: Pubsub Stories

### DIFF
--- a/inbox/stories.xml
+++ b/inbox/stories.xml
@@ -1,0 +1,125 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY % ents SYSTEM 'xep.ent'>
+  %ents;
+]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+  <header>
+    <title>Pubsub Stories</title>
+    <abstract>This specification defines a way of publishing Stories over XMPP.</abstract>
+    &LEGALNOTICE;
+    <number>xxxx</number>
+    <status>ProtoXEP</status>
+    <type>Standards Track</type>
+    <sig>Standards</sig>
+    <approver>Council</approver>
+    <dependencies>
+      <spec>XMPP Core</spec>
+      <spec>XMPP IM</spec>
+      <spec>XEP-0060</spec>
+      <spec>XEP-0163</spec>
+      <spec>XEP-0472</spec>
+      <spec>RFC 4287</spec>
+    </dependencies>
+    <supersedes/>
+    <supersededby />
+    <shortname>ps</shortname>
+    <author>
+      <firstname>Timothée</firstname>
+      <surname>Jaussoin</surname>
+      <email>edhelas@movim.eu</email>
+      <jid>edhelas@movim.eu</jid>
+      <uri>https://edhelas.movim.eu</uri>
+    </author>
+    <revision>
+      <version>0.0.1</version>
+      <date>2024-12-03</date>
+      <initials>tj</initials>
+      <remark>Initial version.</remark>
+    </revision>
+  </header>
+
+    <section1 topic='Glossary' anchor='glossary'>
+    <dl>
+      <di>
+        <dt>Story</dt>
+        <dd>An item stored in a Stories Pubsub node.</dd>
+      </di>
+    </dl>
+  </section1>
+
+  <section1 topic='Introduction' anchor='intro'>
+    <p>Introduced by Snapchat in 2012 Stories are a way for users to share content that can be viewed for a specific amount of time in chronological order.</p>
+
+    <p>&xep0472; already defines a generic way of publishing social content on XMPP. This extension defines a way to publish Stories content on a user &xep0163; node.</p>
+
+    <p>This extension extends &xep0472; by defining a new Profile (see <link url="https://xmpp.org/extensions/xep-0472.html#profiles">Profiles</link>) called Pubsub Stories.</p>
+  </section1>
+
+  <section1 topic='Discovery' anchor='discovery'>
+    <p>If an entity implements Pubsub Stories, it MUST specify the 'urn:xmpp:pubsub-social-feed:1' and 'urn:xmpp:pubsub-social-feed:stories:0' features in its service discovery information features as specified in &xep0030; and the Entity Capabilities profile specified in &xep0115;.</p>
+
+    <p>If an entity wish to receive notifications from a contact when a Story is published it should also declares it in its service discovery followed by "+notify"</p>
+
+    <example caption='The entity responds with Stories feature'><![CDATA[
+  <iq type='result'
+      id='disco1'
+      from='juliet@capulet.lit/sabo239'
+      to='romeo@montegue.lit/30d3d8'>
+    <query xmlns='http://jabber.org/protocol/disco#info'>
+      ...
+      <feature var='urn:xmpp:pubsub-social-feed:1'/>
+      <feature var='urn:xmpp:pubsub-social-feed:stories:0'/>
+      <feature var='urn:xmpp:pubsub-social-feed:stories:0+notify'/>
+      ...
+    </query>
+  </iq>
+  ]]></example>
+  </section1>
+
+  <section1 topic='Protocol' anchor='protocol'>
+    <section2 topic="Pubsub Stories profile" anchor="profile_stories">
+      <p>This profile is defined by the Pubsub type "urn:xmpp:pubsub-social-feed:stories:0" and is hosted on a "urn:xmpp:pubsub-social-feed:stories:0" &xep0163; node.</p>
+
+      <p>All the items published in a Pubsub Stories node MUST have only one attached media. This media MUST be of type "enclosure" as specified in &rfc4287;.</p>
+      <example caption="An Atom attached picture"><![CDATA[
+<link rel='enclosure' href='https://capulet.lit/upload/romeo-story.jpg' type='image/jpeg' title='Stories 03-02-1597'/>
+]]></example>
+
+      <section3 topic="Pubsub Node Configuration" anchor="profile_base_node_config">
+        <p>Stories node MUST base their default configuration on the <link url="https://xmpp.org/extensions/xep-0472.html#profile_base">Base Profile</link> and:</p>
+        <ol>
+          <li>The "pubsub#type" MUST be set to "urn:xmpp:pubsub-social-feed:stories:0"</li>
+          <li>The "pubsub#access_model" SHOULD be set to "presence".</li>
+        </ol>
+      </section3>
+    </section2>
+  </section1>
+
+  <section1 topic='Business Rules' anchor='bizrules'>
+    <p>Subscribers clients SHOULD hide the items after a specific amount of time, usually 24 hours.</p>
+    <p>Publishers clients SHOULD retract the items after a specific amount of time, usually 24 hours. </p>
+  </section1>
+
+  <section1 topic='Security Considerations' anchor='security'>
+    <p>There are no security features or concerns related to this proposal.</p>
+  </section1>
+
+  <section1 topic='IANA Considerations' anchor='iana'>
+    <p>This document requires no interaction with &IANA;.</p>
+  </section1>
+
+  <section1 topic='XMPP Registrar Considerations' anchor='registrar'>
+    <p>The &REGISTRAR; is requested to issue an initial namespace of "urn:xmpp:pubsub-social-feed:stories:0".</p>
+  </section1>
+
+  <section1 topic='XML Schema' anchor='schema'>
+    <p>
+      This specification re-uses the schema for the Atom content format, i.e., the 'http://www.w3.org/2005/Atom' namespace (see
+      &rfc4287;
+      ).
+    </p>
+  </section1>
+
+</xep>


### PR DESCRIPTION
This new ProtoXEP extends XEP-0472: Pubsub Social Feed by defining a new Profile called Stories.

An HTML version is available here: https://movim.eu/xeps/stories.html