### PR TITLE
XEP-0388: Fix failure example sequence

### DIFF
--- a/xep-0388.xml
+++ b/xep-0388.xml
@@ -27,6 +27,14 @@
   &tmolitor;
   &mwild;
   <revision>
+    <version>1.0.3</version>
+    <date>2024-12-22</date>
+    <initials>sp</initials>
+    <remark><ul>
+      <li>Fix failure example sequence.</li>
+    </ul></remark>
+  </revision>
+  <revision>
     <version>1.0.2</version>
     <date>2024-08-06</date>
     <initials>egp</initials>
@@ -299,13 +307,13 @@
       <p>The &lt;success> element is immediately followed by a &lt;features> element in the "http://etherx.jabber.org/streams" namespace containing the applicable stream features of the newly authenticated stream. Note that no stream restart occurs.</p>
     </section3>
     <section3 topic="Failure" anchor="failure">
-      <p>A &lt;failure/> element is used by the server to terminate the authentication attempt. It MAY contain application-specific error codes, and MAY contain a textual error. It MUST contain one of the SASL error codes from RFC 6120 Section 6.5.</p>
+      <p>A &lt;failure/> element is used by the server to terminate the authentication attempt. It MAY contain a textual error and, MAY contain application-specific error codes. It MUST contain one of the SASL error codes from RFC 6120 Section 6.5.</p>
       <p>The server MUST NOT process any inline features requested by the client in a failed authentication request, if any.</p>
       <example caption="Failure"><![CDATA[
 <failure xmlns='urn:xmpp:sasl:2'>
   <aborted xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/>
-  <optional-application-specific xmlns='urn:something:else'/>
   <text>This is a terrible example.</text>
+  <optional-application-specific xmlns='urn:something:else'/>
 </failure>
 ]]></example>
     </section3>


### PR DESCRIPTION
The schema is as follow

```xml
  <xs:element name="failure">
    <xs:complexType>
      <xs:sequence>
        <xs:element name="text" type="xs:string" minOccurs="0"/>
        <xs:any namespace='##other' minOccurs='0' maxOccurs='unbounded' processContents='lax'/>
      </xs:sequence>
    </xs:complexType>
  </xs:element>
```

Which matches RFC 6120 similar stream error https://xmpp.org/rfcs/rfc6120.html#rfc.section.6.5