### PR TITLE
XEP-0060: Replaced links to non-existing collections anchor with a link to XEP-0248

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -51,6 +51,14 @@
   &stpeter;
   &ralphm;
   <revision>
+   <version>1.26.1</version>
+    <date>2025-09-04</date>
+    <initials>gdk</initials>
+    <remark>
+      <p>Replaced links to non-existing collections anchor with a link to &xep0248;</p>
+    </remark>
+  </revision>
+  <revision>
     <version>1.26.0</version>
     <date>2023-09-07</date>
     <initials>melvo</initials>
@@ -1027,9 +1035,9 @@ And by opposing end them?
   </section2>
 
   <section2 topic='Discover Nodes' anchor='entity-nodes'>
-    <p>If a service implements a hierarchy of nodes (by means of <link url='#collections'>Collection Nodes</link>), it MUST also enable entities to discover the nodes in that hierarchy by means of the <strong>Service Discovery</strong> protocol, subject to the recommendations in &xep0030; regarding large result sets (for which &xep0055; or some other protocol SHOULD be used). The following examples show the use of service discovery in discovering the nodes available at a hierarchical pubsub service.</p>
-    <p>Note: Node hierarchies and collection nodes are OPTIONAL. For details, refer to the <link url='#impl-semantics'>NodeID Semantics</link> and <link url='#collections'>Collection Nodes</link> sections of this document.</p>
-    <p>In the first example, an entity sends a service discovery items ("disco#items") request to the root node (i.e., the service itself), which is a <link url='#collections'>Collection Node</link>:</p>
+    <p>If a service implements a hierarchy of nodes (by means of Collection Nodes as described in &xep0248;), it MUST also enable entities to discover the nodes in that hierarchy by means of the <strong>Service Discovery</strong> protocol, subject to the recommendations in &xep0030; regarding large result sets (for which &xep0055; or some other protocol SHOULD be used). The following examples show the use of service discovery in discovering the nodes available at a hierarchical pubsub service.</p>
+    <p>Note: Node hierarchies and collection nodes are OPTIONAL. For details, refer to &xep0248; and the <link url='#impl-semantics'>NodeID Semantics</link> sections this document.</p>
+    <p>In the first example, an entity sends a service discovery items ("disco#items") request to the root node (i.e., the service itself), which is a Collection Node:</p>
     <example caption='Entity asks service for all first-level nodes'><![CDATA[
 <iq type='get'
     from='francisco@denmark.lit/barracks'


### PR DESCRIPTION
In revision 1.12, text about collections was moved to XEP-0248. In this commit, a few lingering links to anchors in that text are replaced by links to that XEP.