### PR TITLE
XEP-0421 v0.3.0

### DIFF
--- a/xep-0421.xml
+++ b/xep-0421.xml
@@ -6,8 +6,8 @@
 <?xml-stylesheet type='text/xsl' href='xep.xsl'?>
 <xep>
 <header>
-  <title>Anonymous unique occupant identifiers for MUCs</title>
-  <abstract>This specification defines a method that allows clients to identify a MUC participant across reconnects and renames. It thus prevents impersonification of anonymous users.</abstract>
+  <title>Occupant identifiers for semi-anonymous MUCs</title>
+  <abstract>This specification defines a method that allows clients to identify a MUC participant across reconnects and renames. It thus prevents impersonification of semi-anonymous users.</abstract>
   &LEGALNOTICE;
   <number>0421</number>
   <status>Proposed</status>
@@ -24,12 +24,18 @@
   <supersedes/>
   <supersededby/>
   <shortname>occupant-id</shortname>
-  <author>
-    <firstname>Marvin</firstname>
-    <surname>Wissfeld</surname>
-    <email>xsf@larma.de</email>
-    <jid>jabber@larma.de</jid>
-  </author>
+  &larma;
+  <revision>
+    <version>0.3.0</version>
+    <date>2025-01-07</date>
+    <initials>lmw</initials>
+    <remark><ul>
+      <li>Adjust wording to use semi-anonymous or pseudonymous instead of anonymous</li>
+      <li>Explicitly mention issues arising from occupant id matching across rooms</li>
+      <li>Add example with server secret instead of room secret</li>
+      <li>Add some pseudocode</li>
+    </ul></remark>
+  </revision>
   <revision>
     <version>0.2.0</version>
     <date>2024-05-28</date>
@@ -71,13 +77,13 @@
   </p>
   <p>
     This specification defines a method to combat issues arising out of the
-    anonymity of MUC occupants while at the same time ensuring their privacy
-    by not leaking their real JID to other occupants.
+    pseudonymity of MUC occupants while at the same time ensuring their privacy
+    by not revealing their real JID to other occupants.
   </p>
 </section1>
 <section1 topic='Discovering support' anchor='disco'>
   <p>
-    If a MUC implements anonymous unique occupant identifiers, it MUST
+    If a MUC room implements occupant identifiers, it MUST
     specify the 'urn:xmpp:occupant-id:0' feature in its service discovery
     information features as specified in &xep0030;.
   </p>
@@ -88,7 +94,7 @@
     id='info1'>
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>]]></example>
-  <example caption='MUC advertises support for anonymous unique occupant identifiers'><![CDATA[
+  <example caption='MUC advertises support for occupant identifiers'><![CDATA[
 <iq type='result'
     to='hag66@shakespeare.lit/pda'
     from='coven@chat.shakespeare.lit'
@@ -104,9 +110,9 @@
   <section2 topic="Entering a Room" anchor="enter">
     <p>
       When a user enters a room, they send a presence to claim the nickname in
-      the MUC. A MUC that supports anonymous unique occupant identifiers
-      attaches an &lt;occupant-id&gt; element to the presence sent to all
-      occupants in the room.
+      the MUC. A MUC that supports occupant identifiers
+      attaches an &lt;occupant-id&gt; element within the "urn:xmpp:occupant-id:0"
+      namespace to the presence sent to all occupants in the room.
     </p>
     <example caption="Client joins a room"><![CDATA[
 <presence
@@ -128,9 +134,9 @@
       <p>
         An occupant sends a message to all other occupants in the room by
         sending a message of type "groupchat" to the &lt;room@service&gt;. A MUC
-        supporting anonymous unique occupant identifiers attaches an
-        &lt;occupant-id&gt; element to the message sent to all occupants in the
-        room.
+        supporting occupant identifiers attaches an
+        &lt;occupant-id&gt; element within the "urn:xmpp:occupant-id:0" to the
+        message sent to all occupants in the room.
       </p>
     <example caption="Client sends a message to all occupants"><![CDATA[
 <message
@@ -189,13 +195,17 @@
       re-create the occupant identifier of another user.
     </p>
     <p>
-      The occupant identifier MUST be generated such that it is anonymous. This
+      The occupant identifier MUST be generated such that it is pseudonymous. This
       means that it MUST be sufficiently hard to determine the real bare JID of
       an occupant from its occupant identifier. Additionally, a MUC service
       SHOULD generate the identifier such that the occupant identifier of a user
       in one room of the service does not match the occupant identifier of the
       same user in another room of the same service.
-      To guarantee the anonymity property, the server MUST NOT generate an 
+      If the MUC service generates the same occupant identifier for the same
+      user in different rooms, information shared using different nicknames and
+      in different rooms could be combined through the occupant identifier and
+      thereby unintentionally reveal information about the user.
+      To guarantee the pseudonymity property, the server MUST NOT generate an
       occupant identifier by only hashing the real bare JID using static,
       guessable or discoverable parameters.
     </p>
@@ -207,9 +217,22 @@
       One way to ensure these properties is to generate a private secret key for
       every room and use an HMAC algorithm with a sufficiently secure hash
       function to generate the occupant identifier from the real bare JID and
-      that secret key. This procedure ensures all the required properties with
+      that secret key.
+      Alternatively, the service can generate a single private secret key for the
+      whole service and use an HMAC algorithm to generate the occupant identifier
+      from the real bare JID, the room bare JID and the service secret key.
+      This procedure ensures all the required properties with
       minimal server side storage requirements.
     </p>
+    <example caption="Pseudo-code of occupant identifier generation"><![CDATA[
+room_secret_key := RANDOM_BYTES(32) # Stored with room state
+occupant-id := HEX(HMAC_SHA1(room_secret_key, user_bare_jid))
+
+# or #
+
+service_secret_key := RANDOM_BYTES(32) # Stored with service state
+occupant-id := HEX(HMAC_SHA1(service_secret_key, room_bare_jid || NUL || user_bare_jid))
+]]></example>
   </section2>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>
@@ -227,7 +250,7 @@
     <link url='#disco'>Discovering support</link> section.
   </p>
   <p>
-    The anonymity property of occupant identifiers is crucial to not
+    The pseudonymity property of occupant identifiers is crucial to not
     accidentally reveal an occupant's real bare JID to other room occupants.
     Specifically, a simple hash over the occupant's real bare JID is not
     sufficient as an occupant identifier, as unsalted hashes can be reversed


### PR DESCRIPTION
- Adjust wording to use semi-anonymous or pseudonymous instead of anonymous
- Explicitly mention issues arising from occupant id matching across rooms
- Add example with server secret instead of room secret
- Add some pseudocode

Diff is here: https://larma.de/xeps/xep-0421-diff.html
Note that as part of not using the term anonymous anymore, I also adjusted the title to make it more descriptive.