### PR TITLE
Payment Required: identify payment systems by URI scheme, drop XSF registries

### DIFF
--- a/inbox/payment-required.xml
+++ b/inbox/payment-required.xml
@@ -7,7 +7,7 @@
 <xep>
 <header>
   <title>Payment Required</title>
-  <abstract>This specification defines an XMPP protocol extension that enables services to require payment before granting access to a resource. It provides a payment-system neutral invoice format supporting multiple concurrent payment options, including bank transfers (SEPA, IBAN, UPI) and instant-settlement networks (Lightning Network), and integrates with the existing CAPTCHA challenge mechanism defined in XEP-0158.</abstract>
+  <abstract>This specification defines an XMPP protocol extension that enables services to require payment before granting access to a resource. It provides a payment-system-neutral invoice format built on payment URIs (such as the RFC 8905 payto scheme), supporting multiple concurrent payment options, from bank transfers to transfers over distributed ledgers or instant-settlement networks, and integrates with the existing CAPTCHA challenge mechanism defined in XEP-0158.</abstract>
   &LEGALNOTICE;
   <number>xxxx</number>
   <status>ProtoXEP</status>
@@ -31,6 +31,24 @@
     <tag>anti-spam</tag>
   </tags>
   &jcbrand;
+  <revision>
+    <version>0.0.2</version>
+    <date>2026-06-12</date>
+    <initials>jcb</initials>
+    <remark>
+      <p>Following community review: identify payment systems by their URI scheme
+      instead of an XSF-maintained registry; the option payload is now a payment URI
+      and the redundant 'scheme' and 'amount' attributes are removed (amount and
+      currency are carried by the URI). Made the payment URI mandatory and added an optional
+      <tt>&lt;qr/&gt;</tt> child carrying a payment string to render as a QR code, for systems
+      whose scannable QR format differs from the URI. Removed the Payment Schemes and Proof Types
+      registries; proof types are now declared per option by the issuer and echoed by
+      the payer, with a non-normative list of conventional types. Added the
+      'payment-pending' reason and a 'retry-after' attribute returned with stanza error
+      type "wait". Added security guidance on amount-presentation integrity and clarified
+      that clients need not parse payment URIs.</p>
+    </remark>
+  </revision>
   <revision>
     <version>0.0.1</version>
     <date>2026-04-23</date>
@@ -56,9 +74,12 @@
     <li>multiple simultaneously valid payment options MAY be presented so that the client can choose the most suitable scheme.</li>
   </ol>
 
-  <p>This specification is payment-system agnostic. A service MAY require payment exclusively via bank transfer,
-  exclusively via an instant-settlement network, or via any combination thereof. No payment scheme is privileged over any other
-  at the protocol level.</p>
+  <p>This specification is payment-system agnostic. A service MAY require payment exclusively via bank transfer, distributed ledger,
+    instant-settlement network, or any combination thereof. No payment system is privileged over any other at the protocol level.
+    Crucially, this specification does not enumerate or curate payment systems itself: each payment option is
+    expressed as a payment URI, and the payment system is identified by that URI's scheme (registered in the IANA URI Schemes registry,
+    and, for the <tt>payto</tt> scheme, the payment target types maintained externally per RFC 8905). Adding support for a new
+    payment network therefore requires no change to this document.</p>
 </section1>
 
 <section1 topic='Requirements' anchor='reqs'>
@@ -66,7 +87,9 @@
   <ul>
     <li>A service MUST be able to decline a stanza and return structured payment instructions using a standard XMPP error stanza.</li>
     <li>The payment instructions MUST support multiple concurrent payment options, each carrying sufficient information for fully automated processing as well as human-readable presentation.</li>
-    <li>At minimum, a URI-based option renderable as a QR code MUST be defined. The <tt>payto</tt> URI scheme (RFC 8905) is RECOMMENDED as the primary URI scheme because it covers traditional bank accounts (IBAN/SEPA, UPI, etc.) and cryptocurrency addresses within a single, payment-system-neutral standard.</li>
+    <li>Each payment option MUST be expressed as a payment URI, identified by its URI scheme, so that the specification need not maintain its own registry of payment systems. The <tt>payto</tt> URI scheme (RFC 8905) is RECOMMENDED as the primary scheme because it covers traditional bank accounts (IBAN/SEPA, UPI, etc.) and cryptocurrency addresses within a single, payment-system-neutral standard.</li>
+    <li>A client MUST be able to support this protocol without parsing scheme-specific payment URIs and therefore MAY treat a payment URI as an opaque string to be handed over to a payment application (or rendered as a QR code).</li>
+    <li>A payment option MAY additionally carry a pre-formatted QR payload for payment systems whose scannable QR format differs from the URI; clients SHOULD render it as a QR code without interpreting it.</li>
     <li>Proof-of-payment tokens MUST be expressible in-band so that a client can retry a declined stanza with evidence of payment.</li>
     <li>The protocol MUST integrate gracefully with the existing &xep0158; challenge mechanism.</li>
     <li>The protocol MUST be usable at the stanza level independently of the application layer (MUC, file upload, message routing, etc.)
@@ -133,17 +156,27 @@
         Pay once per calendar month. Include your JID as the payment
         reference so your access can be confirmed promptly.
       </description>
-      <option amount='EUR:5.00'
-              label='Bank transfer (SEPA)'
-              scheme='payto'>payto://iban/DE02200400300200270112?amount=EUR:5.00&amp;message=upperroom-c4a1f902&amp;receiver-name=Capulet+Hosting</option>
-      <option amount='INR:450'
-              label='UPI'
-              scheme='payto'>payto://upi/capulethosting@examplebank?amount=INR:450&amp;message=upperroom-c4a1f902&amp;receiver-name=Capulet+Hosting
+      <option label='Bank transfer (SEPA)'
+              proof='reference'>payto://iban/DE02200400300200270112?amount=EUR:5.00&amp;message=upperroom-c4a1f902&amp;receiver-name=Capulet+Hosting
+        <display-amount>EUR 5.00</display-amount>
+        <qr>BCD
+002
+1
+SCT
+
+Capulet Hosting
+DE02200400300200270112
+EUR5.00
+
+
+upperroom-c4a1f902</qr>
+      </option>
+      <option label='UPI'
+              proof='reference'>payto://upi/capulethosting@examplebank?amount=INR:450&amp;message=upperroom-c4a1f902&amp;receiver-name=Capulet+Hosting
         <display-amount>&#x20B9; 450</display-amount>
       </option>
-      <option amount='EUR:5.00'
-              label='Lightning Network (instant)'
-              scheme='lightning-bolt11'>lnbc50n1pn2s4czpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq
+      <option label='Lightning Network (instant)'
+              proof='preimage'>lightning:lnbc50n1pn2s4czpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq
         <display-amount>EUR 5.00 via Lightning</display-amount>
       </option>
     </invoice>
@@ -154,8 +187,7 @@
 <presence from='romeo@shakespeare.lit/orchard'
           to='upperroom@conference.shakespeare.lit/Romeo'>
   <x xmlns='http://jabber.org/protocol/muc'/>
-  <payment scheme='payto'
-           session='c4a1f902-7d3b-4e8c-a510-2f9b0e6d3178'
+  <payment session='c4a1f902-7d3b-4e8c-a510-2f9b0e6d3178'
            xmlns='urn:xmpp:payment:0'>
     <proof type='reference'>NOTPROVIDED20260419DE02</proof>
   </payment>
@@ -165,15 +197,32 @@
 <presence from='romeo@shakespeare.lit/orchard'
           to='upperroom@conference.shakespeare.lit/Romeo'>
   <x xmlns='http://jabber.org/protocol/muc'/>
-  <payment scheme='lightning-bolt11'
-           session='c4a1f902-7d3b-4e8c-a510-2f9b0e6d3178'
+  <payment session='c4a1f902-7d3b-4e8c-a510-2f9b0e6d3178'
            xmlns='urn:xmpp:payment:0'>
-    <proof type='lightning-preimage'>a8f3e1d2b4c9078564fae012cc3d99a1b5e7d0f3a2c81496057832bd7e4f0c1a</proof>
+    <proof type='preimage'>a8f3e1d2b4c9078564fae012cc3d99a1b5e7d0f3a2c81496057832bd7e4f0c1a</proof>
   </payment>
 </presence>
 ]]></example>
   <p>Because SEPA bank transfers may take time to settle, the service SHOULD set a generous session expiry for bank-transfer
-  options and MAY grant access provisionally upon receiving the retry stanza, subsequently revoking it if reconciliation fails.</p>
+  options and MAY grant access provisionally upon receiving the retry stanza, subsequently revoking it if reconciliation fails.
+  Alternatively, where the service has detected the payment but has not yet confirmed settlement, it MAY ask the payer to wait
+  and retry later (see <link url='#protocol-error-flow'>Error Flow</link>).</p>
+    <example caption="The service has seen the transfer but awaits settlement, asking Romeo to retry later"><![CDATA[
+<presence from='upperroom@conference.shakespeare.lit'
+          to='romeo@shakespeare.lit/orchard'
+          type='error'>
+  <error type='wait'>
+    <payment-required xmlns='urn:xmpp:payment:0'
+                      reason='payment-pending'
+                      retry-after='3600'/>
+    <text xml:lang='en'
+          xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'>
+      Your payment has been received and is awaiting settlement.
+      Please retry in about an hour.
+    </text>
+  </error>
+</presence>
+]]></example>
   </section2>
 
   <section2 topic='Per-Message Fee for an AI Agent Bot' anchor='usecase-bot'>
@@ -203,14 +252,12 @@
              purpose='Per-query fee'
              session='a3f7c291-84d0-4b2e-9b1a-0f3e2d1c5678'
              xmlns='urn:xmpp:payment:0'>
-      <option amount='SAT:10'
-          label='Lightning (instant, automated)'
-          scheme='lightning-bolt11'>lnbc100n1pn2s3dzpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq
+      <option label='Lightning (instant, automated)'
+              proof='preimage'>lightning:lnbc100n1pn2s3dzpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq
         <display-amount>10 sats</display-amount>
       </option>
-      <option amount='SAT:10'
-              label='BOLT 12 offer'
-              scheme='lightning-bolt12'>lno1qgsyz4uzesxqcyq5rqwzqfqpqdynf
+      <option label='BOLT 12 offer'
+              proof='preimage'>lightning:lno1qgsyz4uzesxqcyq5rqwzqfqpqdynf
         <display-amount>10 sats</display-amount>
       </option>
     </invoice>
@@ -223,10 +270,9 @@
          to='newssummary@bots.shakespeare.lit'
          type='chat'>
   <body>Summarize today's news from Verona.</body>
-  <payment scheme='lightning-bolt11'
-           session='a3f7c291-84d0-4b2e-9b1a-0f3e2d1c5678'
+  <payment session='a3f7c291-84d0-4b2e-9b1a-0f3e2d1c5678'
            xmlns='urn:xmpp:payment:0'>
-    <proof type='lightning-preimage'>a8f3e1d2b4c9078564fae012cc3d99a1b5e7d0f3a2c81496057832bd7e4f0c1a</proof>
+    <proof type='preimage'>a8f3e1d2b4c9078564fae012cc3d99a1b5e7d0f3a2c81496057832bd7e4f0c1a</proof>
   </payment>
 </message>
 ]]></example>
@@ -237,7 +283,6 @@
          type='chat'>
   <body>Today in Verona: the Montagues and Capulets have agreed to a temporary truce...</body>
   <receipt reference='a8f3e1d2b4c9078564fae012cc3d99a1b5e7d0f3a2c81496057832bd7e4f0c1a'
-           scheme='lightning-bolt11'
            session='a3f7c291-84d0-4b2e-9b1a-0f3e2d1c5678'
            settled='2026-03-20T09:01:14Z'
            xmlns='urn:xmpp:payment:0'/>
@@ -264,9 +309,8 @@
              purpose='First-contact anti-spam deposit'
              session='f1c3d9e2-7a04-4b8f-a629-3e0d15b7c412'
              xmlns='urn:xmpp:payment:0'>
-      <option amount='SAT:10'
-              label='Lightning deposit'
-              scheme='lightning-bolt11'>lnbc100n1pn2s5azpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq
+      <option label='Lightning deposit'
+              proof='preimage'>lightning:lnbc100n1pn2s5azpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq
         <display-amount>10 sats</display-amount>
       </option>
     </invoice>
@@ -296,12 +340,12 @@
            purpose='Premium room monthly entry'
            session='3c91b2e4-6f07-4a2d-b839-5e0f17d9c823'
            xmlns='urn:xmpp:payment:0'>
-    <option amount='EUR:5.00'
-            label='Bank transfer (SEPA)'
-            scheme='payto'>payto://iban/DE02200400300200270112?amount=EUR:5.00&amp;message=3c91b2e4&amp;receiver-name=Capulet+Hosting</option>
-    <option amount='EUR:5.00'
-            label='Lightning (instant)'
-            scheme='lightning-bolt11'>lnbc50n1pn2s4czpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq
+    <option label='Bank transfer (SEPA)'
+            proof='reference'>payto://iban/DE02200400300200270112?amount=EUR:5.00&amp;message=3c91b2e4&amp;receiver-name=Capulet+Hosting
+      <display-amount>EUR 5.00</display-amount>
+    </option>
+    <option label='Lightning (instant)'
+            proof='preimage'>lightning:lnbc50n1pn2s4czpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq
       <display-amount>EUR 5.00</display-amount>
     </option>
   </invoice>
@@ -343,14 +387,12 @@
            purpose='Account verification fee'
            session='9d4e2c01-5b8f-4a3e-b796-0f1e28d7c589'
            xmlns='urn:xmpp:payment:0'>
-    <option amount='EUR:0.01'
-            label='Bank transfer (SEPA)'
-            scheme='payto'>payto://iban/DE02200400300200270112?amount=EUR:0.01&amp;message=9d4e2c01
+    <option label='Bank transfer (SEPA)'
+            proof='reference'>payto://iban/DE02200400300200270112?amount=EUR:0.01&amp;message=9d4e2c01
       <display-amount>EUR 0.01</display-amount>
     </option>
-    <option amount='EUR:0.01'
-            label='Lightning'
-            scheme='lightning-bolt11'>lnbc10p1pn2s6azpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq
+    <option label='Lightning'
+            proof='preimage'>lightning:lnbc10p1pn2s6azpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq
       <display-amount>EUR 0.01</display-amount>
     </option>
   </invoice>
@@ -373,7 +415,7 @@
       <p>The <tt>&lt;invoice/&gt;</tt> element is the container for all payment options associated with a single payment event. It MUST contain at least one <tt>&lt;option/&gt;</tt> child element and MAY contain a <tt>&lt;description/&gt;</tt> child element whose character data provides additional human-readable context.</p>
       <p>The <tt>&lt;invoice/&gt;</tt> element possesses the following attributes:</p>
       <ul>
-        <li><tt>session</tt> (REQUIRED) — An opaque, service-generated string that MUST be globally unique and MUST be included verbatim in the 'session' attribute of the corresponding <tt>&lt;payment/&gt;</tt> element. Services SHOULD generate this value as a UUID version 4 as specified in RFC 4122. Where a bank transfer option is present, the session value also serves as the RECOMMENDED payment reference that the payer SHOULD include in the transfer.</li>
+        <li><tt>session</tt> (REQUIRED) — An opaque, service-generated string that MUST be globally unique and MUST be included verbatim in the 'session' attribute of the corresponding <tt>&lt;payment/&gt;</tt> element. How the service generates this value is an implementation choice; <link url='#security-session-binding'>Session Binding</link> describes two strategies (a random identifier such as a UUID version 4 per RFC 4122 with server-side state, or a stateless keyed token derived from the invoice parameters). Where a bank transfer option is present, the session value also serves as the RECOMMENDED payment reference that the payer SHOULD include in the transfer.</li>
         <li><tt>expires</tt> (RECOMMENDED) — A UTC date-time value, formatted per &xep0082;, after which the invoice MUST NOT be honored. The payer SHOULD NOT attempt payment after this time.</li>
         <li><tt>purpose</tt> (OPTIONAL) — A short human-readable string describing the reason for the payment requirement (e.g., "Room entry fee", "File upload", "Anti-spam deposit").</li>
       </ul>
@@ -381,31 +423,60 @@
 
     <section3 topic='The option Element' anchor='protocol-option'>
       <p>Each <tt>&lt;option/&gt;</tt> element describes one complete, self-contained payment method. The payer MUST use exactly one option to fulfill the invoice.</p>
-      <p>The character data of the <tt>&lt;option/&gt;</tt> element is the scheme-specific payment payload string (see <link url='#registrar-schemes'>Payment Schemes Registry</link>).</p>
+      <p>The character data of the <tt>&lt;option/&gt;</tt> element MUST be a <strong>payment URI</strong>. The payment system is identified by the URI's scheme (e.g. <tt>payto:</tt> per RFC 8905, or <tt>lightning:</tt> for a Lightning Network invoice or offer), and the amount, currency, and beneficiary are carried within the URI as defined by that scheme's own standard. This specification neither defines nor curates the set of usable schemes; any scheme registered in the IANA URI Schemes registry MAY be used. The <tt>payto</tt> URI scheme (RFC 8905) is RECOMMENDED as the primary scheme.</p>
+      <p>A client is NOT required to parse the payment URI. It MAY treat the URI as an opaque string to be handed to an external payment application or rendered as a QR code; see <link url='#security-amount'>Amount Presentation Integrity</link>.</p>
       <p>The <tt>&lt;option/&gt;</tt> element possesses the following attributes:</p>
       <ul>
-        <li><tt>scheme</tt> (REQUIRED) — A registered payment scheme identifier (see <link url='#registrar-schemes'>Payment Schemes Registry</link>).</li>
-        <li><tt>amount</tt> (OPTIONAL) — The amount required, in the natural denomination of this payment option. The format follows RFC 8905: <tt>currency ":" unit ["." fraction]</tt>, where 'currency' is an ISO 4217 alphabetic code for standard currencies (e.g., EUR:5.00, USD:0.001, ZAR:18.50) or a non-ISO code for assets not covered by that standard (e.g., BTC:0.00001). For schemes whose payload already encodes the amount (e.g., BOLT 11 invoices, <tt>payto</tt> URIs containing an 'amount' parameter), this attribute is redundant but MAY be included to simplify parsing.</li>
+        <li><tt>proof</tt> (OPTIONAL) — The type of proof-of-payment the service expects the payer to echo on retry (see <link url='#protocol-payment'>The payment Element</link>). The issuer declares this value and the payer returns it verbatim in the 'type' attribute of the <tt>&lt;proof/&gt;</tt> element. Its absence means the service verifies payment out of band and requires no payer-supplied proof. The value's meaning is defined by the payment system the option uses; <link url='#proof-types'>Conventional Proof Types</link> lists common values non-normatively.</li>
         <li><tt>label</tt> (OPTIONAL) — A short human-readable string for display in a list (e.g., "Bank transfer (SEPA)", "UPI", "Lightning").</li>
       </ul>
-      <p>The <tt>&lt;option/&gt;</tt> element MAY contain a <tt>&lt;display-amount/&gt;</tt> child element. This element contains a locale-appropriate human-readable string representing the amount for the option, making no assumption about which currency or payment system is primary. Examples: "EUR 5.00", "&#x20B9; 450", "R 18.50", "USD 0.001", "1 000 sat". Services SHOULD include <tt>&lt;display-amount/&gt;</tt> when the amount is not self-evident from the payload string.</p>
+      <p>The <tt>&lt;option/&gt;</tt> element MAY contain a <tt>&lt;display-amount/&gt;</tt> child element. This element contains a locale-appropriate human-readable string previewing the amount for the option, making no assumption about which currency or payment system is primary. Examples: "EUR 5.00", "&#x20B9; 450", "R 18.50", "USD 0.001", "1 000 sat". It is advisory only: it is a presentation hint, not the authoritative amount, and MUST NOT be relied upon for any automated decision (see <link url='#security-amount'>Amount Presentation Integrity</link>). The authoritative amount is the one encoded in the payment URI.</p>
+      <p>The <tt>&lt;option/&gt;</tt> element MAY also contain a <tt>&lt;qr/&gt;</tt> child element whose character data is a payment string to be rendered as a QR code. This is useful where the payment URI is not itself the QR payload that the payer's payment application expects to scan, for example, a SEPA credit transfer for which banking apps scan a European Payments Council (EPC069-12) payload rather than a <tt>payto</tt> URI. A client renders the <tt>&lt;qr/&gt;</tt> content as a QR code <em>without interpreting it</em>, exactly as it would QR-encode the URI, so no scheme-specific parsing is required. This specification does not define or constrain the format of the <tt>&lt;qr/&gt;</tt> payload; that is a matter between the service and the scanning payment application. Because a payment URI is always present, the <tt>&lt;qr/&gt;</tt> element is purely an additional rendering convenience: it is not authoritative and is subject to the same integrity considerations as other invoice content (see <link url='#security-amount'>Amount Presentation Integrity</link>). Clients SHOULD also present the underlying URI as selectable text for accessibility.</p>
     </section3>
 
     <section3 topic='The payment Element' anchor='protocol-payment'>
       <p>The <tt>&lt;payment/&gt;</tt> element is added by the payer as an extension to the retried stanza to indicate that a payment has been made for the referenced session.</p>
-      <p>The <tt>&lt;payment/&gt;</tt> element possesses the following attributes:</p>
+      <p>The <tt>&lt;payment/&gt;</tt> element possesses a single attribute:</p>
       <ul>
-        <li><tt>session</tt> (REQUIRED) — The value of the 'session' attribute from the <tt>&lt;invoice/&gt;</tt> element that this payment satisfies.</li>
-        <li><tt>scheme</tt> (RECOMMENDED) — The scheme identifier of the payment option that was used.</li>
+        <li><tt>session</tt> (REQUIRED) — The value of the 'session' attribute from the <tt>&lt;invoice/&gt;</tt> element that this payment satisfies. The session is the sole correlator the service needs: because the service issued the invoice for that session, it already knows which option(s) and payment system(s) were offered.</li>
       </ul>
-      <p>The <tt>&lt;payment/&gt;</tt> element MAY contain a <tt>&lt;proof/&gt;</tt> child element. The <tt>&lt;proof/&gt;</tt> element possesses a required 'type' attribute identifying the proof format (see <link url='#registrar-prooftypes'>Proof Types Registry</link>), and its character data is the proof token.</p>
+      <p>The <tt>&lt;payment/&gt;</tt> element MAY contain a <tt>&lt;proof/&gt;</tt> child element. The <tt>&lt;proof/&gt;</tt> element possesses a required 'type' attribute and its character data is the proof token. Where the satisfied option carried a 'proof' attribute, the payer SHOULD set 'type' to that declared value. The proof token is opaque to XMPP; its syntax and verification are defined by the payment system the option uses, not by this specification.</p>
+      <section4 topic='Conventional Proof Types' anchor='proof-types'>
+      <p>The following proof types are in common use. This list is <strong>non-normative</strong>: it is a convenience vocabulary, not a registry maintained by this specification. The format and verification of each is defined by the relevant payment system's own standard.</p>
+      <table caption='Conventional Proof Types (non-normative)'>
+        <tr>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+        <tr>
+          <td>preimage</td>
+          <td>A secret revealed upon settlement of a hash-locked payment (e.g. a Lightning Network payment preimage).</td>
+        </tr>
+        <tr>
+          <td>reference</td>
+          <td>A transaction or end-to-end reference string supplied by the payment network (e.g. a SEPA end-to-end identifier, a UPI transaction ID, a PIX E2EID).</td>
+        </tr>
+        <tr>
+          <td>txid</td>
+          <td>An on-chain transaction identifier.</td>
+        </tr>
+        <tr>
+          <td>proof</td>
+          <td>A payee-verifiable cryptographic payment proof supplied out of band (e.g. a private-network transaction proof).</td>
+        </tr>
+        <tr>
+          <td>token</td>
+          <td>An opaque bearer token issued by a facilitator after verified payment, enabling a "pay once, use many times" pattern.</td>
+        </tr>
+      </table>
+      </section4>
     </section3>
 
     <section3 topic='The payment-required Element' anchor='protocol-payment-required'>
       <p>The <tt>&lt;payment-required/&gt;</tt> element is an application-specific stanza error condition. It is used as a child of the <tt>&lt;error/&gt;</tt> element to indicate that the requested action requires payment before it can be fulfilled.</p>
-      <p>The <tt>&lt;payment-required/&gt;</tt> element possesses one OPTIONAL attribute:</p>
+      <p>The <tt>&lt;payment-required/&gt;</tt> element possesses the following OPTIONAL attributes:</p>
       <ul>
-        <li><tt>reason</tt> (OPTIONAL) — A machine-readable code providing additional detail about the payment failure. This is intended for use in error responses to retried stanzas (i.e., where a <tt>&lt;payment/&gt;</tt> was present but verification failed), not in the initial decline. Registered values are:</li>
+        <li><tt>reason</tt> (OPTIONAL) — A machine-readable code providing additional detail. This is intended for use in error responses to retried stanzas (i.e., where a <tt>&lt;payment/&gt;</tt> was present), not in the initial decline. Defined values are:</li>
       </ul>
       <table caption='Registered reason Codes'>
         <tr>
@@ -433,10 +504,11 @@
           <td>The payment amount detected was less than the required amount.</td>
         </tr>
         <tr>
-          <td>scheme-unsupported</td>
-          <td>The 'scheme' value in the <tt>&lt;payment/&gt;</tt> element is not accepted by this service.</td>
+          <td>payment-pending</td>
+          <td>A payment has been detected for the referenced session but has not yet been confirmed as settled. The payer should wait and retry. This is not a failure; it is paired with stanza error type "wait" and SHOULD be accompanied by a 'retry-after' attribute (see <link url='#protocol-error-flow'>Error Flow</link>).</td>
         </tr>
       </table>
+      <p>The <tt>&lt;payment-required/&gt;</tt> element additionally possesses an OPTIONAL <tt>retry-after</tt> attribute: a non-negative integer number of seconds the payer SHOULD wait before retrying the same session. It is meaningful with the 'payment-pending' reason (and MAY accompany any transient condition returned with stanza error type "wait").</p>
     </section3>
 
     <section3 topic='The receipt Element' anchor='protocol-receipt'>
@@ -444,8 +516,7 @@
       <p>The <tt>&lt;receipt/&gt;</tt> element possesses the following attributes:</p>
       <ul>
         <li><tt>session</tt> (REQUIRED) — The session identifier from the <tt>&lt;invoice/&gt;</tt> that was satisfied, allowing the payer to correlate the receipt with the original invoice.</li>
-        <li><tt>scheme</tt> (REQUIRED) — The scheme identifier of the payment option that was used.</li>
-        <li><tt>reference</tt> (RECOMMENDED) — A payment-network reference that can be used for auditing and dispute resolution. For Lightning Network payments this is the payment hash or preimage hash. For bank transfers this is the end-to-end identifier provided by the receiving bank. For on-chain payments this is the transaction identifier.</li>
+        <li><tt>reference</tt> (RECOMMENDED) — A payment-network reference that can be used for auditing and dispute resolution. For Lightning Network payments this is, for example, the payment hash; for bank transfers, the end-to-end identifier provided by the receiving bank; for distributed ledger payments, the transaction identifier.</li>
         <li><tt>settled</tt> (OPTIONAL) — A UTC date-time value, formatted per &xep0082;, indicating when the payment was confirmed as settled. For asynchronous settlement methods (e.g., bank transfers) this MAY be omitted if settlement has not yet been confirmed.</li>
       </ul>
       <p>A service that supports emitting receipts SHOULD advertise the feature 'urn:xmpp:payment:0#receipt' via &xep0030;.</p>
@@ -466,6 +537,7 @@
     <p>If the requesting entity is not authenticated at all (e.g., it has not completed SASL authentication with its own server, or its JID cannot be verified), the service SHOULD return a <tt>&lt;not-authorized/&gt;</tt> error rather than a <tt>&lt;payment-required/&gt;</tt> error. Payment challenges SHOULD only be issued to entities whose identity can be established, to prevent anonymous entities from exploiting the payment flow to probe service behavior.</p>
     <p>The service SHOULD include a human-readable <tt>&lt;text/&gt;</tt> child within the <tt>&lt;error/&gt;</tt> element describing the reason for the payment requirement.</p>
     <p>When a <tt>&lt;payment/&gt;</tt> element is present on a retried stanza but verification fails, the service SHOULD return a <tt>&lt;not-acceptable/&gt;</tt> error of type "modify" containing a <tt>&lt;payment-required/&gt;</tt> element with an appropriate 'reason' attribute (see <link url='#protocol-payment-required'>The payment-required Element</link>), and MAY include a new <tt>&lt;invoice/&gt;</tt> element to allow the payer to retry with a fresh payment. Using a machine-readable 'reason' value allows automated agents to distinguish between a recoverable failure (e.g., 'payment-expired', which warrants requesting a new invoice) and a non-recoverable one (e.g., 'verification-failed', which warrants escalating to the user).</p>
+    <p>Some payment systems settle asynchronously: the service may have detected a payment for the session but cannot yet confirm it has settled (e.g. a bank transfer awaiting reconciliation, or a cryptocurrency payment awaiting confirmations). In this case, where the service does not need a proof from the payer, only more time, it SHOULD return a stanza error of type <strong>"wait"</strong> (per &rfc6120;, signifying a transient condition that warrants retrying after a delay) containing a <tt>&lt;payment-required/&gt;</tt> element with <tt>reason='payment-pending'</tt>, and SHOULD include a <tt>retry-after</tt> attribute giving the number of seconds the payer should wait. The payer then retries the <em>same</em> session after the indicated interval; it does not pay again. This differs from the verification-failure case both in error type ("wait" rather than "modify"/"auth") and in semantics: the payment is on its way, not rejected.</p>
   </section2>
 
   <section2 topic='Verification' anchor='protocol-verification'>
@@ -483,10 +555,9 @@
   <section2 topic='Service Behavior' anchor='rules-service'>
     <ul>
       <li>A service MUST generate a new, unique session identifier for every invoice issued.</li>
-      <li>A service SHOULD include at least one URI-based option (e.g., a <tt>payto</tt> URI) to support human payers using any payment application.</li>
-      <li>A service SHOULD include at least one instant-settlement option (e.g., 'lightning-bolt11') where the use case demands low-latency payment verification.</li>
+      <li>A service MUST include at least one payment option.</li>
       <li>A service MUST NOT include personally identifiable information in invoice payloads beyond what is required for payment routing.</li>
-      <li>Services SHOULD keep session expiry times appropriately short for instant-settlement options (10 to 30 minutes) and appropriately generous for bank-transfer options (1 to 3 business days).</li>
+      <li>Services SHOULD keep session expiry times appropriately short for instant-settlement options (10 to 30 minutes) and appropriately generous for slower bank-transfer options (1 to 3 business days).</li>
     </ul>
   </section2>
   <section2 topic='Client Behavior' anchor='rules-client'>
@@ -494,6 +565,8 @@
       <li>Clients SHOULD present all payment options to the user, ordered from most to least preferred, to allow the user or automated agent to select the most suitable option.</li>
       <li>Automated agents SHOULD prefer instant-settlement options because these can be completed and verified programmatically without user interaction.</li>
       <li>Clients presenting a user interface SHOULD render URI-based options (e.g., <tt>payto</tt> URIs) as QR codes to facilitate payment from a mobile banking or wallet application.</li>
+      <li>A client MAY treat a payment URI as an opaque string and delegate it to an external payment application (via an operating-system URI handler or a QR code) without parsing it. Such a client relies on the payment application to display the authoritative amount and beneficiary and to obtain the user's final authorization.</li>
+      <li>A client that implements automated payment (paying without a human reviewing the amount in a payment application) MUST obtain the amount from the payment URI itself and MUST NOT rely on the <tt>&lt;display-amount/&gt;</tt> element for that purpose.</li>
       <li>Clients MUST NOT silently retry a stanza without presenting payment options to the user unless the client has been explicitly configured by the user to auto-pay up to a defined amount threshold.</li>
       <li>If the 'expires' time has passed before the user initiates payment, the client SHOULD request a fresh invoice via the proactive IQ flow rather than attempting to pay an expired one.</li>
     </ul>
@@ -507,19 +580,19 @@
     <li><tt>payto://upi/merchant@examplebank?amount=INR:200&amp;receiver-name=Example</tt> (India UPI)</li>
     <li><tt>payto://bitcoin/1A1zP1eP5QGefi2DMPTfTL5SLmv7Divf?amount=BTC:0.001</tt> (Bitcoin on-chain)</li>
   </ul>
-  <p>Implementations MAY also use the European Payments Council (EPC) QR code format for SEPA Credit Transfers (the 'epc-qr' scheme) as an alternative for European users, particularly in countries where this format is already widely deployed (Austria, Belgium, Finland, Germany, Netherlands).</p>
+  <p>Because each option carries a payment URI, any payment system reachable through a registered URI scheme is usable without modifying this specification, for example a <tt>lightning:</tt> invoice or a <tt>bitcoin:</tt> (BIP-0321) URI.</p>
+  <p>A QR code is normally generated directly from the payment URI: the client renders the URI string as a QR code without interpreting it, and the payer scans it with a wallet or banking application. This works natively for cryptocurrency URI schemes. For some bank-transfer systems, however, the payment application expects a different QR payload (for example, banking apps in several European countries scan a European Payments Council EPC069-12 payload rather than a <tt>payto</tt> URI). In that case the service MAY additionally supply that payload in the <tt>&lt;qr/&gt;</tt> child of the option, which the client likewise renders as a QR code without interpreting it. The payment URI itself remains REQUIRED, so a machine-readable, scheme-identified payment instruction is always present.</p>
   <p>When generating Lightning Network invoices for inclusion in an <tt>&lt;option/&gt;</tt> element, the service SHOULD encode the payment hash in a way that allows stateless preimage verification (see <link url='#protocol-verification'>Verification</link>), avoiding the need to query the Lightning node on every retry.</p>
 </section1>
 
 <section1 topic='Accessibility Considerations' anchor='access'>
   <p>Clients MUST NOT present a payment interface as the sole means of completing an action where an accessibility-equivalent alternative exists. Where a service also offers a &xep0158; CAPTCHA challenge, the payment option and the CAPTCHA option SHOULD be presented with equal prominence.</p>
-  <p>When rendering URI-based payment options as QR codes, clients SHOULD also present the underlying URI as selectable text so that users of screen readers or other assistive technologies can copy and use it directly.</p>
+  <p>When rendering a payment option as a QR code, whether from the payment URI or from a <tt>&lt;qr/&gt;</tt> payload, clients SHOULD also present the underlying payment URI as selectable text so that users of screen readers or other assistive technologies can copy and use it directly.</p>
 </section1>
 
 <section1 topic='Internationalization Considerations' anchor='i18n'>
   <p>The 'purpose' attribute of <tt>&lt;invoice/&gt;</tt> and the 'label' attribute of <tt>&lt;option/&gt;</tt> are human-readable strings. Services SHOULD provide these in the language of the recipient where known. Multiple language variants MAY be provided using the standard 'xml:lang' attribute on any element containing character data.</p>
-  <p>The 'amount' attribute uses machine-readable RFC 8905 notation (<tt>currency:unit.fraction</tt>) rather than locale-formatted strings to avoid locale-dependent parsing errors. Human-formatted amounts SHOULD be derived by the client from the machine-readable value. The <tt>&lt;display-amount/&gt;</tt> element MAY carry a pre-formatted string if the service wishes to control presentation, but clients SHOULD treat this as advisory only.</p>
-  <p>ISO 4217 currency codes MUST be used for all standard currencies. Non-ISO identifiers (e.g., BTC, msat) MAY be used for assets not covered by ISO 4217.</p>
+  <p>This specification does not define an amount or currency syntax of its own: the amount, currency, and any denomination are carried inside the payment URI and are governed by that URI scheme's own standard (for <tt>payto</tt>, the RFC 8905 <tt>currency:amount</tt> notation). The optional <tt>&lt;display-amount/&gt;</tt> element MAY carry a locale-formatted string for presentation, but clients MUST treat it as advisory only and MUST NOT use it as the authoritative amount (see <link url='#security-amount'>Amount Presentation Integrity</link>).</p>
 </section1>
 
 <section1 topic='Security Considerations' anchor='security'>
@@ -530,12 +603,24 @@
 
   <section2 topic='Session Binding' anchor='security-session-binding'>
     <p>Because XMPP servers routinely mutate stanzas in transit — adding elements such as <tt>&lt;delay/&gt;</tt>, rewriting the 'from' attribute, injecting stream management acknowledgements, and normalizing namespace prefixes — it is not possible for a service to cryptographically bind an invoice to the byte content of the stanza it declined. Body-level hashing, as used by HTTP-based payment protocols, is therefore not applicable in XMPP.</p>
-    <p>Instead, services SHOULD bind the 'session' attribute value to the parameters of the invoice itself using a keyed hash (HMAC). The RECOMMENDED input to the HMAC is the concatenation of: the service's JID, the 'purpose' value, the 'expires' value, and the total amount per scheme. Where the invoice was issued in response to a proactive <tt>&lt;get-invoice/&gt;</tt> request whose 'target' attribute identifies a specific resource (e.g., a content hash, a file identifier, or a room JID), the 'target' value SHOULD also be included as an HMAC input. This binds the session to the specific resource being purchased, so that a client cannot present a session identifier paid for resource A to obtain access to resource B.</p>
-    <p>Upon receiving a retried stanza, the service SHOULD recompute the HMAC over the same inputs and compare it against the received 'session' value. A session value that does not match MUST be rejected. This mechanism does not depend on any property of the client-supplied stanza, and therefore survives any server-side stanza mutation in transit.</p>
+    <p>A service therefore MUST verify a session against parameters it knows itself, never against any property of the client's retry stanza; this is what allows verification to survive server-side stanza mutation. The session value MUST be unguessable and MUST be bound to what was purchased (e.g. the resource the invoice grants access to and the amount required) so that a session obtained for one resource or amount cannot be redeemed for another. Where the invoice was issued in response to a proactive <tt>&lt;get-invoice/&gt;</tt> request, the 'target' resource SHOULD be part of this binding.</p>
+    <p>How the service achieves this is an implementation choice. It MAY store server-side state mapping the session to the invoice, or encode the binding into a self-contained keyed token, for example an HMAC over those service-side parameters (not the option URIs, which embed the session and are not echoed on retry) together with a per-invoice nonce, so that each session stays unique and can be re-verified without storing the invoice. Either way the service MUST record consumed sessions until they expire (see <link url='#security-replay'>Replay Attacks</link>): the token approach avoids storing invoice parameters but not the set of consumed sessions.</p>
   </section2>
   <section2 topic='Invoice Tampering' anchor='security-tampering'>
     <p>An intermediary XMPP server could modify <tt>&lt;invoice/&gt;</tt> contents in transit, redirecting payment destinations to attacker-controlled accounts. Implementations SHOULD use end-to-end encryption (e.g., &xep0384;) when the integrity of invoice contents is critical. For Lightning Network options, stateless preimage verification protects the service from granting access without payment: because the session identifier is bound to the payment hash (see <link url='#security-session-binding'>Session Binding</link>), a tampered invoice would yield a preimage that fails verification. This does not protect the payer, who may still send funds to an attacker; end-to-end encryption is required for that.</p>
     <p>For traditional bank transfer options, no equivalent cryptographic binding between the invoice and the beneficiary account exists. Users SHOULD independently verify beneficiary account details before initiating a bank transfer, particularly when communicating with a service for the first time.</p>
+  </section2>
+  <section2 topic='Amount Presentation Integrity' anchor='security-amount'>
+    <p>The authoritative amount and beneficiary of a payment are those encoded in the payment URI of the chosen <tt>&lt;option/&gt;</tt>. The <tt>&lt;display-amount/&gt;</tt> element and the <tt>label</tt> and <tt>purpose</tt> attributes are human-readable previews supplied by the service; like all invoice content they are mutable in transit (see <link url='#security-tampering'>Invoice Tampering</link>). Because these previews target the human rather than code, a discrepancy between a preview and the URI is a spoofing risk: a payer shown "EUR 5.00" might authorize a URI encoding a far larger amount or a different beneficiary.</p>
+    <p>Accordingly:</p>
+    <ul>
+      <li>A client MUST NOT present <tt>&lt;display-amount/&gt;</tt> (or any other preview field) as the authoritative amount, and MUST NOT use it as the basis for any automated decision, including the financial-safety threshold check of <link url='#security-financial'>Financial Safety</link>.</li>
+      <li>A client is not required to parse payment URIs. A client that treats the URI as opaque and delegates it to a payment application relies on that application to display the authoritative amount and beneficiary and to obtain the user's final authorization; such a client SHOULD make clear in its own UI that the invoice figures are service-supplied previews and that the binding amount is the one shown by the payment application.</li>
+      <li>A client that does parse the URI SHOULD render the amount derived from it (rather than <tt>&lt;display-amount/&gt;</tt>), and where it also shows <tt>&lt;display-amount/&gt;</tt> SHOULD treat that value as a string to validate against the authoritative amount; on a detectable mismatch it MUST prefer the URI value and SHOULD warn the user, as a mismatch is a strong tampering signal.</li>
+      <li>Only a client implementing automated payment (with no human reviewing the amount in a payment application) MUST derive the amount from the URI itself, since there is no downstream party to verify it.</li>
+      <li>A <tt>&lt;qr/&gt;</tt> payload, where present, is a rendering convenience and carries the same in-transit tampering risk as the URI and the previews; it is not a substitute for the payment application's confirmation of the authoritative amount and beneficiary. A client able to interpret both the URI and the <tt>&lt;qr/&gt;</tt> payload SHOULD verify that they describe the same payment.</li>
+    </ul>
+    <p>End-to-end encryption (e.g. &xep0384;) protects the integrity of both the URI and its previews in transit.</p>
   </section2>
   <section2 topic='Financial Safety' anchor='security-financial'>
     <p>Clients MUST NOT automatically pay an invoice above a configurable amount threshold without explicit user confirmation. Implementations SHOULD default this threshold to zero (i.e., all payments require explicit user approval) and SHOULD allow the user to raise it. Automated agents operating within a pre-authorized budget MAY raise this threshold programmatically for their specific use case, but MUST NOT do so without the knowledge and consent of the account holder.</p>
@@ -570,78 +655,12 @@
     <p>An entity that supports the error-flow portion of this protocol MUST advertise the feature 'urn:xmpp:payment:0'. An entity that additionally supports the proactive IQ-based invoice request MUST advertise 'urn:xmpp:payment:0#invoice-request'. An entity that supports emitting <tt>&lt;receipt/&gt;</tt> elements upon successful payment MUST advertise 'urn:xmpp:payment:0#receipt'.</p>
   </section2>
 
-  <section2 topic='Payment Schemes Registry' anchor='registrar-schemes'>
-    <p>The &REGISTRAR; shall maintain a registry of payment scheme identifiers for use in the 'scheme' attribute of the <tt>&lt;option/&gt;</tt> element. The RECOMMENDED process for registering a new scheme is to define it in a Standards Track XEP or in a published specification and submit a registration request to the &REGISTRAR;.</p>
-    <p>Each registration MUST specify all of the following:</p>
-    <ol>
-      <li><em>Scheme identifier</em> — A unique lowercase ASCII string used as the value of the 'scheme' attribute (e.g., <tt>payto</tt>, <tt>lightning-bolt11</tt>).</li>
-      <li><em>Payload format</em> — The syntax and semantics of the character data of the <tt>&lt;option/&gt;</tt> element when this scheme is used (e.g., a <tt>payto</tt> URI per RFC 8905, a BOLT 11 invoice string).</li>
-      <li><em>Proof format</em> — The proof type(s) that MAY accompany a <tt>&lt;payment/&gt;</tt> element for this scheme, and the syntax of the proof token (or explicitly "none" if no machine-verifiable proof exists for this scheme).</li>
-      <li><em>Verification procedure</em> — A description of how a service can verify that a payment was made, including any constraints on timing, idempotency, and the handling of asynchronous settlement.</li>
-    </ol>
-    <p>The initial contents of this registry are as follows.</p>
-    <table caption='Initial Payment Scheme Registry'>
-      <tr>
-        <th>Scheme</th>
-        <th>Description</th>
-        <th>Reference</th>
-      </tr>
-      <tr>
-        <td>payto</td>
-        <td>A 'payto' URI as defined by RFC 8905. This payment-system-neutral scheme covers IBAN/SEPA bank transfers, UPI, PIX, Bitcoin, and other payment target types within a single standardized format. RECOMMENDED as the primary URI scheme for this specification. Example: payto://iban/DE75512108001245126199?amount=EUR:200.00&amp;message=ref</td>
-        <td>RFC 8905</td>
-      </tr>
-      <tr>
-        <td>lightning-bolt11</td>
-        <td>A Lightning Network BOLT 11 invoice string (e.g., beginning with lnbc, lntbs, or another network prefix).</td>
-        <td>BOLT 11</td>
-      </tr>
-      <tr>
-        <td>lightning-bolt12</td>
-        <td>A Lightning Network BOLT 12 offer or invoice string (e.g., beginning with lno or lni).</td>
-        <td>BOLT 12</td>
-      </tr>
-      <tr>
-        <td>epc-qr</td>
-        <td>A European Payments Council QR code payload for SEPA Credit Transfers. Plain-text, newline-delimited format as defined by the EPC (EPC069-12). Commonly used in Austria, Belgium, Finland, Germany, and the Netherlands.</td>
-        <td>EPC069-12</td>
-      </tr>
-    </table>
-    <p>Implementors MAY define private or experimental schemes using reverse-domain-name notation (e.g., com.example.custompay) without &REGISTRAR; registration. Public schemes intended for interoperability MUST be registered.</p>
-  </section2>
-
-  <section2 topic='Proof Types Registry' anchor='registrar-prooftypes'>
-    <p>The &REGISTRAR; shall maintain a registry of proof type identifiers for use in the 'type' attribute of the <tt>&lt;proof/&gt;</tt> element. The initial contents of this registry are as follows.</p>
-    <table caption='Initial Proof Types Registry'>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-        <th>Payload Format</th>
-      </tr>
-      <tr>
-        <td>lightning-preimage</td>
-        <td>A 32-byte Lightning Network payment preimage, serving as cryptographic proof that the corresponding BOLT 11 or BOLT 12 invoice was paid.</td>
-        <td>64-character lowercase hexadecimal string</td>
-      </tr>
-      <tr>
-        <td>reference</td>
-        <td>A payment reference or transaction identifier provided by the payer's bank or payment network after completing a transfer. Examples include a SEPA end-to-end identifier, a UPI transaction ID, and a PIX end-to-end identifier (E2EID).</td>
-        <td>Alphanumeric string; format is network-dependent</td>
-      </tr>
-      <tr>
-        <td>txid</td>
-        <td>An on-chain blockchain transaction identifier (e.g., a Bitcoin transaction ID).</td>
-        <td>Transaction ID string; format is network-dependent</td>
-      </tr>
-      <tr>
-        <td>token</td>
-        <td>An opaque bearer token issued by a facilitator service following verified payment. Enables a "pay once, use many times" pattern within the token's validity period.</td>
-        <td>Opaque string; format is implementation-defined</td>
-      </tr>
-    </table>
+  <section2 topic='Payment Schemes and Proof Types' anchor='registrar-schemes'>
+    <p>This specification deliberately does <strong>not</strong> establish an &REGISTRAR; registry of payment schemes, payment systems, or proof-of-payment formats. Curating payment systems is outside the XSF's area of expertise and is already handled by external bodies. Payment options are identified by their URI scheme via the IANA URI Schemes registry, and for the <tt>payto</tt> scheme by the payment target types maintained externally under RFC 8905. Proof types are declared per option by the issuing service and echoed by the payer (see <link url='#protocol-payment'>The payment Element</link>); the conventional values listed there are non-normative and their formats are defined by the relevant payment systems' own specifications.</p>
   </section2>
 
   <section2 topic='Invoice Request Service Registry' anchor='registrar-services'>
+    <p>This is the one registry this specification defines, and it concerns XMPP application contexts (a domain within the XSF's remit) rather than payment systems.</p>
     <p>The &REGISTRAR; shall maintain a registry of service type identifiers for use in the 'service' attribute of the <tt>&lt;get-invoice/&gt;</tt> element. The initial contents of this registry are as follows.</p>
     <table caption='Initial Invoice Request Service Registry'>
       <tr>
@@ -717,28 +736,31 @@
 
   <xs:element name='description' type='xs:string'/>
 
-  <!-- option: one payment scheme within an invoice -->
+  <!-- option: one payment option (a payment URI) within an invoice -->
   <xs:element name='option'>
     <xs:complexType mixed='true'>
       <xs:sequence>
         <xs:element maxOccurs='1'
                     minOccurs='0'
                     ref='display-amount'/>
+        <xs:element maxOccurs='1'
+                    minOccurs='0'
+                    ref='qr'/>
       </xs:sequence>
-      <xs:attribute name='amount'
-                    type='xs:string'
-                    use='optional'/>
       <xs:attribute name='label'
                     type='xs:string'
                     use='optional'/>
-      <xs:attribute name='scheme'
+      <xs:attribute name='proof'
                     type='xs:string'
-                    use='required'/>
+                    use='optional'/>
     </xs:complexType>
   </xs:element>
 
   <!-- display-amount: locale-appropriate human-readable amount string -->
   <xs:element name='display-amount' type='xs:string'/>
+
+  <!-- qr: a payment string to be rendered as a QR code, for use when the URI is not the scannable payload -->
+  <xs:element name='qr' type='xs:string'/>
 
   <!-- payment: added to retried stanzas by the payer -->
   <xs:element name='payment'>
@@ -748,9 +770,6 @@
                     minOccurs='0'
                     ref='proof'/>
       </xs:sequence>
-      <xs:attribute name='scheme'
-                    type='xs:string'
-                    use='optional'/>
       <xs:attribute name='session'
                     type='xs:string'
                     use='required'/>
@@ -771,6 +790,9 @@
       <xs:attribute name='reason'
                     type='xs:string'
                     use='optional'/>
+      <xs:attribute name='retry-after'
+                    type='xs:nonNegativeInteger'
+                    use='optional'/>
     </xs:complexType>
   </xs:element>
 
@@ -780,9 +802,6 @@
       <xs:attribute name='reference'
                     type='xs:string'
                     use='optional'/>
-      <xs:attribute name='scheme'
-                    type='xs:string'
-                    use='required'/>
       <xs:attribute name='session'
                     type='xs:string'
                     use='required'/>

--- a/inbox/payment-required.xml
+++ b/inbox/payment-required.xml
@@ -46,7 +46,11 @@
       the payer, with a non-normative list of conventional types. Added the
       'payment-pending' reason and a 'retry-after' attribute returned with stanza error
       type "wait". Added security guidance on amount-presentation integrity and clarified
-      that clients need not parse payment URIs.</p>
+      that clients need not parse payment URIs. Removed the <tt>&lt;display-amount/&gt;</tt> element:
+      the amount is carried by the payment URI and obtained from there for display, avoiding a
+      duplicate, unverifiable amount that could diverge from the URI. Clarified that a client can
+      present any option without recognising its scheme — by QR code, URI handoff, or selectable
+      text — and narrowed the case in which an option is genuinely unactionable.</p>
     </remark>
   </revision>
   <revision>
@@ -158,7 +162,6 @@
       </description>
       <option label='Bank transfer (SEPA)'
               proof='reference'>payto://iban/DE02200400300200270112?amount=EUR:5.00&amp;message=upperroom-c4a1f902&amp;receiver-name=Capulet+Hosting
-        <display-amount>EUR 5.00</display-amount>
         <qr>BCD
 002
 1
@@ -173,11 +176,9 @@ upperroom-c4a1f902</qr>
       </option>
       <option label='UPI'
               proof='reference'>payto://upi/capulethosting@examplebank?amount=INR:450&amp;message=upperroom-c4a1f902&amp;receiver-name=Capulet+Hosting
-        <display-amount>&#x20B9; 450</display-amount>
       </option>
       <option label='Lightning Network (instant)'
               proof='preimage'>lightning:lnbc50n1pn2s4czpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq
-        <display-amount>EUR 5.00 via Lightning</display-amount>
       </option>
     </invoice>
   </error>
@@ -254,11 +255,9 @@ upperroom-c4a1f902</qr>
              xmlns='urn:xmpp:payment:0'>
       <option label='Lightning (instant, automated)'
               proof='preimage'>lightning:lnbc100n1pn2s3dzpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq
-        <display-amount>10 sats</display-amount>
       </option>
       <option label='BOLT 12 offer'
               proof='preimage'>lightning:lno1qgsyz4uzesxqcyq5rqwzqfqpqdynf
-        <display-amount>10 sats</display-amount>
       </option>
     </invoice>
   </error>
@@ -311,7 +310,6 @@ upperroom-c4a1f902</qr>
              xmlns='urn:xmpp:payment:0'>
       <option label='Lightning deposit'
               proof='preimage'>lightning:lnbc100n1pn2s5azpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq
-        <display-amount>10 sats</display-amount>
       </option>
     </invoice>
   </error>
@@ -342,11 +340,9 @@ upperroom-c4a1f902</qr>
            xmlns='urn:xmpp:payment:0'>
     <option label='Bank transfer (SEPA)'
             proof='reference'>payto://iban/DE02200400300200270112?amount=EUR:5.00&amp;message=3c91b2e4&amp;receiver-name=Capulet+Hosting
-      <display-amount>EUR 5.00</display-amount>
     </option>
     <option label='Lightning (instant)'
             proof='preimage'>lightning:lnbc50n1pn2s4czpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq
-      <display-amount>EUR 5.00</display-amount>
     </option>
   </invoice>
 </iq>
@@ -389,11 +385,9 @@ upperroom-c4a1f902</qr>
            xmlns='urn:xmpp:payment:0'>
     <option label='Bank transfer (SEPA)'
             proof='reference'>payto://iban/DE02200400300200270112?amount=EUR:0.01&amp;message=9d4e2c01
-      <display-amount>EUR 0.01</display-amount>
     </option>
     <option label='Lightning'
             proof='preimage'>lightning:lnbc10p1pn2s6azpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq
-      <display-amount>EUR 0.01</display-amount>
     </option>
   </invoice>
 </message>
@@ -430,7 +424,7 @@ upperroom-c4a1f902</qr>
         <li><tt>proof</tt> (OPTIONAL) — The type of proof-of-payment the service expects the payer to echo on retry (see <link url='#protocol-payment'>The payment Element</link>). The issuer declares this value and the payer returns it verbatim in the 'type' attribute of the <tt>&lt;proof/&gt;</tt> element. Its absence means the service verifies payment out of band and requires no payer-supplied proof. The value's meaning is defined by the payment system the option uses; <link url='#proof-types'>Conventional Proof Types</link> lists common values non-normatively.</li>
         <li><tt>label</tt> (OPTIONAL) — A short human-readable string for display in a list (e.g., "Bank transfer (SEPA)", "UPI", "Lightning").</li>
       </ul>
-      <p>The <tt>&lt;option/&gt;</tt> element MAY contain a <tt>&lt;display-amount/&gt;</tt> child element. This element contains a locale-appropriate human-readable string previewing the amount for the option, making no assumption about which currency or payment system is primary. Examples: "EUR 5.00", "&#x20B9; 450", "R 18.50", "USD 0.001", "1 000 sat". It is advisory only: it is a presentation hint, not the authoritative amount, and MUST NOT be relied upon for any automated decision (see <link url='#security-amount'>Amount Presentation Integrity</link>). The authoritative amount is the one encoded in the payment URI.</p>
+      <p>This specification does not define a separate human-readable amount field. The amount is carried in the payment URI: a client that parses the option's scheme reads it from there for display, while one that does not delegates the URI to a payment application that displays it (see <link url='#security-amount'>Amount Presentation Integrity</link>). A duplicate amount supplied alongside the URI would be redundant in the first case and unverifiable in the second. The amount is readily extracted from common schemes (<tt>payto</tt> from its <tt>amount=currency:value</tt> parameter, <tt>bitcoin:</tt> from its decimal <tt>amount</tt>, a <tt>lightning:</tt> BOLT 11 invoice from its prefix); for less common schemes, and where no amount is encoded at all (such as a zero-amount Lightning invoice), the payer's payment application presents the amount it is about to send for confirmation.</p>
       <p>The <tt>&lt;option/&gt;</tt> element MAY also contain a <tt>&lt;qr/&gt;</tt> child element whose character data is a payment string to be rendered as a QR code. This is useful where the payment URI is not itself the QR payload that the payer's payment application expects to scan, for example, a SEPA credit transfer for which banking apps scan a European Payments Council (EPC069-12) payload rather than a <tt>payto</tt> URI. A client renders the <tt>&lt;qr/&gt;</tt> content as a QR code <em>without interpreting it</em>, exactly as it would QR-encode the URI, so no scheme-specific parsing is required. This specification does not define or constrain the format of the <tt>&lt;qr/&gt;</tt> payload; that is a matter between the service and the scanning payment application. Because a payment URI is always present, the <tt>&lt;qr/&gt;</tt> element is purely an additional rendering convenience: it is not authoritative and is subject to the same integrity considerations as other invoice content (see <link url='#security-amount'>Amount Presentation Integrity</link>). Clients SHOULD also present the underlying URI as selectable text for accessibility.</p>
     </section3>
 
@@ -566,7 +560,8 @@ upperroom-c4a1f902</qr>
       <li>Automated agents SHOULD prefer instant-settlement options because these can be completed and verified programmatically without user interaction.</li>
       <li>Clients presenting a user interface SHOULD render URI-based options (e.g., <tt>payto</tt> URIs) as QR codes to facilitate payment from a mobile banking or wallet application.</li>
       <li>A client MAY treat a payment URI as an opaque string and delegate it to an external payment application (via an operating-system URI handler or a QR code) without parsing it. Such a client relies on the payment application to display the authoritative amount and beneficiary and to obtain the user's final authorization.</li>
-      <li>A client that implements automated payment (paying without a human reviewing the amount in a payment application) MUST obtain the amount from the payment URI itself and MUST NOT rely on the <tt>&lt;display-amount/&gt;</tt> element for that purpose.</li>
+      <li>A client MAY present a payment option without recognising its URI scheme by renderering the URI as a QR code for the user to scan, hand it to an operating-system URI handler, or show it as selectable text. Recognising the scheme is not a prerequisite for offering an option, and a client SHOULD NOT hide an option merely because it cannot parse its scheme. An option is genuinely unactionable only when the client can surface its URI to the payer in none of these ways (most plausibly an automated agent paying without human interaction and with no means of settling that scheme); such a client SHOULD act on whichever options it can and report that the remainder cannot be fulfilled rather than silently discarding them.</li>
+      <li>A client that implements automated payment (paying without a human reviewing the amount in a payment application) MUST obtain the amount from the payment URI itself.</li>
       <li>Clients MUST NOT silently retry a stanza without presenting payment options to the user unless the client has been explicitly configured by the user to auto-pay up to a defined amount threshold.</li>
       <li>If the 'expires' time has passed before the user initiates payment, the client SHOULD request a fresh invoice via the proactive IQ flow rather than attempting to pay an expired one.</li>
     </ul>
@@ -574,13 +569,13 @@ upperroom-c4a1f902</qr>
 </section1>
 
 <section1 topic='Implementation Notes' anchor='impl'>
-  <p>The 'payto' URI scheme (RFC 8905) is the RECOMMENDED primary URI scheme for this specification because it covers the widest range of payment networks within a single IETF-standardized format. Examples of valid payto URIs include:</p>
+  <p>The 'payto' URI scheme (RFC 8905) is the RECOMMENDED primary URI scheme for traditional bank rails, because it covers the widest range of them within a single IETF-standardized format. Examples of valid payto URIs include:</p>
   <ul>
     <li><tt>payto://iban/DE75512108001245126199?amount=EUR:200.00&amp;message=hello</tt> (SEPA bank transfer)</li>
     <li><tt>payto://upi/merchant@examplebank?amount=INR:200&amp;receiver-name=Example</tt> (India UPI)</li>
-    <li><tt>payto://bitcoin/1A1zP1eP5QGefi2DMPTfTL5SLmv7Divf?amount=BTC:0.001</tt> (Bitcoin on-chain)</li>
+    <li><tt>payto://ach/122000661/0000000123?amount=USD:200.00</tt> (US ACH transfer)</li>
   </ul>
-  <p>Because each option carries a payment URI, any payment system reachable through a registered URI scheme is usable without modifying this specification, for example a <tt>lightning:</tt> invoice or a <tt>bitcoin:</tt> (BIP-0321) URI.</p>
+  <p>Because each option carries a payment URI, any payment system reachable through a registered URI scheme is usable without modifying this specification. Cryptocurrency networks are addressed through their own native schemes rather than through a <tt>payto</tt> target type because typically the native scheme is the form the payer's wallet recognises (see <link url='#protocol-option'>The option Element</link>).</p>
   <p>A QR code is normally generated directly from the payment URI: the client renders the URI string as a QR code without interpreting it, and the payer scans it with a wallet or banking application. This works natively for cryptocurrency URI schemes. For some bank-transfer systems, however, the payment application expects a different QR payload (for example, banking apps in several European countries scan a European Payments Council EPC069-12 payload rather than a <tt>payto</tt> URI). In that case the service MAY additionally supply that payload in the <tt>&lt;qr/&gt;</tt> child of the option, which the client likewise renders as a QR code without interpreting it. The payment URI itself remains REQUIRED, so a machine-readable, scheme-identified payment instruction is always present.</p>
   <p>When generating Lightning Network invoices for inclusion in an <tt>&lt;option/&gt;</tt> element, the service SHOULD encode the payment hash in a way that allows stateless preimage verification (see <link url='#protocol-verification'>Verification</link>), avoiding the need to query the Lightning node on every retry.</p>
 </section1>
@@ -592,7 +587,7 @@ upperroom-c4a1f902</qr>
 
 <section1 topic='Internationalization Considerations' anchor='i18n'>
   <p>The 'purpose' attribute of <tt>&lt;invoice/&gt;</tt> and the 'label' attribute of <tt>&lt;option/&gt;</tt> are human-readable strings. Services SHOULD provide these in the language of the recipient where known. Multiple language variants MAY be provided using the standard 'xml:lang' attribute on any element containing character data.</p>
-  <p>This specification does not define an amount or currency syntax of its own: the amount, currency, and any denomination are carried inside the payment URI and are governed by that URI scheme's own standard (for <tt>payto</tt>, the RFC 8905 <tt>currency:amount</tt> notation). The optional <tt>&lt;display-amount/&gt;</tt> element MAY carry a locale-formatted string for presentation, but clients MUST treat it as advisory only and MUST NOT use it as the authoritative amount (see <link url='#security-amount'>Amount Presentation Integrity</link>).</p>
+  <p>This specification does not define an amount or currency syntax of its own: the amount, currency, and any denomination are carried inside the payment URI and are governed by that URI scheme's own standard (for <tt>payto</tt>, the RFC 8905 <tt>currency:amount</tt> notation). A client that displays the amount derives it from the URI and SHOULD format it for the recipient's locale.</p>
 </section1>
 
 <section1 topic='Security Considerations' anchor='security'>
@@ -611,16 +606,15 @@ upperroom-c4a1f902</qr>
     <p>For traditional bank transfer options, no equivalent cryptographic binding between the invoice and the beneficiary account exists. Users SHOULD independently verify beneficiary account details before initiating a bank transfer, particularly when communicating with a service for the first time.</p>
   </section2>
   <section2 topic='Amount Presentation Integrity' anchor='security-amount'>
-    <p>The authoritative amount and beneficiary of a payment are those encoded in the payment URI of the chosen <tt>&lt;option/&gt;</tt>. The <tt>&lt;display-amount/&gt;</tt> element and the <tt>label</tt> and <tt>purpose</tt> attributes are human-readable previews supplied by the service; like all invoice content they are mutable in transit (see <link url='#security-tampering'>Invoice Tampering</link>). Because these previews target the human rather than code, a discrepancy between a preview and the URI is a spoofing risk: a payer shown "EUR 5.00" might authorize a URI encoding a far larger amount or a different beneficiary.</p>
+    <p>The authoritative amount and beneficiary of a payment are those encoded in the payment URI of the chosen <tt>&lt;option/&gt;</tt>. This specification deliberately carries no separate human-readable amount field: a duplicate amount supplied alongside the URI could not be verified against it by a client that does not parse the scheme, and a preview diverging from the URI is a spoofing risk. The <tt>label</tt> and <tt>purpose</tt> attributes remain human-readable text describing the option and the reason for payment.</p>
     <p>Accordingly:</p>
     <ul>
-      <li>A client MUST NOT present <tt>&lt;display-amount/&gt;</tt> (or any other preview field) as the authoritative amount, and MUST NOT use it as the basis for any automated decision, including the financial-safety threshold check of <link url='#security-financial'>Financial Safety</link>.</li>
-      <li>A client is not required to parse payment URIs. A client that treats the URI as opaque and delegates it to a payment application relies on that application to display the authoritative amount and beneficiary and to obtain the user's final authorization; such a client SHOULD make clear in its own UI that the invoice figures are service-supplied previews and that the binding amount is the one shown by the payment application.</li>
-      <li>A client that does parse the URI SHOULD render the amount derived from it (rather than <tt>&lt;display-amount/&gt;</tt>), and where it also shows <tt>&lt;display-amount/&gt;</tt> SHOULD treat that value as a string to validate against the authoritative amount; on a detectable mismatch it MUST prefer the URI value and SHOULD warn the user, as a mismatch is a strong tampering signal.</li>
-      <li>Only a client implementing automated payment (with no human reviewing the amount in a payment application) MUST derive the amount from the URI itself, since there is no downstream party to verify it.</li>
-      <li>A <tt>&lt;qr/&gt;</tt> payload, where present, is a rendering convenience and carries the same in-transit tampering risk as the URI and the previews; it is not a substitute for the payment application's confirmation of the authoritative amount and beneficiary. A client able to interpret both the URI and the <tt>&lt;qr/&gt;</tt> payload SHOULD verify that they describe the same payment.</li>
+      <li>A client that displays an amount MUST derive it from the payment URI, and MUST NOT treat the <tt>label</tt>, <tt>purpose</tt>, or any other free-text field as an amount or use such a field as the basis for an automated decision, including the financial-safety threshold check of <link url='#security-financial'>Financial Safety</link>.</li>
+      <li>A client is not required to parse payment URIs. A client that treats the URI as opaque and delegates it to a payment application relies on that application to display the authoritative amount and beneficiary and to obtain the user's final authorization; such a client SHOULD make clear that the binding amount and beneficiary are those confirmed in the payment application. This is the established "what you see is what you sign" model: the trusted endpoint that authorizes the payment is also the one that re-displays its details.</li>
+      <li>A client implementing automated payment (with no human reviewing the amount in a payment application) MUST derive the amount from the URI itself, since there is no downstream party to verify it.</li>
+      <li>A <tt>&lt;qr/&gt;</tt> payload, where present, is a rendering convenience and carries the same in-transit tampering risk as the URI; it is not a substitute for the payment application's confirmation of the authoritative amount and beneficiary. A client able to interpret both the URI and the <tt>&lt;qr/&gt;</tt> payload SHOULD verify that they describe the same payment.</li>
     </ul>
-    <p>End-to-end encryption (e.g. &xep0384;) protects the integrity of both the URI and its previews in transit.</p>
+    <p>End-to-end encryption (e.g. &xep0384;) protects the integrity of the URI in transit.</p>
   </section2>
   <section2 topic='Financial Safety' anchor='security-financial'>
     <p>Clients MUST NOT automatically pay an invoice above a configurable amount threshold without explicit user confirmation. Implementations SHOULD default this threshold to zero (i.e., all payments require explicit user approval) and SHOULD allow the user to raise it. Automated agents operating within a pre-authorized budget MAY raise this threshold programmatically for their specific use case, but MUST NOT do so without the knowledge and consent of the account holder.</p>
@@ -742,9 +736,6 @@ upperroom-c4a1f902</qr>
       <xs:sequence>
         <xs:element maxOccurs='1'
                     minOccurs='0'
-                    ref='display-amount'/>
-        <xs:element maxOccurs='1'
-                    minOccurs='0'
                     ref='qr'/>
       </xs:sequence>
       <xs:attribute name='label'
@@ -755,9 +746,6 @@ upperroom-c4a1f902</qr>
                     use='optional'/>
     </xs:complexType>
   </xs:element>
-
-  <!-- display-amount: locale-appropriate human-readable amount string -->
-  <xs:element name='display-amount' type='xs:string'/>
 
   <!-- qr: a payment string to be rendered as a QR code, for use when the URI is not the scannable payload -->
   <xs:element name='qr' type='xs:string'/>


### PR DESCRIPTION
Following community review, restructure the ProtoXEP so it does not maintain its own registry of payment schemes or proof types:

- Each option payload is now a payment URI, identified by its URI scheme (IANA URI Schemes registry; payto target types per RFC 8905). The redundant 'scheme' and 'amount' attributes are removed; amount and currency are carried by the URI. The URI is now mandatory.
- Add an optional <qr/> child carrying a payment string to render as a QR code, for systems whose scannable QR format differs from the URI.
- Remove the Payment Schemes and Proof Types registries. Proof types are declared per option by the issuer and echoed by the payer, with a non-normative list of conventional types.
- Add the 'payment-pending' reason and a 'retry-after' attribute returned with stanza error type "wait" for asynchronous settlement.
- Add an Amount Presentation Integrity security section and clarify that clients need not parse payment URIs.
- Bind the session HMAC to service-side parameters (not the option URIs).