### PR TITLE
New ProtoXEP: TLS Channel-Binding Downgrade Protection (TDP)

### DIFF
--- a/inbox/tdp.xml
+++ b/inbox/tdp.xml
@@ -1,0 +1,191 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY % ents SYSTEM 'xep.ent'>
+%ents;
+]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+<header>
+  <title>TLS Channel-Binding Downgrade Protection</title>
+  <abstract>This specification provides a way to secure the SASL and SASL2 SCRAM handshakes against channel-binding downgrades through TLS version downgrades.</abstract>
+  &LEGALNOTICE;
+  <number>xxxx</number>
+  <status>ProtoXEP</status>
+  <type>Standards Track</type>
+  <sig>Standards</sig>
+  <approver>Council</approver>
+  <dependencies>
+    <spec>XMPP Core</spec>
+    <spec>RFC 5802</spec>
+    <spec>XEP-0388</spec>
+  </dependencies>
+  <supersedes/>
+  <supersededby/>
+  <shortname>TDP</shortname>
+  <tags>
+    <tag>downgade protection</tag>
+    <tag>tls</tag>
+    <tag>scram</tag>
+    <tag>channel-binding</tag>
+  </tags>
+  &tmolitor;
+  <revision>
+    <version>0.0.1</version>
+    <date>2026-03-14</date>
+    <initials>tm</initials>
+    <remark>Initial version.</remark>
+  </revision>
+</header>
+<section1 topic='Introduction' anchor='intro'>
+  <p>&xep0474; defines a way to detect and prevent channel-binding type and SASL method downgrades. While this works well, an attacker could still leverage one specific attack vector to downgrade the channel-binding type to tls-server-end-point: a MITM-attacker could use different TLS versions with a different set of supported channel-binding types on both arms of their connection. This will downgrade the channel-binding type negotiated to the lowest denominator of both lists, which is at least tls-server-end-point per requirement of &xep0440;. If the server violates point 1 of the Business Rules in &xep0440; and the client simultaneously violates point 6 in said Business Rules, the attacker will even be able to downgrade the connection no channel-binding at all!</p>
+  <p>While pinning of channel-binding types can prevent those downgrade attacks, pinning comes with all the downsides explained in &xep0474; and won't secure the very first connection either.</p>
+  <section2 topic='Examples' anchor='examples'>
+    <p>While this attack doesn't depend on specific TLS versions, but can be executed with all current or future TLS versions for which the list of defined/implemented channel-binding types differes, here are two examples for TLS 1.2 and TLS 1.3.</p>
+    <p>If the MITM-attacker terminates the TLS connection to the client with TLS 1.3 and the TLS connection to the server with TLs 1.2, the server will advertise tls-uniqe channel-binding (alongside tls-server-end-point), but not tls-exporter. The client won't pick tls-unique, because it isn't defined for TLS 1.3 and fall back to the weaker tls-server-end-point.</p>
+    <p>If the MITM-attacker chooses to terminate the TLS connection to the client with TLS 1.2 and to the server with TLS 1.3, the server will advertise tls-exporter channel-binding (alongside tls-server-end-point), but not tls-unique. Even though tls-exporter can be securely used if the extended-master-secret extension TLS extension is used, most clients won't pick tls-exporter on TLS 1.2 connections and thus fall back to the weaker tls-server-end-point.</p>
+  </section2>
+</section1>
+<section1 topic='Glossary' anchor='glossary'>
+  <p>This specification uses some abbreviations:</p>
+  <ul>
+    <li>MITM: man-in-the-middle</li>
+    <li>SASL1: the XMPP SASL profile specified in &rfc6120;</li>
+    <li>SASL2: the XMPP SASL profile specified in &xep0388;</li>
+    <li>TDP: TLS downgrade protection, this specification</li>
+  </ul>
+</section1>
+<section1 topic='Requirements' anchor='reqs'>
+  <p>This protocol was designed with the following requirements in mind:</p>
+  <ul>
+    <li>Allow detection of TLS version and thus channel-binding downgrades even if no channel-binding ends-up being used.</li>
+    <li>Support all currently defined and future SCRAM mechanisms (&rfc5802; and &rfc7677;).</li>
+    <li>Secure the very first connection.</li>
+    <li>Be not less secure than pinning when using the SCRAM family of mechanisms (or some similar challenge-response based authentication mechanism).</li>
+  </ul>
+  <p>Note that this specification intentionally leaves out support for SASL PLAIN. If server and client support PLAIN, no protection against SASL method or channel-binding downgrades is possible and the security relies solely on the underlying TLS channel. See the Business Rules section of &xep0474; for some advice on how to handle PLAIN.</p>
+</section1>
+<section1 topic='Protocol' anchor='protocol'>
+  <p>Sections 5.1 and 7 of &rfc5802; allow for arbitrary optional attributes inside SCRAM messages. This specification uses those optional attributes to implement a downgrade protection.</p>
+  <section2 topic="Server Sends TLS Version As Hex" anchor="hex">
+    <p>The server encodes the TLS version number used by the connection as defined in &rfc8446;, &rfc5246; and their predecessors as four lowercased hexadecimal numbers. For convenience the currently defined version numbers follow:</p>
+    <ol>
+      <li>TLS 1.3 has the version number 0x0304, thus is encoded as '0304'</li>
+      <li>TLS 1.2 has the version number 0x0303, thus is encoded as '0303'</li>
+      <li>TLS 1.1 has the version number 0x0302, thus is encoded as '0302'</li>
+      <li>TLS 1.0 has the version number 0x0301, thus is encoded as '0301'</li>
+    </ol>
+    <p>The server then adds the optional attribute "t" with the value of the four hexadecimal characters described above to its server-first-message.</p>
+  </section2>
+  <section2 topic="Client Verifies The TLS Version Number" anchor="verification">
+    <p>Upon receiving the server-first-message the client calculates the version number of its own TLS connection and encodes it as four lowercased hex-encoded characters as described in <link url="#hex">Server Sends TLS Version As Hex</link>.</p>
+    <p>The client then extracts the TLS version number presented by the server in the optional attribute "t" and compares it to its own version number. If the hex-encoded version numbers match, the TLS version used by the server and client have not been altered by an active MITM.</p>
+    <p>If the version numbers do not match, the client MUST fail the authentication. It MAY additionally show a user-facing warning message about an active MITM. If the version numbers match, an attacker could still have manipulated them. If so, the server will always fail the authentication according to &rfc5802; because the client-proof will not be based upon the correct TDP value.</p>
+  </section2>
+  <section2 topic="Full Example" anchor="example">
+    <p>This sections contains an example based on the ones provided in &xep0388;.</p>
+    <example caption="Full SCRAM-SHA-1-PLUS authentication flow using the optional attribute defined in this spec"><![CDATA[
+<!--
+  Client sending stream header
+-->
+<stream:stream
+  from='user@example.org'
+  to='example.org'
+  version='1.0'
+  xml:lang='en'
+  xmlns='jabber:client'
+  xmlns:stream='http://etherx.jabber.org/streams'>
+
+<!--
+  Server responding with stream header and features
+-->
+<stream:stream
+  from='example.org'
+  id='++TR84Sm6A3hnt3Q065SnAbbk3Y='
+  to='user@example.org'
+  version='1.0'
+  xml:lang='en'
+  xmlns='jabber:client'
+  xmlns:stream='http://etherx.jabber.org/streams'>
+<stream:features>
+  <authentication xmlns='urn:xmpp:sasl:2'>
+    <mechanism>SCRAM-SHA-1</mechanism>
+    <mechanism>SCRAM-SHA-1-PLUS</mechanism>
+    <inline xmlns='urn:xmpp:sasl:2'>
+      <!-- Server indicates that XEP-0198 can be negotiated "inline" -->
+      <enable xmlns='urn:xmpp:sm:3'/>
+      <!-- Server indicates support for XEP-0386 Bind 2 -->
+      <bind xmlns='urn:xmpp:bind2:1'/>
+    </inline>
+  </authentication>
+  <!-- Channel-binding information provided by XEP-0440 -->
+  <sasl-channel-binding xmlns='urn:xmpp:sasl-cb:0'>
+    <channel-binding type='tls-server-end-point'/>
+    <channel-binding type='tls-exporter'/>
+  </sasl-channel-binding>
+</stream:features>
+
+<!--
+  Client initiates authentication using SCRAM-SHA-1-PLUS and channel-binding type "tls-exporter"
+-->
+<authenticate xmlns='urn:xmpp:sasl:2' mechanism='SCRAM-SHA-1-PLUS'>
+  <!-- Base64 of: 'p=tls-exporter,,n=user,r=12C4CD5C-E38E-4A98-8F6D-15C38F51CCC6' -->
+  <initial-response>cD10bHMtZXhwb3J0ZXIsLG49dXNlcixyPTEyQzRDRDVDLUUzOEUtNEE5OC04RjZELTE1QzM4RjUxQ0NDNg==</initial-response>
+  <user-agent id='d4565fa7-4d72-4749-b3d3-740edbf87770'>
+    <software>AwesomeXMPP</software>
+    <device>Kiva's Phone</device>
+  </user-agent>
+</authenticate>
+
+<!--
+  SCRAM-SHA-1-PLUS challenge issued by the server as defined in RFC 5802 including the hex-encoded TLS version and the hash defined in XEP-0474..
+  Attribute "t" contains 0304 (TLS 1.3), attribute "h" contains the XEP-0474 hash.
+  Base64 of: 'r=12C4CD5C-E38E-4A98-8F6D-15C38F51CCC6a09117a6-ac50-4f2f-93f1-93799c2bddf6,s=QSXCR+Q6sek8bf92,i=4096,h=G6k/rBLDqgOhRRaCuuatSDFkJ08=,t=0304'
+-->
+<challenge xmlns='urn:xmpp:sasl:2'>
+  cj0xMkM0Q0Q1Qy1FMzhFLTRBOTgtOEY2RC0xNUMzOEY1MUNDQzZhMDkxMTdhNi1hYzUwLTRmMmYtOTNmMS05Mzc5OWMyYmRkZjYscz1RU1hDUitRNnNlazhiZjkyLGk9NDA5NixoPUc2ay9yQkxEcWdPaFJSYUN1dWF0U0RGa0owOD0sdD0wMzA0
+</challenge>
+
+<!--
+  The client responds with the base64 encoded SCRAM-SHA-1-PLUS client-final-message (password: 'pencil')
+  The c-attribute contains the GS2-header and channel-binding data blob as defined in RFC 5802.
+  Base64 of: 'c=cD10bHMtZXhwb3J0ZXIsLFRISVMgSVMgRkFLRSBDQiBEQVRB,r=12C4CD5C-E38E-4A98-8F6D-15C38F51CCC6a09117a6-ac50-4f2f-93f1-93799c2bddf6,p=KHUfN8dSy1K95crT4D5y1ItLJfs='
+-->
+<response xmlns='urn:xmpp:sasl:2'>
+  Yz1jRDEwYkhNdFpYaHdiM0owWlhJc0xGUklTVk1nU1ZNZ1JrRkxSU0JEUWlCRVFWUkIscj0xMkM0Q0Q1Qy1FMzhFLTRBOTgtOEY2RC0xNUMzOEY1MUNDQzZhMDkxMTdhNi1hYzUwLTRmMmYtOTNmMS05Mzc5OWMyYmRkZjYscD1LSFVmTjhkU3kxSzk1Y3JUNEQ1eTFJdExKZnM9
+</response>
+
+<!--
+  The server accepted this authentication, no tampering with the advertised SASL mechanisms or channel-bindings was detected.
+-->
+<success xmlns='urn:xmpp:sasl:2'>
+  <!-- Base64 of: 'v=3w34ZIMVRkx2f2Ozb3/ecRPVdv4=' -->
+  <additional-data>
+    dj0zdzM0WklNVlJreDJmMk96YjMvZWNSUFZkdjQ9
+  </additional-data>
+  <authorization-identifier>user@example.org</authorization-identifier>
+</success>]]></example>
+  </section2>
+</section1>
+<section1 topic='Business Rules' anchor='rules'>
+  <p>To implement this protocol, clients and servers MUST also implement &xep0474;.</p>
+  <p>The rules outlined in the Business Rules section of &xep0474; are important and MUST be followed when implementing this specification.</p>
+</section1>
+<section1 topic='Security Considerations' anchor='security'>
+  <p>Using SCRAM attributes makes them part of the HMAC signatures used in the SCRAM protocol flow, efficiently protecting them against any MITM attacker not knowing the password used.</p>
+</section1>
+<section1 topic='IETF Interaction' anchor='ietf'>
+  <p>This protocol shall be superseded by any IETF RFC providing some or all of the functionality provided by this specification. If such a specification exists implementations SHOULD NOT implement this XEP and SHOULD implement the superseding RFC instead.</p>
+</section1>
+<section1 topic='IANA Considerations' anchor='iana'>
+  <p>This document requires no interaction with &IANA;.</p>
+</section1>
+<section1 topic='Acknowledgements' anchor='acks'>
+  <p>Thanks to Holger Weiß and Paweł Chmielowski for their feedback.</p>
+</section1>
+<section1 topic='XMPP Registrar Considerations' anchor='registrar'>
+  <p>This specification does not need any interaction with the &REGISTRAR;.</p>
+</section1>
+<section1 topic='XML Schema' anchor='schema'>
+  <p>This specification does not specify any new XML elements.</p>
+</section1>
+</xep>


### PR DESCRIPTION
This specification provides a way to secure the SASL and SASL2 SCRAM handshakes against channel-binding downgrades through TLS version downgrades.