### PR TITLE
XEP-0198: Remove leftover optional and required children in sm element

### DIFF
--- a/xep-0198.xml
+++ b/xep-0198.xml
@@ -31,6 +31,12 @@
   &mwild;
   &tmolitor;
   <revision>
+    <version>1.6.3</version>
+    <date>2025-07-28</date>
+    <initials>egp</initials>
+    <remark><p>Remove leftover &lt;optional/&gt; and &lt;required/&gt; children in &lt;sm/&gt; element.</p></remark>
+  </revision>
+  <revision>
     <version>1.6.2</version>
     <date>2024-09-24</date>
     <initials>gk</initials>
@@ -769,14 +775,7 @@
 
   <xs:element name='resumed' type='resumptionElementType'/>
 
-  <xs:element name='sm'>
-    <xs:complexType>
-      <xs:choice>
-        <xs:element name='optional' type='empty'/>
-        <xs:element name='required' type='empty'/>
-      </xs:choice>
-    </xs:complexType>
-  </xs:element>
+  <xs:element name='sm' type='empty'/>
 
   <xs:complexType name='resumptionElementType'>
     <xs:simpleContent>


### PR DESCRIPTION
Both had been removed from the example in 0dcc65319056ddb769b170679796586e7d322d9d, and were only specified in the XML Schema in 0.10 (see 44d58576a48fdcf8f4f62957438f8bb24fef7dac).

They were never specified.