### PR TITLE
Update title to publishing and advise of element atom:link

### DIFF
--- a/xep-0277.xml
+++ b/xep-0277.xml
@@ -6,8 +6,8 @@
 <?xml-stylesheet type='text/xsl' href='xep.xsl'?>
 <xep>
 <header>
-  <title>Microblogging over XMPP</title>
-  <abstract>This specification defines a method for microblogging over XMPP.</abstract>
+  <title>Publishing</title>
+  <abstract>This specification defines a method for publishing over XMPP.</abstract>
   &LEGALNOTICE;
   <number>0277</number>
   <status>Deferred</status>
@@ -109,15 +109,14 @@
 </header>
 
 <section1 topic='Introduction' anchor='intro'>
-  <p>Microblogging is an increasingly popular technology for lightweight interaction over the Internet. It differs from traditional blogging in that:</p>
+  <p>Diginal publishing (or microblogging) is an increasingly popular practice for lightweight interaction over the Internet. It fundamentally differs from traditional journal pubblishing in that:</p>
   <ul>
-    <li>Posts are short (typically less than 140 characters, which is the limit in SMS).</li>
-    <li>Posts are in plain text.</li>
     <li>People can reply to your posts, but not directly comment on them.</li>
     <li>People learn about your posts only if they have permission to view them.</li>
-    <li>Your microblogging feed is discovered based on your identity at a domain or with a service.</li>
+    <li>Your publishing feed is discovered based on your identity at a domain or with a service.</li>
+    <li>Metadata is well defined and explicitly classified by element "atom:link" which enables for fast navigation and integration with software clients.</li>
   </ul>
-  <p>These characteristics map well to instant messaging systems such as those built using Jabber/XMPP technologies (e.g., permissions can be based on existing presence subscriptions as reflected in the XMPP roster or "buddy list"). Furthermore, the push nature of XMPP (especially as formalized in the &xep0163; profile of &xep0060;) overcomes the problems of polling for updates via HTTP, which has caused scaling issues in existing microblogging services. Therefore this specification defines a method for microblogging over XMPP, building on the existing method for transporting Atom syndication data &rfc4287; over XMPP as described in &atomsub;. These XMPP-based methods are complementary to HTTP-based methods, and can provide an XMPP interface to existing microblogging services (which may also be accessible via HTTP, Short Message Service (SMS), and other messaging transports).</p>
+  <p>These characteristics map well to instant messaging systems such as those built using Jabber/XMPP technologies (e.g., permissions can be based on existing presence subscriptions as reflected in the XMPP roster or "buddy list"). Furthermore, the push nature of XMPP (especially as formalized in the &xep0163; profile of &xep0060;) overcomes the problems of polling for updates via HTTP, which has caused scaling issues in existing publishing services. Therefore this specification defines a method for publishing over XMPP, building on the existing method for transporting Atom syndication data &rfc4287; over XMPP as described in &atomsub;. These XMPP-based methods are complementary to HTTP-based methods, and can provide an XMPP interface to existing publishing services (which may also be accessible via Gemini, HTTP, Short Message Service (SMS), and other messaging transports).</p>
 </section1>
 
 <section1 topic='Protocol' anchor='proto'>
@@ -138,7 +137,7 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
   </section2>
   <section2 topic='Publishing a Post' anchor='publish'>
     <p>Romeo can publish a post via any interface provided by his service, such as a website, the Atom Publishing Protocol (see &rfc5023;), SMS, an IM bot, or XMPP pubsub. Here we assume that the post is provided via XMPP pubsub.</p>
-    <p>The post content itself can be either text (content element without "type" attribute or with "type" attribute with "text" value) or XHTML ("content" element "type" attribute with "xhtml" value). If Romeo publishes XHTML content, his client MUST publish two "content" elements: a text one, and a XHTML one. For XHTML publishing, see &xep0060;.</p>
+    <p>The post content itself can be either text (content element without "type" attribute or with "type" attribute with "text" value) or XHTML ("content" element "type" attribute with "xhtml" value). If Romeo publishes XHTML content, his client MUST publish a "link" element with the textual source code of the XHTML content. For XHTML publishing, see &xep0060;.</p>
     <p>Note: Publishing via HTTP, AtomPub, SMS, or IM bot is simpler for the client (e.g., because the client does not need to generate an Item ID).</p>
     <example caption="Publishing a post"><![CDATA[
 <iq from='romeo@montague.lit/pda'
@@ -371,7 +370,7 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
     <p>We have described two pubsub nodes types here: the one is for the microblog itself and the other one is for comments to posts.</p>
     <p>Usage specific requires the special parameters to these nodes to be specified. This section describes recommendation for them.</p>
     <section2 topic="Microblog node configuration" anchor="microblog_node_config">
-        <p>Here are recommendations for a microblogging node (usually located at PEP and named by the "urn:xmpp:microblog:0" namespace) configuration:</p>
+        <p>Here are recommendations for a publishing node (usually located at PEP and named by the "urn:xmpp:microblog:0" namespace) configuration:</p>
         <ol>
           <li>The "pubsub#notify_retract" MUST be set to true to provide clients the ability to track if some items were retracted and reflect such changes in the UI correctly.</li>
           <li>The "pubsub#max_items" SHOULD be increased from the default value to some reasonable value.</li>
@@ -495,7 +494,7 @@ xmpp:romeo@montague.lit?;node=urn%3Axmpp%3Amicroblog%3A0
 </section1>
 
 <section1 topic='Message Body' anchor='body'>
-  <p>Depending on service policies and the value of the "pubsub#include_body" node configuration option, microblogging notifications SHOULD include a message "body" element for backwards-compatibility with Jabber clients that are not pubsub-capable. It is RECOMMENDED for the XML character value of the "body" element to be the same as that of the "atom:title" child of the "atom:entry".</p>
+  <p>Depending on service policies and the value of the "pubsub#include_body" node configuration option, publishing notifications SHOULD include a message "body" element for backwards-compatibility with Jabber clients that are not pubsub-capable. It is RECOMMENDED for the XML character value of the "body" element to be the same as that of the "atom:title" child of the "atom:entry".</p>
 </section1>
 
 <section1 topic='Security Considerations' anchor='security'>


### PR DESCRIPTION
Update title to realize that XMPP is for any kind of publishing.

Change the directive of additional element "atom:content" to element "atom:link" with source code of XHTML content.

Reasons.

* Bandwidth;

* Compliance with RFC 4287;

* Easier development and classification; and

* Obviousness.