### PR TITLE
XEP-0045: Fix 'roomsecret' field inconsistency

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -47,6 +47,12 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.35.2</version>
+    <date>2025-09-30</date>
+    <initials>gk</initials>
+    <remark><p>Fix inconsistency in 'roomconfig_roomsecret' data form field definition.</p></remark>
+  </revision>
+  <revision>
     <version>1.35.1</version>
     <date>2024-09-17</date>
     <initials>gk</initials>
@@ -5378,7 +5384,7 @@
       label='Full List of Room Owners'/>
   <field
       var='muc#roomconfig_roomsecret'
-      type='text-single'
+      type='text-private'
       label='The Room Password'/>
   <field
       var='muc#roomconfig_whois'


### PR DESCRIPTION
The `roomconfig_roomsecret` data form field definition was not consistent.

- In XEP-0045, examples 157 and 165 use `text-private`.
- The registry submission in paragraph 16.5.3 uses `text-single`.
- The registry itself (https://xmpp.org/registrar/formtypes.html) uses `text-private`.

This commit changes paragraph 16.5.3 to use `text-private`.

A discussion for this change was started on the XSF's Standards mailinglist on https://mail.jabber.org/hyperkitty/list/standards@xmpp.org/message/K7QCGVMT3XNE4LV3ILHKU3CPV5N63VQC/