### PR TITLE
XEP-0377: Add report processing opt-in

### DIFF
--- a/inbox/pubsub-server-info.xml
+++ b/inbox/pubsub-server-info.xml
@@ -18,12 +18,7 @@
   <supersedes/>
   <supersededby/>
   <shortname>serverinfo</shortname>
-  <author>
-    <firstname>Guus</firstname>
-    <surname>der Kinderen</surname>
-    <email>guus.der.kinderen@gmail.com</email>
-    <jid>guus.der.kinderen@igniterealtime.org</jid>
-  </author>
+  &gdk;
   <revision>
     <version>0.0.1</version>
     <date>2023-12-19</date>

--- a/inbox/xep-happy-eyeballs.xml
+++ b/inbox/xep-happy-eyeballs.xml
@@ -23,12 +23,7 @@
   <supersedes/>
   <supersededby/>
   <shortname>NOT_YET_ASSIGNED</shortname>
-  <author>
-    <firstname>Guus</firstname>
-    <surname>der Kinderen</surname>
-    <email>guus.der.kinderen@gmail.com</email>
-    <jid>guus.der.kinderen@igniterealtime.org</jid>
-  </author>
+  &gdk;
   <revision>
     <version>1.0.0</version>
     <date>2024-09-19</date>

--- a/inbox/xep-http_online_meetings.xml
+++ b/inbox/xep-http_online_meetings.xml
@@ -24,12 +24,7 @@
     <email>dele@olajide.net</email>
     <jid>dele.olajide@igniterealtime.org</jid>
   </author>
-  <author>
-    <firstname>Guus</firstname>
-    <surname>der Kinderen</surname>
-    <email>guus.der.kinderen@gmail.com</email>
-    <jid>guus.der.kinderen@igniterealtime.org</jid>
-  </author>
+  &gdk;
   <revision>
     <version>0.0.3</version>
     <date>2023-09-12</date>

--- a/xep-0377.xml
+++ b/xep-0377.xml
@@ -27,6 +27,12 @@
   <shortname>NOT_YET_ASSIGNED</shortname>
   &sam;
   <revision>
+    <version>0.4.0</version>
+    <date>2025-03-11</date>
+    <initials>gdk</initials>
+    <remark><p>Add spam report processing opt-in.</p></remark>
+  </revision>
+  <revision>
     <version>0.3.1</version>
     <date>2023-04-03</date>
     <initials>egp</initials>
@@ -141,6 +147,49 @@
   </text>
 </report>]]></example>
 </section1>
+<section1 topic='Report Processing Opt-in' anchor='processing'>
+  <p>
+    Reports MAY contain user provided approval ('opt-in') for processing of the report.
+    This document defines the following processing of a report:
+  </p>
+  <dl>
+    <di>
+      <dt>report-origin</dt>
+      <dd>Forward the report to the domain where the reported message originated.</dd>
+    </di>
+    <di>
+      <dt>third-party</dt>
+      <dd>Forward the report to third-party entities that process reports for purposes
+        including, but not limited to, the collection of statistics, analysis, and 
+        block list services.</dd>
+    </di>
+  </dl>
+  <p>
+    To express approval of a certain type of processing, a &lt;report-origin&gt; and/or
+    &lt;third-party&gt; element is added to the report.
+  </p>
+  <example caption='Report with optional processing opt-in'><![CDATA[
+<report xmlns="urn:xmpp:reporting:1" reason="urn:xmpp:reporting:spam">
+  <text xml:lang="en">
+    Never came trouble to my house like this.
+  </text>
+  <report-origin/>
+  <third-party/>
+</report>]]></example>
+  <p>
+    Servers MAY ignore processing options when their implementation does not support
+    the corresponding functionality. Servers MUST NOT process a report if the report
+    that do not explicitly include the corresponding processing option.
+  </p>
+  <p>
+    Servers MAY anonymize any submission to third-party services to protect the identity
+    of the reporter. Servers SHOULD NOT protect the identity of the reported entity (the
+    alleged spammer/abuser), as it hurts processing without adding any significant
+    protection: it is likely that the origin server can easily look up the original 
+    stanza in their local message archive anyway. Servers can anonymize the report by
+    removing the 'to' attribute of the reported message.
+  </p>
+</section1>
 <section1 topic='Use with the Blocking Command' anchor='blocking'>
   <p>
     To send a report, a report payload MAY be inserted into an &lt;item/&gt;
@@ -200,6 +249,11 @@
     the "block and report" dialog is accessed, and multiple JIDs when the
     "block" dialog is accessed.
   </p>
+  <p>
+    Software clients may offer processing opt-in options to an end-user whenever
+    they are reporting a message, but also could use a (configurable) default 
+    that is automatically applied to all reports issued by the client.
+  </p>
 </section1>
 <section1 topic='Internationalization Considerations' anchor='i18n'>
   <p>
@@ -235,11 +289,12 @@
     </section2>
     <section2 topic='Abuse Reporting Registry' anchor='registrar-reporting'>
       <p>
-        The XMPP Registrar shall maintain a registry of abuse report reasons.
-        All abuse report reason registrations shall be defined in separate
-        specifications (not in this document). Application types defined within
-        the XEP series MUST be registered with the XMPP Registrar, resulting in
-        protocol URNs representing the reason.
+        The XMPP Registrar shall maintain a registry of abuse report reasons
+        and abuse report processing opt-in options. All abuse report reason
+        and processing opt-in registrations shall be defined in separate
+        specifications (not in this document). Application types defined 
+        within the XEP series MUST be registered with the XMPP Registrar,
+        resulting in protocol URNs representing the reason.
       </p>
       &REGPROCESS;
       <code>
@@ -250,7 +305,17 @@
   <doc>
     The document in which the report reason is specified.
   </doc>
-</reason>]]></code>
+</reason>
+
+<processing>
+  <name>Element name representing the processing opt-in.</name>
+  <namespace>A unique qualifier of the element name</namespace>
+  <desc>A natural-language summary of the processing functionality.</desc>
+  <doc>
+    The document in which the report processing functionality is specified.
+  </doc>
+</processing>
+]]></code>
     </section2>
     <section2 topic='Abuse Reporting Reasons' anchor='registrar-reasons'>
       <p>This specification defines the following abuse reporting reasons:</p>
@@ -275,6 +340,37 @@
   <name>abuse</name>
   <feature>urn:xmpp:reporting:abuse</feature>
   <desc>Used to report general abuse that is not covered by a more specific reason.</desc>
+  <doc>XEP-0377</doc>
+</reason>]]></code>
+    </section2>
+    <section2 topic='Abuse Reporting Processing' anchor='registrar-processing'>
+      <p>This specification defines the following processing opt-in identifiers:</p>
+      <ul>
+        <li>report-origin</li>
+        <li>third-party</li>
+      </ul>
+      <p>
+        Upon advancement of this specification from a status of Experimental to
+        a status of Draft, the &REGISTRAR; shall add the following definition to
+        the abuse report processing opt-in options registry, as described in this
+        document:
+      </p>
+      <code><![CDATA[
+<processing>
+  <name>report-origin</name>
+  <namespace>urn:xmpp:reporting:spam</namespace>
+  <desc>Forward the report to the domain where the reported message originated.</desc>
+  <doc>XEP-0377</doc>
+</reason>]]></code>
+      <code><![CDATA[
+<reason>
+  <name>third-party</name>
+  <namespace>urn:xmpp:reporting:spam</namespace>
+  <desc>
+    Forward the report to third-party entities that process reports for purposes
+    including, but not limited to, the collection of statistics, analysis, and
+    block list services.
+  </desc>
   <doc>XEP-0377</doc>
 </reason>]]></code>
     </section2>
@@ -315,6 +411,8 @@
       <xs:sequence>
         <xs:element ref='sid:stanza-id' minOccurs='0' maxOccurs='unbounded'/>
         <xs:element ref='text' minOccurs='0' maxOccurs='unbounded'/>
+        <xs:element ref='report-origin' minOccurs='0' maxOccurs='1'/>
+        <xs:element ref='third-party' minOccurs='0' maxOccurs='1'/>
       </xs:sequence>
       <xs:attribute name='reason' type='xs:string' use='required'/>
     </xs:complexType>
@@ -333,6 +431,10 @@
       </xs:simpleContent>
     </xs:complexType>
   </xs:element>
+
+  <xs:element name='report-origin' type='empty'/>
+
+  <xs:element name='third-party' type='empty'/>
 
   <xs:simpleType name='empty'>
     <xs:restriction base='xs:string'>

--- a/xep-0377.xml
+++ b/xep-0377.xml
@@ -26,11 +26,17 @@
   <supersededby/>
   <shortname>NOT_YET_ASSIGNED</shortname>
   &sam;
+  &gdk;
   <revision>
     <version>0.4.0</version>
-    <date>2025-03-11</date>
+    <date>2025-04-09</date>
     <initials>gdk</initials>
-    <remark><p>Add spam report processing opt-in.</p></remark>
+    <remark>
+      <ul>
+        <li>Add spam report processing opt-in.</li>
+        <li>Add Guus der Kinderen as co-author.</li>
+      </ul>
+    </remark>
   </revision>
   <revision>
     <version>0.3.1</version>

--- a/xep-0483.xml
+++ b/xep-0483.xml
@@ -24,12 +24,7 @@
     <email>dele@olajide.net</email>
     <jid>dele.olajide@igniterealtime.org</jid>
   </author>
-  <author>
-    <firstname>Guus</firstname>
-    <surname>der Kinderen</surname>
-    <email>guus.der.kinderen@gmail.com</email>
-    <jid>guus.der.kinderen@igniterealtime.org</jid>
-  </author>  
+  &gdk;
   <revision>
     <version>0.2.0</version>
     <date>2023-12-12</date>

--- a/xep-0485.xml
+++ b/xep-0485.xml
@@ -18,12 +18,7 @@
   <supersedes/>
   <supersededby/>
   <shortname>serverinfo</shortname>
-  <author>
-    <firstname>Guus</firstname>
-    <surname>der Kinderen</surname>
-    <email>guus.der.kinderen@gmail.com</email>
-    <jid>guus.der.kinderen@igniterealtime.org</jid>
-  </author>
+  &gdk;
   <revision>
     <version>0.1.0</version>
     <date>2024-03-10</date>

--- a/xep-0495.xml
+++ b/xep-0495.xml
@@ -23,12 +23,7 @@
   <supersedes/>
   <supersededby/>
   <shortname>NOT_YET_ASSIGNED</shortname>
-  <author>
-    <firstname>Guus</firstname>
-    <surname>der Kinderen</surname>
-    <email>guus.der.kinderen@gmail.com</email>
-    <jid>guus.der.kinderen@igniterealtime.org</jid>
-  </author>
+  &gdk;
   <revision>
     <version>0.1.0</version>
     <date>2024-10-17</date>

--- a/xep.ent
+++ b/xep.ent
@@ -1185,6 +1185,14 @@ IANA Service Location Protocol, Version 2 (SLPv2) Templates</link></span> <note>
     <jid>singpolyma@singpolyma.net</jid>
   </author>
 " >
+<!ENTITY gdk "
+  <author>
+    <firstname>Guus</firstname>
+    <surname>der Kinderen</surname>
+    <email>guus.der.kinderen@gmail.com</email>
+    <jid>guus.der.kinderen@igniterealtime.org</jid>
+  </author>
+" >
 
 <!-- XMPP Extension Protocols -->
 


### PR DESCRIPTION
Introduces an additional feature that allows end-users to opt-in to processing of submitted reports.

Changes like these were discussed on the XSF's 'standards' mailing list, as archived at https://mail.jabber.org/hyperkitty/list/standards@xmpp.org/thread/RDLWOMBMT24DCH54O2HEV2S3WW67FETE/