### PR TITLE
XEP-0463 v0.2.0

### DIFF
--- a/xep-0463.xml
+++ b/xep-0463.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE xep SYSTEM 'xep.dtd' [
   <!ENTITY % ents SYSTEM 'xep.ent'>
-  <!ENTITY mav0 'urn:xmpp:muc:affiliations:0'>
+  <!ENTITY mav 'urn:xmpp:muc:affiliations:1'>
   <!ENTITY muc 'http://jabber.org/protocol/muc'>
   <!ENTITY muc-user 'http://jabber.org/protocol/muc#user'>
 %ents;
@@ -23,9 +23,15 @@
   </dependencies>
   <supersedes/>
   <supersededby/>
-  <shortname>NOT_YET_ASSIGNED</shortname>
+  <shortname>mav</shortname>
   &pep.;
   &larma;
+  <revision>
+    <version>0.2.0</version>
+    <date>2026-04-21</date>
+    <initials>lmw</initials>
+    <remark>Use a dedicated child element of &lt;x/&gt; rather than namespaced attributes.</remark>
+  </revision>
   <revision>
     <version>0.1.0</version>
     <date>2022-03-08</date>
@@ -68,44 +74,44 @@
 </section1>
 
 <section1 topic='Discovering Support' anchor='disco'>
-  <p>A server implementing this specification MUST advertise the <tt>&mav0;</tt> as a &xep0030; feature on the &xep0045; room JID itself.</p>
+  <p>A server implementing this specification MUST advertise the <tt>&mav;</tt> as a &xep0030; feature on the &xep0045; room JID itself.</p>
 </section1>
 
 <section1 topic='Usage Flow' anchor='usage'>
   <section2 topic='Client request' anchor='request'>
-    <p>When sending a join presence to a &xep0045; room, a client may include a <tt>since</tt> attribute in the <tt>&mav0;</tt> namespace on the <tt>&lt;x xmlns='&muc;'&gt;</tt> element. This attribute, a unique and opaque string, indicates the last affiliation version sent by the server that the client has seen, and cached. Sending an empty <tt>since</tt> attribute is a called bootstrap request, which asks the server for a full response.</p>
+    <p>When sending a join presence to a &xep0045; room, a client may include a <tt>mav</tt> element in the <tt>&mav;</tt> namespace in the <tt>&lt;x xmlns='&muc;'&gt;</tt> element. This element has an attribute <tt>since</tt>, a unique and opaque string, indicating the last affiliation version sent by the server that the client has seen, and cached. Sending the <tt>mav</tt> element without a <tt>since</tt> attribute is a called bootstrap request, which asks the server for a full response.</p>
 
-    <p>This <tt>since</tt> attribute MUST NOT be broadcasted by the server to other participants. A room not stripping the attribute may disclose information about an occupant to other participants, even though this information is not intended for them.</p>
+    <p>This <tt>mav</tt> element MUST NOT be broadcasted by the server to other participants. A room not stripping the element may disclose information about an occupant to other participants, even though this information is not intended for them.</p>
 
     <example caption='Bootstrap request to get the full list.'><![CDATA[
 <presence to='news@chat.commons.example' from='louise@commons.example/desktop'>
-  <x xmlns=']]>&muc;<![CDATA['
-     xmlns:mav=']]>&mav0;<![CDATA['
-     mav:since='' />
+  <x xmlns=']]>&muc;<![CDATA['>
+    <mav xmlns=']]>&mav;<![CDATA[' />
+  </x>
 </presence>]]></example>
     <example caption='Request since specific version.'><![CDATA[
 <presence to='news@chat.commons.example' from='rosa@commons.example/toaster'>
-  <x xmlns=']]>&muc;<![CDATA['
-     xmlns:mav=']]>&mav0;<![CDATA['
-     mav:since='9pacabr2q1' />
+  <x xmlns=']]>&muc;<![CDATA['>
+    <mav xmllns=']]>&mav;<![CDATA[' since='9pacabr2q1' />
+  </x>
 </presence>]]></example>
   </section2>
 
   <section2 topic='Server Response' anchor='response'>
     <section3 topic='On Join' anchor='self'>
-      <p>Returning the list of affiliation changes is done as a <tt>&MESSAGE;</tt> stanza inside the <tt>&lt;x xmlns='&muc-user;'&gt;</tt> element to which <tt>since</tt> and/or <tt>until</tt> attributes of namespace <tt>&mav0;</tt> MAY be added. Each affiliation is to be sent as an <tt>&lt;item&gt;</tt> element in the same namespace as its x parent, and MUST at least contain a <tt>jid</tt> attribute and an <tt>affiliation</tt> attribute, similarly to what is specified in <link url='https://xmpp.org/extensions/xep-0045.html#affil'>MUC Affiliations</link>.</p>
+      <p>Returning the list of affiliation changes is done as a <tt>&MESSAGE;</tt> stanza inside the <tt>&lt;x xmlns='&muc-user;'&gt;</tt> element to which a <tt>mav</tt> element in the <tt>&mav;</tt> namespace with <tt>since</tt> and/or <tt>until</tt> attributes MAY be added. Each affiliation is to be sent as an <tt>&lt;item&gt;</tt> element in the same namespace as its x parent, and MUST at least contain a <tt>jid</tt> attribute and an <tt>affiliation</tt> attribute, similarly to what is specified in <link url='https://xmpp.org/extensions/xep-0045.html#affil'>MUC Affiliations</link>.</p>
       <p>The <tt>since</tt> attribute is used to reflect the version sent by the client and is the starting point of the diff that will be computed. The <tt>until</tt> attribute is the latest version the server has. When these attributes are present they MUST contain a valid version string (unique and opaque).</p>
       <p>The reponse MUST be sent during the join process before any <tt>&PRESENCE;</tt> is sent to the joining user.</p>
       <p>If a client sends a version that the server doesn't know, (e.g., because it only stores the last N versions, or the client made a mistake), the response MUST be a full response, with the <tt>since</tt> attribute not present, and the <tt>until</tt> attribute filled with the latest version.</p>
-      <p>If both attributes have the same value, meaning a client already has the latest version, the x element MUST be empty, only containing the two filled attributes.</p>
-      <p>There can be no empty diff but there can be empty full reponses (no affiliations).</p>
+      <p>If a client sends the current version, no <tt>&MESSAGE;</tt> is sent. Instead the version is only indicated in the "self-presence" (see below).</p>
+      <p>The response may be split into multiple <tt>&MESSAGE;</tt> stanzas, which must have their <tt>until</tt> and <tt>since</tt> attributes match the adjacent message.</p>
+      <p>There can be no empty diff but there can be full reponses without an <tt>item</tt> elements (no affiliations).</p>
 
       <example caption="Room full response for a version that it didn't know."><![CDATA[
 <message from='news@chat.commons.example'
          to='louise@commons.example/desktop'>
-  <x xmlns=']]>&muc-user;<![CDATA['
-     xmlns:mav=']]>&mav0;<![CDATA['
-     mav:until='ruz41312vw'>
+  <x xmlns=']]>&muc-user;<![CDATA['>
+    <mav xmlns']]>&mav;<![CDATA[' until='ruz41312vw' />
     <item jid='louise@commons.example' affiliation='owner' />
     <item jid='peter@commons.example' affiliation='owner' />
     <item jid='rosa@commons.example' affiliation='owner' />
@@ -114,10 +120,8 @@
       <example caption='Room versioned response.'><![CDATA[
 <message from='news@chat.commons.example'
          to='louise@commons.example/desktop'>
-  <x xmlns=']]>&muc-user;<![CDATA['
-     xmlns:mav=']]>&mav0;<![CDATA['
-     mav:since='9pacabr2q1'
-     mav:until='ruz41312vw'>
+  <x xmlns=']]>&muc-user;<![CDATA['>
+    <mav xmlns=']]>&mav;<![CDATA[' since='9pacabr2q1' until='ruz41312vw' />
     <item jid='vladimir@commons.example' affiliation='none' />
     <item jid='rosa@commons.example' affiliation='owner' />
   </x>
@@ -125,24 +129,33 @@
       <example caption='Room full response with no affiliation'><![CDATA[
 <message from='news@chat.commons.example'
          to='louise@commons.example/desktop'>
-  <x xmlns=']]>&muc-user;<![CDATA['
-     xmlns:mav=']]>&mav0;<![CDATA['
-     mav:until='ruz41312vw'/>
+  <x xmlns=']]>&muc-user;<![CDATA['>
+    <mav xmlns=']]>&mav;<![CDATA[' until='ruz41312vw' />
+  </x>
 </message>]]></example>
+      <p>When the room sends a self-presence with a status code of 110, i.e. after the user completed joining the room, the room must include a <tt>mav</tt> element in the <tt>&mav;</tt> namespace in the <tt>&lt;x xmlns='&muc-user;'&gt;</tt> element with <tt>until</tt> attribute set to the current version.</p>
+      <p>If a client receives a self-presence with a status code of 110, but without a <tt>mav</tt> element or with a <tt>until</tt> attribute that is not the expected value, it must assume the room does not support the specification and must consider any previous affiliation data to be outdated.</p>
+      <example caption='Self-Presence with version statement'><![CDATA[
+<presence from='news@chat.commons.example'
+          to='louise@commons.example/desktop'>
+  <x xmlns=']]>&muc-user;<![CDATA['>
+    <mav xmlns=']]>&mav;<![CDATA[' until='ruz41312vw' />
+    <item affiliation='member' role='participant'/>
+    <status code='110'/>
+  </x>
+</presence>]]></example>
     </section3>
 
     <section3 topic='Affiliation Changes' anchor='changes'>
-      <p>A new unique (to the room) version string MUST be generated for every affiliation change and included in the broadcast of this change.</p>
-      <p>When broadcasting an affiliation change (as a &PRESENCE; or &MESSAGE;), on the <tt>&lt;x xmlns='&muc-user;'&gt;</tt>, a MUC room MUST add the <tt>since</tt> attribute in the <tt>&mav0;</tt> namespace, containing the original version string (before the affiliation change), and the new version string (after the affiliation change) in the <tt>until</tt> attribute (of the same namespace).</p>
-    <p>Affiliation changes broadcasted to room occupants as &MESSAGE; defined as a MAY in &xep0045;, for example in <link url='https://xmpp.org/extensions/xep-0045.html#grantowner'>Granting Owner Status</link>, <link url='https://xmpp.org/extensions/xep-0045.html#grantadmin'>Granting Admin Status</link>, or <link url='https://xmpp.org/extensions/xep-0045.html#revokeadmin'>Revoking Admin Status</link>, MUST be supported by the MUC room when implementing this specification.</p>
+      <p>When any affiliation list is modified, such modification MUST result in a new version string which is included in the broadcast of this change.</p>
+      <p>When broadcasting an affiliation change (as a &PRESENCE; or &MESSAGE;), the romm MUST add the <tt>mav</tt> element in the <tt>&mav;</tt> namespace to the <tt>&lt;x xmlns='&muc-user;'&gt;</tt> element containing the original version string (before the affiliation change) in the <tt>since</tt> attribute, and the new version string (after the affiliation change) in the <tt>until</tt> attribute.</p>
+      <p>Affiliation changes broadcasted to room occupants as &MESSAGE; defined as a MAY in &xep0045;, for example in <link url='https://xmpp.org/extensions/xep-0045.html#grantowner'>Granting Owner Status</link>, <link url='https://xmpp.org/extensions/xep-0045.html#grantadmin'>Granting Admin Status</link>, or <link url='https://xmpp.org/extensions/xep-0045.html#revokeadmin'>Revoking Admin Status</link>, MUST be supported by the MUC room when implementing this specification.</p>
 
       <example caption='Room broadcasts an affiliation change for a user not in the room.'><![CDATA[
 <message from='news@chat.commons.example'
          to='louise@commons.example/desktop'>
-  <x xmlns=']]>&muc-user;<![CDATA['
-     xmlns:mav=']]>&mav0;<![CDATA['
-     mav:since='9pacabr2q1'
-     mav:until='ruz41312vw'>
+  <x xmlns=']]>&muc-user;<![CDATA['>
+    <mav xmlns=']]>&mav;<![CDATA[' since='9pacabr2q1' until='ruz41312vw' />
     <item jid='peter@commons.example/mobile' affiliation='none' role='none'/>
   </x>
 </message>]]></example>
@@ -166,7 +179,7 @@
 </section1>
 
 <section1 topic='Security Considerations' anchor='security'>
-  <p>An observer has to join the MUC room to use the protocol as the <tt>since</tt> element must be included in the join presence. This makes this specification less prone to vulnerabilities that may have happened with protocols such as MAM in the past (i.e., scraping information without being joined).</p>
+  <p>An observer has to join the MUC room to use the protocol as the <tt>mav</tt> element must be included in the join presence. This makes this specification less prone to vulnerabilities that may have happened with protocols such as MAM in the past (i.e., scraping information without being joined).</p>
   <p>A server should be careful not to disclose past affiliation states. If an observer requests a version of which they weren't a part of, a server MUST return an error as specified in <link url='#errors'>Error Cases</link>.</p>
   <p>When caching server responses, a client should make sure to associate the received version string to the room JID and not have a global cache for affiliation versions to prevent any cache poisoning issues.</p>
 </section1>
@@ -176,7 +189,7 @@
 </section1>
 
 <section1 topic='XMPP Registrar Considerations' anchor='registrar'>
-  <p>The XMPP Registrar includes the <tt>&mav0;</tt> namespace in its registry of protocol namespaces at <link url='https://xmpp.org/registrar/namespaces.html'>https://xmpp.org/registrar/namespaces.html</link>.</p>
+  <p>The XMPP Registrar includes the <tt>&mav;</tt> namespace in its registry of protocol namespaces at <link url='https://xmpp.org/registrar/namespaces.html'>https://xmpp.org/registrar/namespaces.html</link>.</p>
 </section1>
 
 <section1 topic='Design Considerations' anchor='design'>
@@ -200,7 +213,11 @@
     </xs:documentation>
   </xs:annotations>
 
-  <!-- TODO: How do I schematize standalone attributes? -->
+  <xs:element name='mav'>
+    <xs:complexType>
+      <xs:attribute name='since' type='xs:string' use='optional'/>
+      <xs:attribute name='until' type='xs:string' use='optional'/>
+    </xs:complexType>
   </xs:element>
 </xs:schema>]]></code>
 </section1>


### PR DESCRIPTION
Use a dedicated child element of `<x/>` rather than namespaced attributes.