### PR TITLE
XEP-0317 Hats: Typos, examples and clarifications

### DIFF
--- a/xep-0317.xml
+++ b/xep-0317.xml
@@ -27,6 +27,12 @@
   &mwild;
   &edhelas;
   <revision>
+    <version>0.3.1</version>
+    <date>2025-08-18</date>
+    <initials>tj</initials>
+    <remark><p>Typos, completed some examples and paragraph clarifications thanks to badlop feedback.</p></remark>
+  </revision>
+  <revision>
     <version>0.3.0</version>
     <date>2025-04-30</date>
     <initials>tj</initials>
@@ -63,24 +69,24 @@
 </section1>
 
 <section1 topic='Discovery' anchor='disco'>
-  <p>A MUC service that supports hats MUST advertise a &xep0030; feature of "urn:xmpp:hats:0" to the requesting entity.</p>
+  <p>A room in a MUC service that supports hats MUST advertise a &xep0030; feature of "urn:xmpp:hats:0" to the requesting entity.</p>
 
   <p>The "hat list" and all associated commands are OPTIONAL. Some of the commands might be restricted by some business logic or internal rules (such as a LDAP configuration where the hats are already preconfigured).</p>
 
   <p>If the room has a list of hats configured, it should advertise it in its 'muc#roominfo' extension form by computing a unique hash based on the list of hats URIs provided. The way the hash is computed is left to the implementer.</p>
 
-  <example caption='User’s client discovers the hat features of a MUC service'><![CDATA[
-<iq type='get'
+  <example caption='User’s client discovers the hat features of a MUC room'><![CDATA[
+<iq from='professor@example.edu/office'
     id='p87Ne'
-    from='romeo@montague.example.net/garden'
-    to='physicsforpoets@courses.example.edu'>
+    to='physicsforpoets@courses.example.edu'
+    type='get'>
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>]]></example>
     <example caption='Room advertises hats support'><![CDATA[
-<iq type='result'
+<iq from='physicsforpoets@courses.example.edu'
     id='p87Ne'
-    to='romeo@montague.example.net/garden'
-    from='physicsforpoets@courses.example.edu'>
+    to='professor@example.edu/office'
+    type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     <identity
         category='conference'
@@ -105,10 +111,219 @@
 
 <p>If the requesting entity detects that, based on a mismatching hash, the localy stored hats list is considered outdated.</p>
 
+</section1>
+
+<section1 topic='Protocol' anchor='protocol'>
+  <section2 topic='Hats in Presence' anchor='presence'>
+    <p>MUC already includes a way for the room to signal the roles and affiliations of room occupants. Hats are signalled in a similar way. A participant can wear many hats. The following example shows a participant who is a MUC room owner and both a "host" and a "presenter" in an online meeting system. This system also demonstrates how hats can be annotated with custom information (here, the example &lt;badge/> element).</p>
+    <example caption='Presence With Multiple Hats'><![CDATA[
+<presence
+    from='meeting123@meetings.example.com/Harry'
+    id='D568A74F-E062-407C-83E9-531E91526516'
+    to='someone@example.com/foo'>
+  <x xmlns='http://jabber.org/protocol/muc#user'>
+    <item affiliation='owner' role='moderator'/>
+  </x>
+  <hats xmlns='urn:xmpp:hats:0'>
+    <hat title='Host' uri='http://schemas.example.com/hats#host' hue='327.255249' xml:lang='en-us'>
+      <badge xmlns="urn:example:badges" level="3"/>
+    </hat>
+    <hat title='Presenter' uri='http://schemas.example.com/hats#presenter' hue='171.430664' xml:lang='en-us'>
+      <badge xmlns="urn:example:badges" level="5"/>
+    </hat>
+  </hats>
+</presence>
+]]></example>
+    <p>Every hat is uniquely identified by its URI. Hats also carry a human-readable title for display purposes. Within XMPP, a hat is contained within a &lt;hat/> element in the 'urn:xmpp:hats:0' namespace. This element MUST possess a 'uri' attribute (containing the hat's URI), a 'title' attribute containing the name of the hat for display purposes, MAY contain an 'xml:lang' attribute that identifies the language used in the 'title' attribute and MAY contain a Hue Angle color that define the hat color to apply. The &lt;hat/> element MAY contain additional custom payloads defined by other XEPs, or payloads specific to an implementation or deployment.</p>
+    <p>Entities may have multiple hats. The &lt;hats/> element is defined as a container of zero or more &lt;hat/> elements.</p>
+
+  </section2>
+  <section2 topic='Creating and Updating a Hat' anchor='create'>
+    <p>Hats are created and destroyed using &xep0050;.</p>
+    <p>The following flow shows how to create a hat.</p>
+    <p>Updating a hat follows the same flow but set an existing "hats#uri". If a hat is updated the room SHOULD broadcast the related JID presences with the refreshed hat list.</p>
+    <example caption='Admin Requests to Create a Hat'><![CDATA[
+<iq from='professor@example.edu/office'
+    id='gd53a2b6'
+    to='physicsforpoets@courses.example.edu'
+    type='set'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+            action='execute'
+            node='urn:xmpp:hats:commands:create'/>
+</iq>
+]]></example>
+
+    <example caption='Room Returns Form to Admin'><![CDATA[
+<iq from='physicsforpoets@courses.example.edu'
+    id='gd53a2b6'
+    to='professor@example.edu/office'
+    type='result'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+            node='urn:xmpp:hats:commands:create'
+            sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'
+            status='executing'>
+    <x xmlns='jabber:x:data' type='form'>
+      <title>Creating a Hat</title>
+      <instructions>Fill out this form to create a hat.</instructions>
+      <field type='hidden' var='FORM_TYPE'>
+        <value>urn:xmpp:hats:commands</value>
+      </field>
+      <field var='hats#title'
+            type='text-single'
+            label='Hat Title'>
+        <required/>
+      </field>
+      <field var='hats#uri'
+            type='text-single'
+            label='Hat URI'>
+        <required/>
+      </field>
+      <field var='hats#hue'
+            type='text-single'
+            label='Hat Hue'/>
+    </x>
+  </command>
+</iq>
+]]></example>
+    <example caption='Admin Submits Form'><![CDATA[
+<iq from='professor@example.edu/office'
+    id='9fets723'
+    to='physicsforpoets@courses.example.edu'
+    type='set'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+            node='urn:xmpp:hats:commands:create'
+            sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'>
+    <x xmlns='jabber:x:data' type='submit'>
+      <field type='hidden' var='FORM_TYPE'>
+        <value>urn:xmpp:hats:commands</value>
+      </field>
+      <field var='hats#title'>
+        <value>Assistant</value>
+      </field>
+      <field var='hats#uri'>
+        <value>http://tech.example.edu/hats#TeacherAssistant</value>
+      </field>
+      <field var='hats#hue'>
+        <value>327.255249</value>
+      </field>
+    </x>
+  </command>
+</iq>
+]]></example>
+    <example caption='Room Informs Admin of Completion'><![CDATA[
+<iq from='physicsforpoets@courses.example.edu'
+    id='9fets723'
+    to='professor@example.edu/office'
+    type='result'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+            node='urn:xmpp:hats:commands:assign'
+            sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'
+            status='completed'/>
+</iq>
+]]></example>
+  <p>When any change is applied to the hats list the room SHOULD broadcast a notification that the configuration changed to all users present.</p>
+  <example caption='Room broadcasts a configuration change'><![CDATA[
+<message type='groupchat'
+      to='professor@example.edu/office'
+      from='physicsforpoets@courses.example.edu'>
+  <x xmlns='http://jabber.org/protocol/muc#user'>
+    <status code='104'/>
+  </x>
+</message>
+
+<message type='groupchat'
+      to='student@example.edu/bedroom'
+      from='physicsforpoets@courses.example.edu'>
+  <x xmlns='http://jabber.org/protocol/muc#user'>
+    <status code='104'/>
+  </x>
+</message>]]></example>
+
+  </section2>
+  <section2 topic='Destroying a Hat' anchor='destroy'>
+    <p>The following flow shows how to destroy a hat and remove it from the list of available hats.</p>
+    <p>It first asks the formulary, which returns a list of all the available hats, and then actually requests to destroy one of them. Notice that alternatively, the client may send directly the query to destroy a hat without first requesting the formulary, as it already knows many hats that were received in presence stanzas.</p>
+    <p>When a hat is destroyed, it is automatically removed from all the JIDs where it was assigned.</p>
+    <p>The room SHOULD broadcast the related JID presences with the refreshed hats list.</p>
+    <example caption='Admin Requests Form to Destroy a Hat'><![CDATA[
+<iq from='professor@example.edu/office'
+    id='gd53a2b6'
+    to='physicsforpoets@courses.example.edu'
+    type='set'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+           action='execute'
+           node='urn:xmpp:hats:commands:destroy'>
+  </command>
+</iq>
+]]></example>
+    <example caption='Room Provides Form to Destroy a Hat'><![CDATA[
+<iq from='physicsforpoets@courses.example.edu'
+    id='gd53a2b6'
+    to='professor@example.edu/office'
+    type='result'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+            node='urn:xmpp:hats:commands:destroy'
+            sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'
+            status='executing'>
+    <x xmlns='jabber:x:data' type='form'>
+      <title>Destroying a Hat</title>
+      <instructions>Fill out this form to destroy a hat.</instructions>
+      <field type='hidden' var='FORM_TYPE'>
+        <value>urn:xmpp:hats:commands</value>
+      </field>
+      <field label='The role'
+             type='list-single'
+             var='hat'>
+        <option label='Teacher'><value>http://tech.example.edu/hats#Teacher</value></option>
+        <option label='Teacher&apos;s Assistant'><value>http://tech.example.edu/hats#TeacherAssistant</value></option>
+        <option label='Test Proctor'><value>http://tech.example.edu/hats#Proctor</value></option>
+      </field>
+    </x>
+  </command>
+</iq>
+]]></example>
+    <example caption='Admin Requests to Destroy a Hat'><![CDATA[
+<iq from='professor@example.edu/office'
+    id='rei4n2b0'
+    to='physicsforpoets@courses.example.edu'
+    type='set'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+           action='execute'
+           node='urn:xmpp:hats:commands:destroy'>
+    <x xmlns='jabber:x:data' type='submit'>
+      <field type='hidden' var='FORM_TYPE'>
+        <value>urn:xmpp:hats:commands</value>
+      </field>
+      <field var='hats#uri'>
+        <value>http://tech.example.edu/hats#TeacherAssistant</value>
+      </field>
+    </x>
+  </command>
+</iq>
+]]></example>
+    <example caption='Room Informs Admin of Completion'><![CDATA[
+<iq from='physicsforpoets@courses.example.edu'
+    id='rei4n2b0'
+    to='professor@example.edu/office'
+    type='result'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+           node='urn:xmpp:hats:commands:destroy'
+           sessionid='A971D19A-2226-4DAD-B261-7D0886B9A123'
+           status='completed'/>
+</iq>
+]]></example>
+  </section2>
   <section2 topic='Listing Hats'>
     <p>An entity might be interested to get all the existing hats available in a chatroom.</p>
-
-    <example caption='User’s client request the hats list configured on a MUC service'><![CDATA[
+    <example caption='User’s client request the hats list configured on a MUC room'><![CDATA[
 <iq from='professor@example.edu/office'
   id='fdi3n2b6'
   to='physicsforpoets@courses.example.edu'
@@ -118,7 +333,7 @@
           action='execute'
           node='urn:xmpp:hats:commands:list'/>
 </iq>]]></example>
-    <example caption='Service returns the list of configured hats'><![CDATA[
+    <example caption='Room Returns the List of Configured Hats'><![CDATA[
 <iq from='physicsforpoets@courses.example.edu'
     id='fdi3n2b6'
     to='professor@example.edu/office'
@@ -163,176 +378,6 @@
 </iq>
 ]]></example>
   </section2>
-</section1>
-
-<section1 topic='Protocol' anchor='protocol'>
-  <section2 topic='Hats in Presence' anchor='presence'>
-    <p>MUC already includes a way for the room to signal the roles and affiliations of room occupants. Hats are signalled in a similar way. A participant can wear many hats. The following example shows a participant who is a MUC room owner and both a "host" and a "presenter" in an online meeting system. This system also demonstrates how hats can be annotated with custom information (here, the example &lt;badge/> element).</p>
-    <example caption='Presence With Multiple Hats'><![CDATA[
-<presence
-    from='meeting123@meetings.example.com/Harry'
-    id='D568A74F-E062-407C-83E9-531E91526516'
-    to='someone@example.com/foo'>
-  <x xmlns='http://jabber.org/protocol/muc#user'>
-    <item affiliation='owner' role='moderator'/>
-  </x>
-  <hats xmlns='urn:xmpp:hats:0'>
-    <hat title='Host' uri='http://schemas.example.com/hats#host' hue='327.255249' xml:lang='en-us'>
-      <badge xmlns="urn:example:badges" level="3"/>
-    </hat>
-    <hat title='Presenter' uri='http://schemas.example.com/hats#presenter' hue='171.430664' xml:lang='en-us'>
-      <badge xmlns="urn:example:badges" level="5"/>
-    </hat>
-  </hats>
-</presence>
-]]></example>
-    <p>Every hat is uniquely identified by its URI. Hats also carry a human-readable title for display purposes. Within XMPP, a hat is contained within a &lt;hat/> element in the 'urn:xmpp:hats:0' namespace. This element MUST possess a 'uri' attribute (containing the hat's URI), a 'title' attribute containing the name of the hat for display purposes, MAY contain an 'xml:lang' attribute that identifies the language used in the 'title' attribute and MAY contain a Hue Angle color that define the hat color to apply. The &lt;hat/> element MAY contain additional custom payloads defined by other XEPs, or payloads specific to an implementation or deployment.</p>
-    <p>Entities may have multiple hats. The &lt;hats/> element is defined as a container of zero or more &lt;hat/> elements.</p>
-
-  </section2>
-  <section2 topic='Creating and Updating a Hat' anchor='create'>
-    <p>Hats are created and destroyed using &xep0050;.</p>
-    <p>The following flow shows how to create a hat.</p>
-    <p>Updating a hat follows the same flow but set an existing "hats#uri". If a hat is updated the service SHOULD broadcast the related JID presences with the refreshed hat list.</p>
-    <example caption='Admin Requests to Create a Hat'><![CDATA[
-<iq from='professor@example.edu/office'
-    id='gd53a2b6'
-    to='physicsforpoets@courses.example.edu'
-    type='set'
-    xml:lang='en'>
-  <command xmlns='http://jabber.org/protocol/commands'
-            action='execute'
-            node='urn:xmpp:hats:commands:create'/>
-</iq>
-]]></example>
-
-    <example caption='Service Returns Form to Admin'><![CDATA[
-<iq from='physicsforpoets@courses.example.edu'
-    id='gd53a2b6'
-    to='professor@example.edu/office'
-    type='result'
-    xml:lang='en'>
-  <command xmlns='http://jabber.org/protocol/commands'
-            node='urn:xmpp:hats:commands:create'
-            sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'
-            status='executing'>
-    <x xmlns='jabber:x:data' type='form'>
-      <title>Creating a Hat</title>
-      <instructions>Fill out this form to create a hat.</instructions>
-      <field type='hidden' var='FORM_TYPE'>
-        <value>urn:xmpp:hats:commands</value>
-      </field>
-      <field var='hats#title'
-            type='text-single'
-            label='Hat title'>
-        <required/>
-      </field>
-      <field var='hats#uri'
-            type='text-single'
-            label='Hat URI'>
-        <required/>
-      </field>
-      <field var='hats#hue'
-            type='text-single'
-            label='Hat Hue'/>
-    </x>
-  </command>
-</iq>
-]]></example>
-    <example caption='Admin Submits Form'><![CDATA[
-<iq from='professor@example.edu/office'
-    id='9fets723'
-    to='physicsforpoets@courses.example.edu'
-    type='set'
-    xml:lang='en'>
-  <command xmlns='http://jabber.org/protocol/commands'
-            node='urn:xmpp:hats:commands:create'
-            sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'>
-    <x xmlns='jabber:x:data' type='submit'>
-      <field type='hidden' var='FORM_TYPE'>
-        <value>urn:xmpp:hats:commands</value>
-      </field>
-      <field var='hats#title'>
-        <value>Assistant</value>
-      </field>
-      <field var='hats#uri'>
-        <value>http://tech.example.edu/hats#TeacherAssistant</value>
-      </field>
-      <field var='hats#hue'>
-        <value>327.255249</value>
-      </field>
-    </x>
-  </command>
-</iq>
-]]></example>
-    <example caption='Service Informs Admin of Completion'><![CDATA[
-<iq from='physicsforpoets@courses.example.edu'
-    id='9fets723'
-    to='professor@example.edu/office'
-    type='result'
-    xml:lang='en'>
-  <command xmlns='http://jabber.org/protocol/commands'
-            node='urn:xmpp:hats:commands:assign'
-            sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'
-            status='completed'/>
-</iq>
-]]></example>
-  <p>When any change is applied to the hats list the room should SHOULD broadcast a notification that the configuration changed to all users present.</p>
-  <example caption='Room broadcasts a configuration change'><![CDATA[
-<message type='groupchat'
-      to='professor@example.edu/office'
-      from='physicsforpoets@courses.example.edu'>
-  <x xmlns='http://jabber.org/protocol/muc#user'>
-    <status code='104'/>
-  </x>
-</message>
-
-<message type='groupchat'
-      to='student@example.edu/bedroom'
-      from='physicsforpoets@courses.example.edu'>
-  <x xmlns='http://jabber.org/protocol/muc#user'>
-    <status code='104'/>
-  </x>
-</message>]]></example>
-
-  </section2>
-  <section2 topic='Destroying a Hat' anchor='destroy'>
-    <p>The following flow shows how to destroy a hat and remove it from the list of available hats.</p>
-    <p>When a hat is destroyed, it is automatically removed from all the JIDs where it was assigned.</p>
-    <p>The service SHOULD broadcast the related JID presences with the refreshed hats list.</p>
-    <example caption='Admin Requests to Destroy a Hat'><![CDATA[
-<iq from='professor@example.edu/office'
-    id='rei4n2b0'
-    to='physicsforpoets@courses.example.edu'
-    type='set'
-    xml:lang='en'>
-  <command xmlns='http://jabber.org/protocol/commands'
-           action='execute'
-           node='urn:xmpp:hats:commands:destroy'>
-    <x xmlns='jabber:x:data' type='submit'>
-      <field type='hidden' var='FORM_TYPE'>
-        <value>urn:xmpp:hats:commands</value>
-      </field>
-      <field var='hat'>
-        <value>http://tech.example.edu/hats#TeacherAssistant</value>
-      </field>
-    </x>
-  </command>
-</iq>
-]]></example>
-    <example caption='Service Informs Admin of Completion'><![CDATA[
-<iq from='physicsforpoets@courses.example.edu'
-    id='rei4n2b0'
-    to='professor@example.edu/office'
-    type='result'
-    xml:lang='en'>
-  <command xmlns='http://jabber.org/protocol/commands'
-           node='urn:xmpp:hats:commands:destroy'
-           sessionid='A971D19A-2226-4DAD-B261-7D0886B9A123'
-           status='completed'/>
-</iq>
-]]></example>
-  </section2>
   <section2 topic='Assigning a Hat' anchor='add'>
     <p>Hats are assigned and removed using &xep0050;.</p>
     <p>The following flow shows how to assign a hat.</p>
@@ -347,8 +392,8 @@
            node='urn:xmpp:hats:commands:assign'/>
 </iq>
 ]]></example>
-    <p>Unless an error occurs, the service returns the appropriate form.</p>
-    <example caption='Service Returns Form to Admin'><![CDATA[
+    <p>Unless an error occurs, the room returns the appropriate form.</p>
+    <example caption='Room Returns Form to Admin'><![CDATA[
 <iq from='physicsforpoets@courses.example.edu'
     id='fdi3n2b6'
     to='professor@example.edu/office'
@@ -371,7 +416,7 @@
       </field>
       <field label='The role'
              type='list-single'
-             var='hat'>
+             var='hats#uri'>
         <option label='Teacher'><value>http://tech.example.edu/hats#Teacher</value></option>
         <option label='Teacher&apos;s Assistant'><value>http://tech.example.edu/hats#TeacherAssistant</value></option>
         <option label='Test Proctor'><value>http://tech.example.edu/hats#Proctor</value></option>
@@ -396,14 +441,14 @@
       <field var='hats#jid'>
         <value>terry.anderson@example.edu</value>
       </field>
-      <field var='hat'>
+      <field var='hats#uri'>
         <value>http://tech.example.edu/hats#TeacherAssistant</value>
       </field>
     </x>
   </command>
 </iq>
 ]]></example>
-    <example caption='Service Informs Admin of Completion'><![CDATA[
+    <example caption='Room Informs Admin of Completion'><![CDATA[
 <iq from='physicsforpoets@courses.example.edu'
     id='9fens61z'
     to='professor@example.edu/office'
@@ -419,7 +464,7 @@
   </section2>
   <section2 topic='Removing a Hat' anchor='remove'>
     <p>The following flow shows how to remove a hat.</p>
-    <p>When the hat is removed service SHOULD broadcast the related JID presence with the refreshed hat list.</p>
+    <p>When the hat is removed, the room SHOULD broadcast the related JID presence with the refreshed hat list.</p>
     <example caption='Admin Requests to Remove a Hat'><![CDATA[
 <iq from='professor@example.edu/office'
     id='fdi3n2b6'
@@ -436,14 +481,14 @@
       <field var='hats#jid'>
         <value>terry.anderson@example.edu</value>
       </field>
-      <field var='hat'>
+      <field var='hats#uri'>
         <value>http://tech.example.edu/hats#TeacherAssistant</value>
       </field>
     </x>
   </command>
 </iq>
 ]]></example>
-    <example caption='Service Informs Admin of Completion'><![CDATA[
+    <example caption='Room Informs Admin of Completion'><![CDATA[
 <iq from='physicsforpoets@courses.example.edu'
     id='fdi3n2b6'
     to='professor@example.edu/office'
@@ -453,6 +498,58 @@
            node='urn:xmpp:hats:commands:unassign'
            sessionid='A971D19A-2226-4DAD-B261-8D0886B9A026'
            status='completed'/>
+</iq>
+]]></example>
+  </section2>
+
+  <section2 topic='Listing Assigned Hats'>
+    <p>An entity might be interested to get all the hats assigned to users in a chatroom.</p>
+
+    <example caption='User’s client request the hats list assigned on a MUC room'><![CDATA[
+<iq from='professor@example.edu/office'
+  id='fdi3n2b6'
+  to='physicsforpoets@courses.example.edu'
+  type='set'
+  xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+          action='execute'
+          node='urn:xmpp:hats:commands:list-assigned'/>
+</iq>]]></example>
+    <example caption='Room Returns the List of Assigned Hats'><![CDATA[
+<iq from='physicsforpoets@courses.example.edu'
+    id='fdi3n2b6'
+    to='professor@example.edu/office'
+    type='result'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+           node='urn:xmpp:hats:commands:list-assigned'
+           status='completed'
+           sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'>
+    <x xmlns='jabber:x:data' type='result'>
+      <title>Assigned Hats List</title>
+      <reported>
+        <field var='hats#jid'/>
+        <field var='hats#uri'/>
+        <field var='hats#title'/>
+        <field var='hats#hue'/>
+      </reported>
+      <item>
+        <field var='hats#jid'>
+            <value>terry.anderson@example.edu</value>
+        </field>
+        <field var='hats#uri'>
+            <value>http://tech.example.edu/hats#TeacherAssistant</value>
+        </field>
+        <field var='hats#title'>
+            <value>Assistant</value>
+        </field>
+        <field var='hats#hue'>
+            <value>327.255249</value>
+        </field>
+      </item>
+      …
+    </x>
+  </command>
 </iq>
 ]]></example>
   </section2>
@@ -513,7 +610,7 @@
 </section1>
 
 <section1 topic='Acknowledgements' anchor='acks'>
-  <p>The concepts underlying this specification were first discussed several years ago at an XMPP Summit in Brussels, Belgium. Special thanks to Joe Hildebrand and Ralph Meijer for their contributions to those discussions. Thanks also to Matt Miller, Kevin Smith, and Matthew Wild for their feedback on the written specification.</p>
+  <p>The concepts underlying this specification were first discussed several years ago at an XMPP Summit in Brussels, Belgium. Special thanks to Joe Hildebrand and Ralph Meijer for their contributions to those discussions. Thanks also to Matt Miller, Kevin Smith, Matthew Wild and badlop for their feedback on the written specification.</p>
 </section1>
 
 </xep>


### PR DESCRIPTION
All those changes are just clarifications and typos except the new section that defines a way to list assigned Hats. 

- Say "room" instead of "service" when the action deals with a specific room
- In Example 1, instead of Romeo, use the same User JID than the other examples
- In Example 1, sort attributes
- Fix capitalization of "Hat title" label
- In examples, use the defined field var "hats#uri" instead of ambiguous "hat"
- Fix duplicate "should" word
- Destroy Hat: Show example how to query form with list of hats
- Listing Hats: Move to the Protocol section
- Listing Assigned Hats: New section

Thanks a lot to @badlop for his work on those changes !

Generated HTML version available there https://movim.eu/xeps/xep-0317.html :)