### PR TITLE
XEP-0060: Remove ambiguity in disco#info feature usage

### DIFF
--- a/xep-0060.xml
+++ b/xep-0060.xml
@@ -51,6 +51,15 @@
   &stpeter;
   &ralphm;
   <revision>
+    <version>1.27.0</version>
+    <date>2025-10-03</date>
+    <initials>gdk</initials>
+    <remark>
+      <p>Removed non-normative 'http://jabber.org/protocol/pubsub' disco#info feature from examples</p>
+      <p>Resolved ambiguity around the mandatory status of the 'publish' feature by no longer defining it to be REQUIRED.</p>
+    </remark>
+  </revision>
+  <revision>
     <version>1.26.0</version>
     <date>2023-09-07</date>
     <initials>melvo</initials>
@@ -1020,10 +1029,12 @@ And by opposing end them?
   <query xmlns='http://jabber.org/protocol/disco#info'>
     <identity category='pubsub' type='service'/>
     <feature var='http://jabber.org/protocol/pubsub'/>
+    <feature var='http://jabber.org/protocol/pubsub#subscribe'/>
   </query>
 </iq>
 ]]></example>
     <p>The possible pubsub features are noted throughout this document and have been registered as described in the <link url='#registrar'>XMPP Registrar Considerations</link> section of this document. For information regarding which features are required, recommended, and optional, see the <link url='#features'>Feature Summary</link> section of this document.</p>
+    <p>Note: The value 'http://jabber.org/protocol/pubsub' is historically commonly advertised as a feature for a pubsub service. Although it has been used in examples of previous versions of this specification, it is not a feature that is registered with the XMPP Registrar. It is RECOMMENDED that services include that value as feature for compatibility, but entities should not depend on it being advertised.</p>
   </section2>
 
   <section2 topic='Discover Nodes' anchor='entity-nodes'>
@@ -1150,6 +1161,7 @@ And by opposing end them?
          node='princely_musings'>
     <identity category='pubsub' type='leaf'/>
     <feature var='http://jabber.org/protocol/pubsub'/>
+    <feature var='http://jabber.org/protocol/pubsub#subscribe'/>
     <x xmlns='jabber:x:data' type='result'>
       <field var='FORM_TYPE' type='hidden'>
         <value>http://jabber.org/protocol/pubsub#meta-data</value>
@@ -5401,7 +5413,7 @@ And by opposing end them?
     <tr>
       <td>publish</td>
       <td>Publishing items is supported.</td>
-      <td>REQUIRED</td>
+      <td>RECOMMENDED</td>
       <td><link url='#publisher-publish'>Publish an Item to a Node</link></td>
     </tr>
     <tr>


### PR DESCRIPTION
This change addresses two issues:
1. Section 10 previously defined the `http://jabber.org/protocol/pubsub#publish` feature to be REQUIRED, while section 7.1.1 defines it to be optional.
2. The value `http://jabber.org/protocol/pubsub`, which isn't registered as a feature in this document or with the XMPP Registrar, should not be primarily used in examples of this XEP. Instead, add `http://jabber.org/protocol/pubsub#subscribe` (which is a required feature), keeping `http://jabber.org/protocol/pubsub` as a recommendation for compatiblity.

These changes have been discussed in the XMPP Standards chatroom (logs: https://logs.xmpp.org/xsf/2025-10-03#2025-10-03-f173fd843da7c3ee ) and on the standards mailinglist: https://mail.jabber.org/hyperkitty/list/standards@xmpp.org/thread/R4K2OAPVBQ4IC757F2YBZDV4PPHFGRNS/