### PR TITLE
XEP-0045: Fix examples for messages from the room itself

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -47,6 +47,17 @@
   <registry/>
   &stpeter;
   <revision>
+    <version>1.35.5</version>
+    <date>2026-05-03</date>
+    <initials>nc</initials>
+    <remark>
+      <ul>
+        <li>Fix 'from' attribute in examples where the room itself sends a message.</li>
+        <li>Fix associated pubsub node field name in disco info example.</li>
+      </ul>
+    </remark>
+  </revision>
+  <revision>
     <version>1.35.4</version>
     <date>2026-03-13</date>
     <initials>ph</initials>
@@ -1371,7 +1382,7 @@
              label='Maximum Number of History Messages Returned by Room'>
         <value>50</value>
       </field>
-      <field var='muc#roominfo_pubsub'
+      <field var='muc#roomconfig_pubsub'
              label='Associated pubsub node'>
         <value>xmpp:pubsub.shakespeare.lit?;node=the-coven-node</value>
       </field>
@@ -4600,7 +4611,7 @@
     <p>If the user is not in the room, the service MAY send a message from the room itself to the room occupants, indicating the granting of owner status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "owner".</p>
     <example caption="Service Sends Notice of Owner Status to All Occupants"><![CDATA[
 <message
-    from='chat.shakespeare.lit'
+    from='coven@chat.shakespeare.lit'
     id='22B0F570-526A-4F22-BDE3-52EC3BB18371'
     to='crone1@shakespeare.lit/desktop'>
   <x xmlns='http://jabber.org/protocol/muc#user'>
@@ -4781,7 +4792,7 @@
     <p>If the user is not in the room, the service MAY send a message from the room itself to the room occupants, indicating the granting of admin status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "admin".</p>
     <example caption="Service Sends Notice of Admin Status to All Occupants"><![CDATA[
 <message
-    from='chat.shakespeare.lit'
+    from='coven@chat.shakespeare.lit'
     id='C75B919A-30B3-4233-AE89-6E9834E26929'
     to='crone1@shakespeare.lit/desktop'>
   <x xmlns='http://jabber.org/protocol/muc#user'>
@@ -4848,7 +4859,7 @@
     <p>If the user is not in the room, the service MAY send a message from the room itself to the room occupants, indicating the loss of admin status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value other than "admin".</p>
     <example caption="Service Notes Loss of Admin Affiliation"><![CDATA[
 <message
-    from='chat.shakespeare.lit'
+    from='coven@chat.shakespeare.lit'
     id='2CF9013B-E8A8-42A1-9633-85AD7CA12F40'
     to='crone1@shakespeare.lit/desktop'>
   <x xmlns='http://jabber.org/protocol/muc#user'>


### PR DESCRIPTION
- 3 examples had the from attribute set to the MUC service instead of the room (contradicting the text just above).
- The room disco info example had a field named "roominfo_pubsub" but it should be "roomconfig_pubsub"