### PR TITLE
XEP-0501: Add pubsub#item_expire in the node configuration

### DIFF
--- a/xep-0501.xml
+++ b/xep-0501.xml
@@ -33,6 +33,14 @@
       <uri>https://edhelas.movim.eu</uri>
     </author>
     <revision>
+      <version>0.2.0</version>
+      <date>2024-12-20</date>
+      <initials>tj</initials>
+      <remark>
+        <p>Add pubsub#item_expire in the node configuration</p>
+      </remark>
+    </revision>
+    <revision>
       <version>0.1.0</version>
       <date>2024-12-19</date>
       <initials>XEP Editor: dg</initials>
@@ -100,14 +108,15 @@
         <ol>
           <li>The "pubsub#type" MUST be set to "urn:xmpp:pubsub-social-feed:stories:0"</li>
           <li>The "pubsub#access_model" SHOULD be set to "presence".</li>
+          <li>The "pubsub#item_expire" SHOULD be set, usually 24 hours (86400).</li>
         </ol>
       </section3>
     </section2>
   </section1>
 
   <section1 topic='Business Rules' anchor='bizrules'>
-    <p>Subscribers clients SHOULD hide the items after a specific amount of time, usually 24 hours.</p>
-    <p>Publishers clients SHOULD retract the items after a specific amount of time, usually 24 hours. </p>
+    <p>If the "pubsub#item_expire" value is set subscribers clients MUST hide or destroy the received items once they expire.</p>
+    <p>If the "pubsub#item_expire" value is not set publishers clients SHOULD retract the items after a specific amount of time, usually 24 hours. </p>
   </section1>
 
   <section1 topic='Security Considerations' anchor='security'>


### PR DESCRIPTION
This update mention pubsub#item_expire to allow the automatic expiration of the items on the server and a fallback on the clients if not set.