### PR TITLE
XEP-0345: Apply policy changes after Board vote on 2026-04-16

### DIFF
--- a/xep-0345.xml
+++ b/xep-0345.xml
@@ -24,6 +24,17 @@
 		<shortname>N/A</shortname>
 		&dcridland;
   <revision>
+    <version>1.1.0</version>
+    <date>2026-04-20</date>
+    <initials>gdk</initials>
+    <remark>
+      <p>Apply policy changes after Board vote on 2026-04-16</p>
+      <p>Allow Legal Name to be provided privately to the Secretary instead of published.</p>
+      <p>Add support for alternative public identifiers.</p>
+      <p>Clarify handling of private information and alignment with XSF disclosure policy.</p>
+    </remark>
+  </revision>
+  <revision>
     <version>1.0.0</version>
     <date>2020-02-18</date>
     <initials>XEP Editor (jsc)</initials>
@@ -85,9 +96,11 @@
 		<p>Applicants are solely responsible for their own applications, and the applications shall be their own. Members and prospective members should not edit anyone else's application. Exceptions to this latter shall
 		be made only with permission of the Board, the XSF Secretary, or the Executive Director; and
 		the Applicant concerned.</p>
+    <p>Applicants may omit certain sensitive personal information (such as their Legal Name, where permitted by this specification) from the public application page, provided that such information has been supplied to the XSF Secretary in order to satisfy the mandatory requirements of this specification. Information not included in the public application MUST be transmitted directly to the XSF Secretary using a communication method acceptable to the Secretary.</p>
 	</section1>
 	<section1 topic='Challenges and Final Arbiter' anchor='arbiter'>
 		<p>In the case that a particular application is questionable for some reason - if it is thought to be missing mandatory information, containing incorrect information, or failing to disclose affiliations - a member may raise a Challenge with the membership, by sending a message to the members list detailing the issues. A member may request a member of the &BOARD; to raise the Challenge anonymously on their behalf; the member of the Board however is in no way compelled to do so.</p>
+    <p>The XSF Board and Secretary shall have access to the Applicant's Legal Name regardless of whether it is publicly disclosed, and may use this information when evaluating Challenges or verifying eligibility.</p>
 		<p>The XSF Board is the final arbiter of such Challenges, and shall make a final decision on whether the application should be rejected; however the Board is expected to take into account any rough consensus of the members. Any rejection will include any remedies possible.</p>
 		<p>Notwithstanding the final nature of the XSF Board's decision, any application so rejected may be resubmitted by the Applicant, presumably after addressing the issues.</p>
 	</section1>
@@ -98,7 +111,7 @@
 		<p>In the case that voting (including proxy voting) has not yet begun, pages may be changed by the applicant at any time. The application need not notify members or the secretary.</p>
 		</section2>
 		<section2 topic='During Voting'>
-		<p>If voting (including proxy voting) has begun, the applicant must notify the XSF Secretary. Applicants who are existing members should also notify the membership directly themselves. If An Application does not (or if they are not a member), the XSF Secretary shall do so.</p>
+		<p>If voting (including proxy voting) has begun, the applicant must notify the XSF Secretary. Applicants who are existing members should also notify the membership directly themselves. If an Application does not (or if they are not a member), the XSF Secretary shall do so.</p>
 		</section2>
 	</section1>
 	<section1 topic='Mandatory Information' anchor='mandatory'>
@@ -108,13 +121,14 @@
 				<di><dt>Contact Email</dt><dd>A valid email address, specific to the Applicant, suitable for members to contact and request further information.</dd></di>
 				<di><dt>Contact Jid</dt><dd>A valid jid, specific to the Applicant, suitable for members to contact and request further information.</dd></di>
 				<di><dt>Relevant Affiliations</dt><dd>Any affiliations, as described within the final clause of the XSF Bylaws, Section 2.1. Note that this is not limited to employment, but must include it. Other relevant affiliations include any other organization the applicant may represent.</dd></di>
-				<di><dt>Legal Name</dt><dd>A full name by which the Applicant is known and identified for legal purposes. This could be the name on a Natural Applicant's passport.</dd></di>
+				<di><dt>Legal Name</dt><dd>A full name by which the Applicant is known and identified for legal purposes. This information MUST be provided to the XSF Secretary, but need not be published on the public application page. If the Legal Name is not published, the Applicant MUST provide an alternative public identifier (such as a username or handle) by which members can refer to the Applicant during discussion and voting, and which is used in public records related to the application.</dd></di>
 			</dl>
 	</section1>
 	<section1 topic='Security Considerations' anchor='security'>
 		<p>There are privacy implications inherent in the public disclosure of the information in an Application, particularly by a Natural Applicant.</p>
-		<p>These are an unavoidable consequence of the Application.</p>
-		<p>Applicants may deliberately mislead Members through their applications. This document provides no rememdy for such action., and members are advised to be aware of this possibility.</p>
+		<p>While applications are publicly visible, this specification permits Applicants to limit the disclosure of certain personal information (such as their Legal Name) on the public application page. However, such information is still required to be provided to the XSF and retained for internal use.</p>
+    <p>Public identification of members after acceptance is governed by XSF policy, including provisions for alternative identifiers and role-based disclosure requirements.</p>
+		<p>Applicants may deliberately mislead Members through their applications. This document provides no remedy for such action, and members are advised to be aware of this possibility.</p>
 	</section1>
 	<section1 topic='IANA Considerations' anchor='iana'>
 		<p>This document has no considerations for IANA.</p>


### PR DESCRIPTION
Allow Legal Name to be provided privately to the Secretary instead of published.

Add support for alternative public identifiers.

Clarify handling of private information and alignment with XSF disclosure policy.