### PR TITLE
XEP-0485: Fixed references to XEP identifier.

### DIFF
--- a/xep-0485.xml
+++ b/xep-0485.xml
@@ -20,6 +20,16 @@
   <shortname>serverinfo</shortname>
   &gdk;
   <revision>
+    <version>0.1.1</version>
+    <date>2025-06-06</date>
+    <initials>gdk</initials>
+    <remark>
+      <ul>
+        <li>Fixed references to XEP identifier.</li>
+      </ul>
+    </remark>
+  </revision>
+  <revision>
     <version>0.1.0</version>
     <date>2024-03-10</date>
     <initials>dg</initials>
@@ -189,7 +199,7 @@
     <code caption='Registry Submission'><![CDATA[
 <form_type>
   <name>http://jabber.org/network/serverinfo</name>
-  <doc>XEP-0XXX</doc>
+  <doc>XEP-0485</doc>
   <desc>
     Forms advertising the coordinates of a pub-sub service and node for publication of Server Information data.
   </desc>
@@ -215,7 +225,7 @@
   <xs:annotation>
     <xs:documentation>
       The protocol documented by this schema is defined in
-      XEP-0XXX: http://www.xmpp.org/extensions/xep-0XXX.html
+      XEP-0485: http://www.xmpp.org/extensions/xep-0485.html
     </xs:documentation>
   </xs:annotation>
   


### PR DESCRIPTION
The original specification referenced `XEP-0XXX` as no XEP number was assigned at the time of writing. This commit updates those references to XEP-0485.