### PR TITLE
XEP-0392: Add missing information needed to compute test vectors

### DIFF
--- a/xep-0392.xml
+++ b/xep-0392.xml
@@ -25,6 +25,12 @@
   <shortname>colors</shortname>
   &jonaswielicki;
   <revision>
+    <version>1.0.1</version>
+    <date>2025-10-03</date>
+    <initials>egp</initials>
+    <remark><p>Add missing saturation and lightness information to compute the test vectors.</p></remark>
+  </revision>
+  <revision>
     <version>1.0.0</version>
     <date>2024-03-27</date>
     <initials>XEP Editor (dg)</initials>
@@ -270,7 +276,7 @@
 </section1>
 <section1 topic='Test Vectors' anchor='vectors'>
   <section2 topic='Test Vectors' anchor='testvectors-fullrange'>
-    <p>This section holds test vectors. The test vectors are provided as Comma Separated Values. Strings are enclosed by single quotes (&apos;). The first line contains a header. Each row contains, in that order, the original text, the text encoded as UTF-8 as hexadecimal octets, the angle in degrees, the calculated hue in degrees (hue and angle are the same as of version 0.8.0), and the Red, Green, and Blue values.</p>
+    <p>This section holds test vectors. The test vectors are provided as Comma Separated Values. Strings are enclosed by single quotes (&apos;). The first line contains a header. Each row contains, in that order, the original text, the text encoded as UTF-8 as hexadecimal octets, the angle in degrees, the calculated hue in degrees (hue and angle are the same as of version 0.8.0), and the Red, Green, and Blue values at saturation 100 and lightness 50.</p>
     <code><![CDATA[text,hextext,angle,hue,r,g,b
 'Romeo','526f6d656f',327.255249,327.255249,0.865,0.000,0.686
 'juliet@capulet.lit','6a756c69657440636170756c65742e6c6974',209.410400,209.410400,0.000,0.515,0.573


### PR DESCRIPTION
Saturation and lightness are necessary to get the same rgb values as the test vectors. Thanks @grimmy for figuring it out!