### PR TITLE
xsd: align xep.xsd with current XEP document usage

### DIFF
--- a/xep.xsd
+++ b/xep.xsd
@@ -138,7 +138,7 @@ THE SOFTWARE.
 
   <xs:element name='supersedes'>
     <xs:complexType>
-      <xs:sequence>
+      <xs:sequence minOccurs='0' maxOccurs='unbounded'>
         <xs:element name='spec' type='xs:string'/>
       </xs:sequence>
     </xs:complexType>
@@ -146,7 +146,7 @@ THE SOFTWARE.
 
   <xs:element name='supersededby'>
     <xs:complexType>
-      <xs:sequence>
+      <xs:sequence minOccurs='0' maxOccurs='unbounded'>
         <xs:element name='spec' type='xs:string'/>
       </xs:sequence>
     </xs:complexType>

--- a/xep.xsd
+++ b/xep.xsd
@@ -328,7 +328,7 @@ THE SOFTWARE.
         <xs:element ref='li' minOccurs='1' maxOccurs='unbounded'/>
       </xs:sequence>
       <xs:attribute name='class' type='xs:string' use='optional'/>
-      <xs:attribute name='start' type='xs:byte' use='optional'/>
+      <xs:attribute name='start' type='xs:positiveInteger' use='optional'/>
       <xs:attribute name='style' type='xs:string' use='optional'/>
     </xs:complexType>
   </xs:element>

--- a/xep.xsd
+++ b/xep.xsd
@@ -189,15 +189,15 @@ THE SOFTWARE.
 
   <xs:element name='councilnote'>
     <xs:complexType>
-      <xs:choice maxOccurs='unbounded'>
-        <xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='dl' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='table' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/>
+      <xs:choice minOccurs='0' maxOccurs='unbounded'>
+        <xs:element ref='code'/>
+        <xs:element ref='div'/>
+        <xs:element ref='dl'/>
+        <xs:element ref='example'/>
+        <xs:element ref='ol'/>
+        <xs:element ref='p'/>
+        <xs:element ref='table'/>
+        <xs:element ref='ul'/>
       </xs:choice>
     </xs:complexType>
   </xs:element>
@@ -221,17 +221,17 @@ THE SOFTWARE.
 
   <xs:element name='section1'>
     <xs:complexType>
-      <xs:choice maxOccurs='unbounded'>
-        <xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='cve' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='dl' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='section2' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='table' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/>
+      <xs:choice minOccurs='0' maxOccurs='unbounded'>
+        <xs:element ref='code'/>
+        <xs:element ref='cve'/>
+        <xs:element ref='div'/>
+        <xs:element ref='dl'/>
+        <xs:element ref='example'/>
+        <xs:element ref='ol'/>
+        <xs:element ref='p'/>
+        <xs:element ref='section2'/>
+        <xs:element ref='table'/>
+        <xs:element ref='ul'/>
       </xs:choice>
       <xs:attribute name='topic' type='xs:string' use='required'/>
       <xs:attribute name='anchor' type='xs:string' use='optional'/>
@@ -240,17 +240,17 @@ THE SOFTWARE.
 
   <xs:element name='section2'>
     <xs:complexType>
-      <xs:choice maxOccurs='unbounded'>
-        <xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='cve' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='dl' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='section3' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='table' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/>
+      <xs:choice minOccurs='0' maxOccurs='unbounded'>
+        <xs:element ref='code'/>
+        <xs:element ref='cve'/>
+        <xs:element ref='div'/>
+        <xs:element ref='dl'/>
+        <xs:element ref='example'/>
+        <xs:element ref='ol'/>
+        <xs:element ref='p'/>
+        <xs:element ref='section3'/>
+        <xs:element ref='table'/>
+        <xs:element ref='ul'/>
       </xs:choice>
       <xs:attribute name='topic' type='xs:string' use='required'/>
       <xs:attribute name='anchor' type='xs:string' use='optional'/>
@@ -259,17 +259,17 @@ THE SOFTWARE.
 
   <xs:element name='section3'>
     <xs:complexType>
-      <xs:choice maxOccurs='unbounded'>
-        <xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='cve' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='dl' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='section4' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='table' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/>
+      <xs:choice minOccurs='0' maxOccurs='unbounded'>
+        <xs:element ref='code'/>
+        <xs:element ref='cve'/>
+        <xs:element ref='div'/>
+        <xs:element ref='dl'/>
+        <xs:element ref='example'/>
+        <xs:element ref='ol'/>
+        <xs:element ref='p'/>
+        <xs:element ref='section4'/>
+        <xs:element ref='table'/>
+        <xs:element ref='ul'/>
       </xs:choice>
       <xs:attribute name='topic' type='xs:string' use='required'/>
       <xs:attribute name='anchor' type='xs:string' use='optional'/>
@@ -278,16 +278,16 @@ THE SOFTWARE.
 
   <xs:element name='section4'>
     <xs:complexType>
-      <xs:choice maxOccurs='unbounded'>
-        <xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='cve' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='dl' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='table' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/>
+      <xs:choice minOccurs='0' maxOccurs='unbounded'>
+        <xs:element ref='code'/>
+        <xs:element ref='cve'/>
+        <xs:element ref='div'/>
+        <xs:element ref='dl'/>
+        <xs:element ref='example'/>
+        <xs:element ref='ol'/>
+        <xs:element ref='p'/>
+        <xs:element ref='table'/>
+        <xs:element ref='ul'/>
       </xs:choice>
       <xs:attribute name='topic' type='xs:string' use='required'/>
       <xs:attribute name='anchor' type='xs:string' use='optional'/>
@@ -296,14 +296,14 @@ THE SOFTWARE.
 
   <xs:element name='div'>
     <xs:complexType>
-      <xs:choice maxOccurs='unbounded'>
-        <xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='cve' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/>
-        <xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/>
+      <xs:choice minOccurs='0' maxOccurs='unbounded'>
+        <xs:element ref='div'/>
+        <xs:element ref='p'/>
+        <xs:element ref='example'/>
+        <xs:element ref='code'/>
+        <xs:element ref='cve'/>
+        <xs:element ref='ul'/>
+        <xs:element ref='ol'/>
       </xs:choice>
       <xs:attribute name='class' type='xs:string' use='optional'/>
       <xs:attribute name='style' type='xs:string' use='optional'/>

--- a/xep.xsd
+++ b/xep.xsd
@@ -26,9 +26,7 @@ THE SOFTWARE.
 
 <xs:schema
     xmlns:xs='http://www.w3.org/2001/XMLSchema'
-    targetNamespace='http://www.xmpp.org/extensions'
-    xmlns='http://www.xmpp.org/extensions'
-    elementFormDefault='qualified'>
+    elementFormDefault='unqualified'>
 
   <xs:element name='xep'>
     <xs:annotation>

--- a/xep.xsd
+++ b/xep.xsd
@@ -123,6 +123,7 @@ THE SOFTWARE.
         <xs:enumeration value='Humorous'/>
         <xs:enumeration value='Informational'/>
         <xs:enumeration value='Organizational'/>
+        <xs:enumeration value='Procedural'/>
         <xs:enumeration value='Standards Track'/>
       </xs:restriction>
     </xs:simpleType>

--- a/xep.xsd
+++ b/xep.xsd
@@ -51,13 +51,19 @@ THE SOFTWARE.
     </xs:complexType>
   </xs:element>
 
+  <xs:simpleType name='headerNumber'>
+    <xs:restriction base='xs:string'>
+      <xs:pattern value='[0-9]{4}'/>
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:element name='header'>
     <xs:complexType>
       <xs:sequence>
         <xs:element name='title' type='xs:string'/>
         <xs:element name='abstract' type='xs:string'/>
         <xs:element ref='legal'/>
-        <xs:element name='number' type='xs:byte'/>
+        <xs:element name='number' type='headerNumber'/>
         <xs:element ref='status'/>
         <xs:element name='lastcall' minOccurs='0' type='xs:string'/>
         <xs:element name='interim' minOccurs='0' type='empty'/>
@@ -173,8 +179,8 @@ THE SOFTWARE.
     <xs:complexType>
       <xs:sequence>
         <xs:element name='version' type='xs:string'/>
-        <xs:element name='date' type='xs:dateTime'/>
-        <xs:element name='initials' type='xs:NCName'/>
+        <xs:element name='date' type='xs:date'/>
+        <xs:element name='initials' type='xs:string'/>
         <xs:element ref='remark'/>
       </xs:sequence>
     </xs:complexType>


### PR DESCRIPTION
This PR aims to reduce validation mismatches between `xep.xsd` and the XEP XML files in this repository. It focuses on practical schema maintenance: improving compatibility with existing documents, tightening or clarifying selected metadata constraints, and simplifying repetitive schema patterns so the XSD is easier to maintain and review. It is not a complete overhaul, but it should better reflect the XEPs currently in-tree.

Please refer to the individual commit messages for change-by-change details.