### PR TITLE
New ProtoXEP: Pubsub Node Bookmark

### DIFF
--- a/inbox/pubsub-node-bookmark.xml
+++ b/inbox/pubsub-node-bookmark.xml
@@ -1,0 +1,167 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY % ents SYSTEM 'xep.ent'>
+  <!ENTITY namespace "urn:xmpp:pubsub-node-bookmark:0">
+  <!ENTITY pubsub-node "&lt;pubsub-node/&gt;">
+%ents;
+]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+  <header>
+    <title>Pubsub Node Bookmark</title>
+    <abstract>This specification defines a bookmark element pointing to a Pubsub node</abstract>
+    &LEGALNOTICE;
+    <number>xxxx</number>
+    <status>ProtoXEP</status>
+    <type>Standards Track</type>
+    <sig>Standards</sig>
+    <approver>Council</approver>
+    <dependencies>
+      <spec>XMPP Core</spec>
+      <spec>XEP-0001</spec>
+      <spec>XEP-0163</spec>
+      <spec>XEP-0060</spec>
+    </dependencies>
+    <supersedes/>
+    <supersededby/>
+    <shortname>NOT_YET_ASSIGNED</shortname>
+    &edhelas;
+    <revision>
+      <version>0.0.1</version>
+      <date>2025-09-19</date>
+      <initials>psa</initials>
+      <remark><p>First draft.</p></remark>
+    </revision>
+  </header>
+<section1 topic='Introduction' anchor='intro'>
+    <p>This document defines an extensible bookmark element pointing to a Pubsub node, compatible with the extensions defined in &xep0402;.</p>
+    <p>This bookmarks elements are always listed as Pubsub items allowing an entity to discover and explore a list of bookmarks listed by another entity. For example in &xep0503; it allows a Space to list Pubsub nodes besides MUCs in a Space and in &xep0330; it allows an entity to share Pubsub nodes it subscribed to.</p>
+</section1>
+<section1 topic='Protocol' anchor='protocol'>
+    <p>Information about a Pubsub Node Bookmark is provided by the entity. The bookmark container is defined as a classic &pubsub-node; element, qualified by with theses specific constraints:</p>
+    <table caption='attributes'>
+        <tr>
+            <td><strong>Name</strong></td>
+            <td><strong>Type</strong></td>
+            <td><strong>Description</strong></td>
+            <td><strong>Support</strong></td>
+        </tr>
+        <tr>
+            <td>jid</td>
+            <td>attribute</td>
+            <td>The node jid address</td>
+            <td>REQUIRED</td>
+        </tr>
+        <tr>
+            <td>node</td>
+            <td>attribute</td>
+            <td>The node node</td>
+            <td>REQUIRED</td>
+        </tr>
+        <tr>
+            <td>&lt;extensions/&gt; element</td>
+            <td>XML Elements</td>
+            <td>A set of child elements (of potentially any namespace). Clients MUST preserve these (particularly preserving unknown elements) when editing items.</td>
+            <td>OPTIONAL</td>
+        </tr>
+    </table>
+    <section2 topic="Item ID">
+        <p>The aim of this XEP is to allow an entity to handle a list of subscriptions. To simplify the managment of this list the ID of the &xep0060; items MUST be the Pubsub URI of the node as defined in &xep0060;#impl-uri without the 'xmpp:' part.</p>
+    </section2>
+</section1>
+<section1 topic='Requirements' anchor='reqs'>
+    <p>The motivations for this document are to:</p>
+    <ul>
+        <li>Allow entities to list &xep0060; Pubsub Nodes as Pubsub items</li>
+        <li>Allow entities to discover &xep0060; nodes using different scenarios, not defined here</li>
+        <li>Allow those new Pubsub Node Bookmark items to be extensible</li>
+    </ul>
+</section1>
+<section1 topic='Use Cases' anchor='usecases'>
+  <section2 topic='Discovering Pubsub Nodes Bookmarks' anchor='usecases'>
+    <example caption='Requests the list of bookmarks'><![CDATA[
+<iq type='get'
+    from='student@university.org'
+    to='library.university.org'
+    id='list-bookmarks'>
+  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+    <items node='bookmarks-lists'/>
+  </pubsub>
+</iq>]]></example>
+    <example caption='Server return the list of bookmarks'><![CDATA[
+<iq type='result'
+    from='library.university.org'
+    to='student@university.org/cool-client'
+    id='list-bookmarks'>
+  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+    <items node='bookmarks-lists'>
+      <item id='bookmarks.library.org?;node=books'>
+        <pubsub-node xmlns="urn:xmpp:pubsub-node_bookmark:0"
+                      jid="bookmarks.library.org"
+                      node="books" />
+      </item>
+      <item id='bookmarks.library.org?;node=books'>
+        <pubsub-node xmlns="urn:xmpp:pubsub-node_bookmark:0"
+                      jid="bookmarks.library.org"
+                      node="movies">
+          <extensions>
+            <pinned xmlns='urn:xmpp:bookmarks-pinning:0'/>
+          </extensions>
+        </pubsub-node>
+      </item>
+      <!-- other items -->
+    </items>
+  </pubsub>
+</iq>
+]]></example>
+    </section2>
+</section1>
+<section1 topic='Security Considerations' anchor='security'>
+  <p>Related to the XEPs using this document.</p>
+</section1>
+<section1 topic='IANA Considerations' anchor='iana'>
+  <p>This document requires no interaction with &IANA;.</p>
+</section1>
+<section1 topic='XMPP Registrar Considerations' anchor='registrar'>
+  <p>The &REGISTRAR; is requested to issue an initial namespace of "urn:xmpp:pubsub:subscription".</p>
+</section1>
+<section1 topic='XML Schema' anchor='schema'>
+      <code><![CDATA[
+<?xml version='1.0' encoding='UTF-8'?>
+
+<xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace=']]>&namespace;<![CDATA['
+    xmlns=']]>&namespace;<![CDATA['
+    elementFormDefault='qualified'>
+
+  <xs:annotation>
+    <xs:documentation>
+      The protocol documented by this schema is defined in
+      XEP-xxxx: http://www.xmpp.org/inbox/pubsub-node-bookmark.html
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name='pubsub-node'>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref='extensions' minOccurs='0' />
+      </xs:sequence>
+      <xs:attribute name='jid' type='xs:string' use='required'/>
+      <xs:attribute name='node' type='xs:string' use='required'/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='extensions'>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:any namespace='##other'
+                minOccurs='0'
+                maxOccurs='unbounded'
+                processContents='lax'/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>]]></code>
+    </section1>
+</xep>


### PR DESCRIPTION
This document defines an extensible bookmark element pointing to a Pubsub node, compatible with the extensions defined in XEP-0402: PEP Native Bookmarks.

It is motivated to be as close to the XEP-0402: PEP Native Bookmarks items but for Pubsub Nodes. 
It will be primarily used to list Pubsub Nodes in XEP-0503: Spaces but might also be used in other XEPs (I'm planning to bump XEP-0330: Pubsub Subscription to reuse it as well).

A compiled HTML version is available there: https://movim.eu/xeps/pubsub-node-bookmark.html