### PR TITLE
XEP-0167: Make ssrc attribute unsignedInt instead of generic string

### DIFF
--- a/xep-0167.xml
+++ b/xep-0167.xml
@@ -43,6 +43,12 @@
   &robmcqueen;
   &diana;
   <revision>
+    <version>1.2.3</version>
+    <date>2025-07-04</date>
+    <initials>lnj</initials>
+    <remark>Make 'ssrc' attribute 'xs:unsignedInt' (32-bit) instead of 'xs:string' to match RFC3550.</remark>
+  </revision>
+  <revision>
     <version>1.2.2</version>
     <date>2022-09-26</date>
     <initials>melvo</initials>
@@ -1795,7 +1801,7 @@ Romeo                         Juliet
                     type='xs:NCName'
                     use='required'/>
       <xs:attribute name='ssrc'
-                    type='xs:string'
+                    type='xs:unsignedInt'
                     use='optional'/>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
'ssrc' is no generic string, but an 32-bit unsigned integer.

The XEP text also says:
> The <description/> element MAY possess a 'ssrc' attribute that
> specifies the 32-bit synchronization source for this media stream,
> as defined in RFC 3550 [2].

so I'd argue that the XEP already required 'ssrc' to be a uint32 before.
