### PR TITLE
XEP-0317: Hats, Update and complete the protocol

### DIFF
--- a/xep-0317.xml
+++ b/xep-0317.xml
@@ -17,6 +17,7 @@
   <dependencies>
     <spec>XMPP Core</spec>
     <spec>XEP-0045</spec>
+    <spec>XEP-0068</spec>
     <spec>XEP-0050</spec>
   </dependencies>
   <supersedes/>
@@ -24,6 +25,13 @@
   <shortname>NOT_YET_ASSIGNED</shortname>
   &stpeter;
   &mwild;
+  &edhelas;
+  <revision>
+    <version>0.3.0</version>
+    <date>2025-04-30</date>
+    <initials>tj</initials>
+    <remark><p>Add hat creation and detruction flows; add hue optional parameter; add chatroom presence hats broadcast; complete disco#info; clarify how the service should broadcast updated hats; typos; standardize the form fields;</p></remark>
+  </revision>
   <revision>
     <version>0.2.0</version>
     <date>2023-06-28</date>
@@ -55,29 +63,111 @@
 </section1>
 
 <section1 topic='Discovery' anchor='disco'>
-  <p>A MUC service that supports hats MUST advertise a &xep0030; feature of "urn:xmpp:hats:0".</p>
+  <p>A MUC service that supports hats MUST advertise a &xep0030; feature of "urn:xmpp:hats:0" to the requesting entity.</p>
+
+  <p>The "hat list" and all associated commands are OPTIONAL. Some of the commands might be restricted by some business logic or internal rules (such as a LDAP configuration where the hats are already preconfigured).</p>
+
+  <p>If the room has a list of hats configured, it should advertise it in its 'muc#roominfo' extension form by computing a unique hash based on the list of hats URIs provided. The way the hash is computed is left to the implementer.</p>
+
+  <example caption='User’s client discovers the hat features of a MUC service'><![CDATA[
+<iq type='get'
+    id='p87Ne'
+    from='romeo@montague.example.net/garden'
+    to='physicsforpoets@courses.example.edu'>
+  <query xmlns='http://jabber.org/protocol/disco#info'/>
+</iq>]]></example>
+    <example caption='Room advertises hats support'><![CDATA[
+<iq type='result'
+    id='p87Ne'
+    to='romeo@montague.example.net/garden'
+    from='physicsforpoets@courses.example.edu'>
+  <query xmlns='http://jabber.org/protocol/disco#info'>
+    <identity
+        category='conference'
+        type='text'
+        name='Shakespearean Chat Service'/>
+    <feature var='urn:xmpp:hats:0'/>
+    <x xmlns='jabber:x:data' type='result'>
+      <field var='FORM_TYPE' type='hidden'>
+        <value>http://jabber.org/protocol/muc#roominfo</value>
+      </field>
+      ...
+      <field var='hats#hash'
+             type='text-single'
+             label='Hats hash'>
+        <value>d0f8d96ef806c440d4d2bce0bb56244540fd292f</value>
+      </field>
+      ...
+    </x>
+    ...
+  </query>
+</iq>]]></example>
+
+<p>If the requesting entity detects that, based on a mismatching hash, the localy stored hats list is considered outdated.</p>
+
+  <section2 topic='Listing Hats'>
+    <p>An entity might be interested to get all the existing hats available in a chatroom.</p>
+
+    <example caption='User’s client request the hats list configured on a MUC service'><![CDATA[
+<iq from='professor@example.edu/office'
+  id='fdi3n2b6'
+  to='physicsforpoets@courses.example.edu'
+  type='set'
+  xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+          action='execute'
+          node='urn:xmpp:hats:commands:list'/>
+</iq>]]></example>
+    <example caption='Service returns the list of configured hats'><![CDATA[
+<iq from='physicsforpoets@courses.example.edu'
+    id='fdi3n2b6'
+    to='professor@example.edu/office'
+    type='result'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+           node='urn:xmpp:hats:commands:list'
+           status='completed'
+           sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'>
+    <x xmlns='jabber:x:data' type='result'>
+      <title>Hats List</title>
+      <reported>
+        <field var='hats#title'/>
+        <field var='hats#uri'/>
+        <field var='hats#hue'/>
+      </reported>
+      <item>
+        <field var='hats#title'>
+            <value>Host</value>
+        </field>
+        <field var='hats#uri'>
+            <value>http://schemas.example.com/hats#host</value>
+        </field>
+        <field var='hats#hue'>
+            <value>327.255249</value>
+        </field>
+      </item>
+      <item>
+        <field var='hats#title'>
+            <value>Presenter</value>
+        </field>
+        <field var='hats#uri'>
+            <value>http://schemas.example.com/hats#presenter</value>
+        </field>
+        <field var='hats#hue'>
+            <value>171.430664</value>
+        </field>
+      </item>
+      …
+    </x>
+  </command>
+</iq>
+]]></example>
+  </section2>
 </section1>
 
 <section1 topic='Protocol' anchor='protocol'>
-  <section2 topic='Including a Hat in Presence' anchor='presence'>
-    <p>MUC already includes a way for the room to signal the roles and affiliations of room occupants. Hats are signalled in a similar way. For example, the following presence notification would be sent by the room for an occupant who is a MUC room moderator but who also has a hat of "teacher's assistant" in an online classroom.</p>
-    <example caption='Presence With Hat'><![CDATA[
-<presence
-    from='physicsforpoets@courses.example.edu/Terry'
-    id='DE5C66DE-EC7D-4ECB-844A-B717A67CCE3D'
-    to='steve@example.edu/tablet'>
-  <x xmlns='http://jabber.org/protocol/muc#user'>
-    <item affiliation='owner' role='moderator'/>
-  </x>
-  <hats xmlns='urn:xmpp:hats:0'>
-    <hat uri='http://tech.example.edu/hats#TeacherAssistant' title='Teacher&apos;s Assistant' xml:lang='en-us'/>
-  </hats>
-</presence>
-]]></example>
-    <p>Every hat is uniquely identified by its URI. Hats also carry a human-readable title for display purposes. Within XMPP, a hat is contained within a &lt;hat/> element in the 'urn:xmpp:hats:0' namespace. This element MUST possess a 'uri' attribute (containing the hat's URI), a 'title' attribute containing the name of the hat for display purposes, and MAY contain an 'xml:lang' attribute that identifies the language used in the 'title' attribute. The &lt;hat/> element MAY contain additional custom payloads defined by other XEPs, or payloads specific to an implementation or deployment.</p>
-    <p>Entities may have multiple hats. The &lt;hats/> element is defined as a container of zero or more &lt;hat/> elements.</p>
-
-    <p>As noted, a participant can wear many hats. The following example shows a participant who is a MUC room owner and both a "host" and a "presenter" in an online meeting system. This system also demonstrates how hats can be annotated with custom information (here, the example &lt;badge/> element).</p>
+  <section2 topic='Hats in Presence' anchor='presence'>
+    <p>MUC already includes a way for the room to signal the roles and affiliations of room occupants. Hats are signalled in a similar way. A participant can wear many hats. The following example shows a participant who is a MUC room owner and both a "host" and a "presenter" in an online meeting system. This system also demonstrates how hats can be annotated with custom information (here, the example &lt;badge/> element).</p>
     <example caption='Presence With Multiple Hats'><![CDATA[
 <presence
     from='meeting123@meetings.example.com/Harry'
@@ -87,20 +177,166 @@
     <item affiliation='owner' role='moderator'/>
   </x>
   <hats xmlns='urn:xmpp:hats:0'>
-    <hat title='Host' uri='http://schemas.example.com/hats#host' xml:lang='en-us'>
-        <badge xmlns="urn:example:badges" fgcolor="#000000" bgcolor="#58C5BA"/>
+    <hat title='Host' uri='http://schemas.example.com/hats#host' hue='327.255249' xml:lang='en-us'>
+      <badge xmlns="urn:example:badges" level="3"/>
     </hat>
-    <hat title='Presenter' uri='http://schemas.example.com/hats#presenter' xml:lang='en-us'>
-        <badge xmlns="urn:example:badges" fgcolor="#000000" bgcolor="#EC0524"/>
+    <hat title='Presenter' uri='http://schemas.example.com/hats#presenter' hue='171.430664' xml:lang='en-us'>
+      <badge xmlns="urn:example:badges" level="5"/>
     </hat>
   </hats>
 </presence>
 ]]></example>
+    <p>Every hat is uniquely identified by its URI. Hats also carry a human-readable title for display purposes. Within XMPP, a hat is contained within a &lt;hat/> element in the 'urn:xmpp:hats:0' namespace. This element MUST possess a 'uri' attribute (containing the hat's URI), a 'title' attribute containing the name of the hat for display purposes, MAY contain an 'xml:lang' attribute that identifies the language used in the 'title' attribute and MAY contain a Hue Angle color that define the hat color to apply. The &lt;hat/> element MAY contain additional custom payloads defined by other XEPs, or payloads specific to an implementation or deployment.</p>
+    <p>Entities may have multiple hats. The &lt;hats/> element is defined as a container of zero or more &lt;hat/> elements.</p>
+
   </section2>
-  <section2 topic='Adding a Hat' anchor='add'>
-    <p>Hats are added and removed using &xep0050;.</p>
-    <p>The following flow shows how to add a hat.</p>
-    <example caption='Admin Requests to Add a Hat'><![CDATA[
+  <section2 topic='Creating and Updating a Hat' anchor='create'>
+    <p>Hats are created and destroyed using &xep0050;.</p>
+    <p>The following flow shows how to create a hat.</p>
+    <p>Updating a hat follows the same flow but set an existing "hats#uri". If a hat is updated the service SHOULD broadcast the related JID presences with the refreshed hat list.</p>
+    <example caption='Admin Requests to Create a Hat'><![CDATA[
+<iq from='professor@example.edu/office'
+    id='gd53a2b6'
+    to='physicsforpoets@courses.example.edu'
+    type='set'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+            action='execute'
+            node='urn:xmpp:hats:commands:create'/>
+</iq>
+]]></example>
+
+    <example caption='Service Returns Form to Admin'><![CDATA[
+<iq from='physicsforpoets@courses.example.edu'
+    id='gd53a2b6'
+    to='professor@example.edu/office'
+    type='result'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+            node='urn:xmpp:hats:commands:create'
+            sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'
+            status='executing'>
+    <x xmlns='jabber:x:data' type='form'>
+      <title>Creating a Hat</title>
+      <instructions>Fill out this form to create a hat.</instructions>
+      <field type='hidden' var='FORM_TYPE'>
+        <value>urn:xmpp:hats:commands</value>
+      </field>
+      <field var='hats#title'
+            type='text-single'
+            label='Hat title'>
+        <required/>
+      </field>
+      <field var='hats#uri'
+            type='text-single'
+            label='Hat URI'>
+        <required/>
+      </field>
+      <field var='hats#hue'
+            type='text-single'
+            label='Hat Hue'/>
+    </x>
+  </command>
+</iq>
+]]></example>
+    <example caption='Admin Submits Form'><![CDATA[
+<iq from='professor@example.edu/office'
+    id='9fets723'
+    to='physicsforpoets@courses.example.edu'
+    type='set'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+            node='urn:xmpp:hats:commands:create'
+            sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'>
+    <x xmlns='jabber:x:data' type='submit'>
+      <field type='hidden' var='FORM_TYPE'>
+        <value>urn:xmpp:hats:commands</value>
+      </field>
+      <field var='hats#title'>
+        <value>Assistant</value>
+      </field>
+      <field var='hats#uri'>
+        <value>http://tech.example.edu/hats#TeacherAssistant</value>
+      </field>
+      <field var='hats#hue'>
+        <value>327.255249</value>
+      </field>
+    </x>
+  </command>
+</iq>
+]]></example>
+    <example caption='Service Informs Admin of Completion'><![CDATA[
+<iq from='physicsforpoets@courses.example.edu'
+    id='9fets723'
+    to='professor@example.edu/office'
+    type='result'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+            node='urn:xmpp:hats:commands:assign'
+            sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'
+            status='completed'/>
+</iq>
+]]></example>
+  <p>When any change is applied to the hats list the room should SHOULD broadcast a notification that the configuration changed to all users present.</p>
+  <example caption='Room broadcasts a configuration change'><![CDATA[
+<message type='groupchat'
+      to='professor@example.edu/office'
+      from='physicsforpoets@courses.example.edu'>
+  <x xmlns='http://jabber.org/protocol/muc#user'>
+    <status code='104'/>
+  </x>
+</message>
+
+<message type='groupchat'
+      to='student@example.edu/bedroom'
+      from='physicsforpoets@courses.example.edu'>
+  <x xmlns='http://jabber.org/protocol/muc#user'>
+    <status code='104'/>
+  </x>
+</message>]]></example>
+
+  </section2>
+  <section2 topic='Destroying a Hat' anchor='destroy'>
+    <p>The following flow shows how to destroy a hat and remove it from the list of available hats.</p>
+    <p>When a hat is destroyed, it is automatically removed from all the JIDs where it was assigned.</p>
+    <p>The service SHOULD broadcast the related JID presences with the refreshed hats list.</p>
+    <example caption='Admin Requests to Destroy a Hat'><![CDATA[
+<iq from='professor@example.edu/office'
+    id='rei4n2b0'
+    to='physicsforpoets@courses.example.edu'
+    type='set'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+           action='execute'
+           node='urn:xmpp:hats:commands:destroy'>
+    <x xmlns='jabber:x:data' type='submit'>
+      <field type='hidden' var='FORM_TYPE'>
+        <value>urn:xmpp:hats:commands</value>
+      </field>
+      <field var='hat'>
+        <value>http://tech.example.edu/hats#TeacherAssistant</value>
+      </field>
+    </x>
+  </command>
+</iq>
+]]></example>
+    <example caption='Service Informs Admin of Completion'><![CDATA[
+<iq from='physicsforpoets@courses.example.edu'
+    id='rei4n2b0'
+    to='professor@example.edu/office'
+    type='result'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+           node='urn:xmpp:hats:commands:destroy'
+           sessionid='A971D19A-2226-4DAD-B261-7D0886B9A123'
+           status='completed'/>
+</iq>
+]]></example>
+  </section2>
+  <section2 topic='Assigning a Hat' anchor='add'>
+    <p>Hats are assigned and removed using &xep0050;.</p>
+    <p>The following flow shows how to assign a hat.</p>
+    <example caption='Admin Requests to Assign a Hat'><![CDATA[
 <iq from='professor@example.edu/office'
     id='fdi3n2b6'
     to='physicsforpoets@courses.example.edu'
@@ -108,7 +344,7 @@
     xml:lang='en'>
   <command xmlns='http://jabber.org/protocol/commands'
            action='execute'
-           node='urn:xmpp:hats:commands:don'/>
+           node='urn:xmpp:hats:commands:assign'/>
 </iq>
 ]]></example>
     <p>Unless an error occurs, the service returns the appropriate form.</p>
@@ -119,7 +355,7 @@
     type='result'
     xml:lang='en'>
   <command xmlns='http://jabber.org/protocol/commands'
-           node='urn:xmpp:hats:commands:don'
+           node='urn:xmpp:hats:commands:assign'
            sessionid='A971D19A-2226-4DAD-B261-8D0886B9A026'
            status='executing'>
     <x xmlns='jabber:x:data' type='form'>
@@ -130,7 +366,7 @@
       </field>
       <field label='User Address'
              type='jid-single'
-             var='accountjid'>
+             var='hats#jid'>
         <required/>
       </field>
       <field label='The role'
@@ -151,13 +387,13 @@
     type='set'
     xml:lang='en'>
   <command xmlns='http://jabber.org/protocol/commands'
-           node='urn:xmpp:hats:commands:don'
+           node='urn:xmpp:hats:commands:assign'
            sessionid='A971D19A-2226-4DAD-B261-8D0886B9A026'>
     <x xmlns='jabber:x:data' type='submit'>
       <field type='hidden' var='FORM_TYPE'>
         <value>urn:xmpp:hats:commands</value>
       </field>
-      <field var='accountjid'>
+      <field var='hats#jid'>
         <value>terry.anderson@example.edu</value>
       </field>
       <field var='hat'>
@@ -174,7 +410,7 @@
     type='result'
     xml:lang='en'>
   <command xmlns='http://jabber.org/protocol/commands'
-           node='urn:xmpp:hats:commands:don'
+           node='urn:xmpp:hats:commands:assign'
            sessionid='A971D19A-2226-4DAD-B261-8D0886B9A026'
            status='completed'/>
 </iq>
@@ -183,6 +419,7 @@
   </section2>
   <section2 topic='Removing a Hat' anchor='remove'>
     <p>The following flow shows how to remove a hat.</p>
+    <p>When the hat is removed service SHOULD broadcast the related JID presence with the refreshed hat list.</p>
     <example caption='Admin Requests to Remove a Hat'><![CDATA[
 <iq from='professor@example.edu/office'
     id='fdi3n2b6'
@@ -191,16 +428,16 @@
     xml:lang='en'>
   <command xmlns='http://jabber.org/protocol/commands'
            action='execute'
-           node='urn:xmpp:hats:commands:doff'>
+           node='urn:xmpp:hats:commands:unassign'>
     <x xmlns='jabber:x:data' type='submit'>
       <field type='hidden' var='FORM_TYPE'>
         <value>urn:xmpp:hats:commands</value>
       </field>
-      <field var='accountjid'>
+      <field var='hats#jid'>
         <value>terry.anderson@example.edu</value>
       </field>
       <field var='hat'>
-        <option label='Teacher&apos;s Assistant'><value>http://tech.example.edu/hats#TeacherAssistant</value></option>
+        <value>http://tech.example.edu/hats#TeacherAssistant</value>
       </field>
     </x>
   </command>
@@ -208,16 +445,50 @@
 ]]></example>
     <example caption='Service Informs Admin of Completion'><![CDATA[
 <iq from='physicsforpoets@courses.example.edu'
-    id='9fens61z'
+    id='fdi3n2b6'
     to='professor@example.edu/office'
     type='result'
     xml:lang='en'>
   <command xmlns='http://jabber.org/protocol/commands'
-           node='urn:xmpp:hats:commands:doff'
+           node='urn:xmpp:hats:commands:unassign'
            sessionid='A971D19A-2226-4DAD-B261-8D0886B9A026'
            status='completed'/>
 </iq>
 ]]></example>
+  </section2>
+
+  <section2 topic='Field Standardization' anchor='registrar-formtype'>
+    <p>&xep0068; defines a process for standardizing the fields used within Data Forms qualified by a particular FORM_TYPE. Within Hats, all the interactions revolves around one unique FORM_TYPE, urn:xmpp:hats:commands. The reserved fields are defined below.</p>
+
+    <code caption='Registry Submission'><![CDATA[
+<form_type>
+  <name>urn:xmpp:hats:commands</name>
+  <doc>XEP-0317</doc>
+  <desc>
+    Forms enabling the creation, destruction, assignal and removal of hats.
+  </desc>
+  <field
+      var='hats#jid'
+      type='text-single'
+      label='JID to which a hat is assigned'/>
+  <field
+      var='hats#title'
+      type='text-single'
+      label='Title'/>
+  <field
+      var='hats#uri'
+      type='text-single'
+      label='Unique URI'/>
+  <field
+      var='hats#hue'
+      type='text-single'
+      label='Custom color'/>
+  <field
+      var='hats#hash'
+      type='text-single'
+      label='Hash computed from the list of hats available in a room'/>
+</form_type>
+]]></code>
   </section2>
 </section1>
 

--- a/xep.ent
+++ b/xep.ent
@@ -1150,6 +1150,7 @@ IANA Service Location Protocol, Version 2 (SLPv2) Templates</link></span> <note>
     <surname>Jaussoin</surname>
     <email>edhelas@movim.eu</email>
     <jid>edhelas@movim.eu</jid>
+    <uri>https://edhelas.movim.eu</uri>
   </author>
 ">
 <!ENTITY tmolitor "
@@ -1168,7 +1169,7 @@ IANA Service Location Protocol, Version 2 (SLPv2) Templates</link></span> <note>
     <jid>travis@burtrum.org</jid>
     <uri>https://moparisthebest.com/</uri>
  </author>
-" >   
+" >
 <!ENTITY nicoco "
   <author>
     <firstname>Nicolas</firstname>
@@ -1739,4 +1740,3 @@ IANA Service Location Protocol, Version 2 (SLPv2) Templates</link></span> <note>
 <!ENTITY xep0503 "<span class='ref'><link url='https://xmpp.org/extensions/xep-0503.html'>Server-side spaces (XEP-0503)</link></span><note>XEP-0503: Server-side spaces &lt;<link url='https://xmpp.org/extensions/xep-0503.html'>https://xmpp.org/extensions/xep-0503.html</link>&gt;.</note>">
 <!ENTITY xep0504 "<span class='ref'><link url='https://xmpp.org/extensions/xep-0504.html'>Data Policy (XEP-0504)</link></span><note>XEP-0504: Data Policy &lt;<link url='https://xmpp.org/extensions/xep-0504.html'>https://xmpp.org/extensions/xep-0504.html</link>&gt;.</note>">
 <!ENTITY xep0505 "<span class='ref'><link url='https://xmpp.org/extensions/xep-0505.html'>Data Forms File Input Element (XEP-0505)</link></span><note>XEP-0505: Data Forms File Input Element &lt;<link url='https://xmpp.org/extensions/xep-0505.html'>https://xmpp.org/extensions/xep-0505.html</link>&gt;.</note>">
-


### PR DESCRIPTION
As a client developper the current Hats XEP is far from be usable and feature complete.

The goal of those changes is to:
- Allow clients to develop a nice UI to manage and assign hats, for example like Discord is doing (see https://support.discord.com/hc/en-us/articles/214836687-Discord-Roles-and-Permissions)
- Reconciliate existing implementations and their specificities, see https://docs.ejabberd.im/tutorials/muc-hats/
- Those changes were meant to be backward compatible with the current 0.2.0 version

This PR make the following changes:

- Specify a urn:xmpp:hats:commands:dcreate command to add a hat to the available list
- Specify a urn:xmpp:hats:commands:ddestroy command to destroy a hat from the list
- Clarify how the service should broadcast the hat changes when it is edited, assigned, removed or destroyed
- Specify a way for an entity to get the complete list of hats using a hash in disco#info 
- Add a hue optional parameter allowing entities to assign a color to the hat that can be displayed properly in any conditions on the client (as explained in XEP-0392: Consistent Color Generation)
- Standardize the all the form fields using XEP-0068
- Rename the :dlist, :don and :doff commands to :list, :assign and :unassign
- Add myself in the list of authors
- Fix some typos

The HTML generated version of this PR is available here: https://movim.eu/xeps/xep-0317.html