### PR TITLE
XEP-0455: Fix typo in JSON Schema

### DIFF
--- a/xep-0455.xml
+++ b/xep-0455.xml
@@ -29,6 +29,12 @@
     <jid>mathieui@mathieui.net</jid>
   </author>
   <revision>
+    <version>0.3.1</version>
+    <date>2025-04-20</date>
+    <initials>ka</initials>
+    <remark>Fix typo in JSON Schema.</remark>
+  </revision>
+  <revision>
     <version>0.3.0</version>
     <date>2025-04-05</date>
     <initials>mp</initials>
@@ -157,7 +163,7 @@
     },
     "message": {
     "type": "object",
-      "description": "Textual message to service users, each key being 'defaul' or a BCP47 language tag.",
+      "description": "Textual message to service users, each key being 'default' or a BCP47 language tag.",
       "required": ["default"],
       "properties": {
         "default": { "type": "string"}


### PR DESCRIPTION
Noticed a typo in the JSON Schema, `defaul`, and corrected it to `default`.
