### PR TITLE
XEP-0070: extend security section

### DIFF
--- a/xep-0070.xml
+++ b/xep-0070.xml
@@ -31,6 +31,12 @@
   &dizzyd;
   &stpeter;
   <revision>
+    <version>1.0.2</version>
+    <date>2025-09-30</date>
+    <initials></initials>
+    <remark>Mention risk of users entering their XMPP password instead of a token in security considerations.</remark>
+  </revision>
+  <revision>
     <version>1.0.1</version>
     <date>2016-12-09</date>
     <initials>mp (XEP Editor: ssw)</initials>


### PR DESCRIPTION
- Explain that the transaction identifier helps mitigating prompt bombing/fatigue attacks (where an attacker sends a lot of authentication requests and the user ends up accepting the wrong one)
- Add a note about the default login prompt in web browsers, that may mislead users into using their XMPP account password as a transaction identifier