### PR TITLE
Add TeleTypTel ProtoXEP drafts for Total Conversation

### DIFF
--- a/inbox/jingle-session-history.xml
+++ b/inbox/jingle-session-history.xml
@@ -1,0 +1,424 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY % ents SYSTEM 'xep.ent'>
+%ents;
+]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+  <header>
+    <title>Jingle Session History</title>
+    <abstract>This specification defines an archiveable message event for representing Jingle call history, including missed calls, completed calls, Total Conversation calls, and optional recording or transcript metadata.</abstract>
+    &LEGALNOTICE;
+    <number>xxxx</number>
+    <status>ProtoXEP</status>
+    <type>Standards Track</type>
+    <sig>Standards</sig>
+    <approver>Council</approver>
+    <dependencies>
+      <spec>XMPP Core</spec>
+      <spec>XEP-0030</spec>
+      <spec>XEP-0166</spec>
+      <spec>XEP-0167</spec>
+      <spec>XEP-0301</spec>
+      <spec>XEP-0313</spec>
+      <spec>XEP-0334</spec>
+      <spec>XEP-0353</spec>
+      <spec>XEP-0447</spec>
+    </dependencies>
+    <supersedes/>
+    <supersededby/>
+    <shortname>jingle-session-history</shortname>
+    <tags>
+      <tag>jingle</tag>
+      <tag>history</tag>
+      <tag>calls</tag>
+      <tag>mam</tag>
+      <tag>accessibility</tag>
+    </tags>
+    <author>
+      <firstname>Edward</firstname>
+      <surname>Tie</surname>
+      <email>info@tiedragon.com</email>
+    </author>
+    <revision>
+      <version>0.0.1</version>
+      <date>2026-06-15</date>
+      <initials>et</initials>
+      <remark><p>Initial ProtoXEP submission.</p></remark>
+    </revision>
+  </header>
+
+  <section1 topic='Introduction' anchor='intro'>
+    <p>&xep0166; defines Jingle session signalling, and &xep0353; defines message-based Jingle initiation. These protocols describe how a call is proposed and negotiated, but they do not define a compact, archiveable call-history entry for the user-visible conversation timeline.</p>
+    <p>Many messaging clients show entries such as "missed video call", "voice call, 3:12", or "Total Conversation call, 12:44". Such entries need to synchronize across devices and may be archived by &xep0313;, but raw media streams do not belong in MAM.</p>
+    <p>This specification defines a <tt>jingle-history</tt> element carried inside an ordinary XMPP message stanza. The element describes the outcome and metadata of a Jingle session. It does not store media streams, recordings, RTP packets, WebRTC data channel contents, or location history.</p>
+  </section1>
+
+  <section1 topic='Requirements' anchor='reqs'>
+    <p>This specification is designed to meet the following requirements.</p>
+    <ol>
+      <li>Represent missed, declined, cancelled, failed, busy, timeout and completed Jingle calls as normal message events.</li>
+      <li>Represent audio, video, real-time text, captions, screen sharing, file and location media types in call summaries.</li>
+      <li>Allow Total Conversation calls to be shown as one timeline event without storing audio or video in MAM.</li>
+      <li>Support local-only call history for privacy-sensitive clients.</li>
+      <li>Support MAM-synchronized call history by using ordinary messages with fallback body text.</li>
+      <li>Represent optional recording and transcript availability as metadata only.</li>
+      <li>Support group calls and emergency-call profiles without requiring servers to understand Jingle media.</li>
+      <li>Remain compatible with clients that ignore the extension by requiring a readable message body.</li>
+    </ol>
+  </section1>
+
+  <section1 topic='Glossary' anchor='glossary'>
+    <dl>
+      <di>
+        <dt>Call-history event</dt>
+        <dd>An ordinary message stanza containing a <tt>jingle-history</tt> element.</dd>
+      </di>
+      <di>
+        <dt>Recording metadata</dt>
+        <dd>Information that a recording may exist elsewhere. The recording itself is not carried by this specification.</dd>
+      </di>
+      <di>
+        <dt>Total Conversation call</dt>
+        <dd>A call containing audio, video and real-time text as one conversational unit.</dd>
+      </di>
+      <di>
+        <dt>Local-only history</dt>
+        <dd>A call log stored only by a client and not sent as an XMPP message.</dd>
+      </di>
+    </dl>
+  </section1>
+
+  <section1 topic='Use Cases' anchor='usecases'>
+    <section2 topic='Missed video call' anchor='uc-missed'>
+      <p>A user receives a video call but does not answer before the call times out. The caller or callee stores a message event that can be shown as "Missed video call".</p>
+    </section2>
+    <section2 topic='Completed Total Conversation call' anchor='uc-total-conversation'>
+      <p>Two users complete a call containing audio, video and real-time text. The client stores one summary event with the Jingle session ID, media list, duration and transcript availability.</p>
+    </section2>
+    <section2 topic='Recording available separately' anchor='uc-recording'>
+      <p>A service deployment records calls only after explicit consent or policy-based rules. The call-history message records that a recording is available in cloud storage, while the file itself is described using a file-sharing protocol such as &xep0447;.</p>
+    </section2>
+    <section2 topic='Local privacy mode' anchor='uc-local'>
+      <p>A client may maintain a private local call log for failed or temporary calls. In that mode the client MUST NOT send the <tt>jingle-history</tt> message and MUST NOT rely on MAM to store the event.</p>
+    </section2>
+  </section1>
+
+  <section1 topic='Protocol Overview' anchor='overview'>
+    <p>The primary element is <tt>jingle-history</tt> qualified by the namespace <tt>urn:xmpp:jingle-history:0</tt>. It is carried as a child of a normal XMPP <tt>message</tt> stanza.</p>
+    <example caption='Missed video call'><![CDATA[
+<message from='romeo@example.net'
+         to='juliet@example.com'
+         type='chat'
+         id='msg-call-001'>
+  <body>Missed video call</body>
+  <jingle-history xmlns='urn:xmpp:jingle-history:0'
+                  sid='a73sjjvkla37jfea'
+                  direction='incoming'
+                  disposition='missed'
+                  media='audio video'
+                  profile='video'
+                  started='2026-06-15T14:03:10Z'
+                  ended='2026-06-15T14:03:42Z'
+                  duration='32'
+                  recording='none'
+                  transcript='none'/>
+  <store xmlns='urn:xmpp:hints'/>
+</message>
+]]></example>
+    <p>A client that does not understand this extension will still display the message body. A server that supports &xep0313; can archive the message as ordinary message history.</p>
+  </section1>
+
+  <section1 topic='Discovery' anchor='disco'>
+    <p>An entity supporting this specification MUST advertise the following discovery feature using &xep0030;:</p>
+    <example caption='Primary discovery feature'><![CDATA[
+<feature var='urn:xmpp:jingle-history:0'/>
+]]></example>
+    <p>Entities MAY advertise the following additional features when they implement the corresponding metadata profile:</p>
+    <example caption='Optional discovery features'><![CDATA[
+<feature var='urn:xmpp:jingle-history:recording:0'/>
+<feature var='urn:xmpp:jingle-history:transcript:0'/>
+<feature var='urn:xmpp:jingle-history:emergency:0'/>
+]]></example>
+  </section1>
+
+  <section1 topic='Application Format' anchor='format'>
+    <p>The <tt>jingle-history</tt> element has the following attributes.</p>
+    <table caption='Attributes of jingle-history'>
+      <tr>
+        <th>Attribute</th>
+        <th>Required</th>
+        <th>Values</th>
+        <th>Meaning</th>
+      </tr>
+      <tr>
+        <td>sid</td>
+        <td>yes</td>
+        <td>Jingle session ID</td>
+        <td>The session ID from the related Jingle session.</td>
+      </tr>
+      <tr>
+        <td>direction</td>
+        <td>yes</td>
+        <td>incoming, outgoing</td>
+        <td>Direction from the perspective of the archiving client.</td>
+      </tr>
+      <tr>
+        <td>disposition</td>
+        <td>yes</td>
+        <td>completed, missed, declined, cancelled, failed, busy, timeout, replaced, emergency</td>
+        <td>User-visible outcome of the session.</td>
+      </tr>
+      <tr>
+        <td>media</td>
+        <td>yes</td>
+        <td>Space-separated tokens: audio, video, rtt, captions, screen, file, location</td>
+        <td>Media or contextual modalities associated with the session.</td>
+      </tr>
+      <tr>
+        <td>profile</td>
+        <td>no</td>
+        <td>audio, video, total-conversation, group-call, emergency, screen-share, custom</td>
+        <td>High-level call profile.</td>
+      </tr>
+      <tr>
+        <td>started</td>
+        <td>no</td>
+        <td>ISO 8601 timestamp</td>
+        <td>When the relevant call attempt or session started.</td>
+      </tr>
+      <tr>
+        <td>ended</td>
+        <td>no</td>
+        <td>ISO 8601 timestamp</td>
+        <td>When the call attempt or session ended.</td>
+      </tr>
+      <tr>
+        <td>duration</td>
+        <td>no</td>
+        <td>Non-negative integer seconds</td>
+        <td>Call duration in seconds.</td>
+      </tr>
+      <tr>
+        <td>recording</td>
+        <td>no</td>
+        <td>none, local, cloud, external, policy-based</td>
+        <td>Whether a recording exists and where it is expected to be stored.</td>
+      </tr>
+      <tr>
+        <td>transcript</td>
+        <td>no</td>
+        <td>none, local, cloud, external, policy-based</td>
+        <td>Whether a transcript exists and where it is expected to be stored.</td>
+      </tr>
+      <tr>
+        <td>encrypted</td>
+        <td>no</td>
+        <td>true, false</td>
+        <td>Whether referenced recording or transcript material is known to be encrypted.</td>
+      </tr>
+      <tr>
+        <td>consent</td>
+        <td>no</td>
+        <td>none, initiator, all-participants, policy-based</td>
+        <td>Consent state for recording or transcript storage.</td>
+      </tr>
+      <tr>
+        <td>retention</td>
+        <td>no</td>
+        <td>Token such as 30d, 1y or policy</td>
+        <td>Known retention period or policy label.</td>
+      </tr>
+    </table>
+    <p>Unknown attributes and child elements MUST be ignored by receivers. Implementations SHOULD preserve unknown attributes and child elements when rewriting or exporting history, where practical.</p>
+  </section1>
+
+  <section1 topic='Recording and Transcript Metadata' anchor='metadata'>
+    <p>The <tt>recording</tt> and <tt>transcript</tt> attributes are intentionally summary fields. They do not contain the recording, transcript or file bytes.</p>
+    <p>A sender MAY include more detailed metadata using child elements in optional namespaces.</p>
+    <example caption='Detailed metadata'><![CDATA[
+<jingle-history xmlns='urn:xmpp:jingle-history:0'
+                sid='tc-777'
+                direction='incoming'
+                disposition='completed'
+                media='audio video rtt'
+                profile='total-conversation'
+                recording='cloud'
+                transcript='cloud'>
+  <recording xmlns='urn:xmpp:jingle-history:recording:0'
+             encrypted='true'
+             retention='30d'
+             consent='all-participants'
+             storage='cloud'/>
+  <transcript xmlns='urn:xmpp:jingle-history:transcript:0'
+              available='true'
+              storage='cloud'
+              encrypted='true'
+              language='nl'
+              source='rtt captions'/>
+</jingle-history>
+]]></example>
+    <p>If a recording or transcript file is shared with the user, the file metadata SHOULD be expressed using an existing file-sharing specification such as &xep0447; elsewhere in the same message or in a related message. This specification does not define a new file-transfer mechanism.</p>
+  </section1>
+
+  <section1 topic='MAM and Local Storage' anchor='mam'>
+    <p>In synchronized mode, the sender builds an ordinary message with a fallback body and a <tt>jingle-history</tt> element. The sender SHOULD include &xep0334; <tt>store</tt> when it wants the event to be archiveable.</p>
+    <p>In local-only mode, a client MUST NOT send the call-history message. The event is stored only by that client and is outside the scope of &xep0313;.</p>
+    <p>MAM stores event metadata only. It MUST NOT be used as a container for raw audio, raw video, RTP packets, WebRTC streams or full call recordings.</p>
+  </section1>
+
+  <section1 topic='Rendering Guidance' anchor='rendering'>
+    <p>Clients SHOULD render concise timeline summaries. Examples include:</p>
+    <ul>
+      <li>Missed video call</li>
+      <li>Audio call, 03:12</li>
+      <li>Video call, 12:44</li>
+      <li>Total Conversation call, 08:22</li>
+      <li>Emergency Total Conversation call</li>
+      <li>Call failed</li>
+      <li>Recording available</li>
+      <li>Transcript available</li>
+    </ul>
+    <p>Clients SHOULD show recording, transcript, encryption, consent and retention indicators when they are known.</p>
+  </section1>
+
+  <section1 topic='Group Calls' anchor='group'>
+    <p>For group calls, the <tt>jingle-history</tt> element MAY be sent in a <tt>groupchat</tt> message to the room. For this version, group-call support is limited to the room JID implied by the message route, <tt>sid</tt>, <tt>disposition</tt>, <tt>media</tt>, <tt>profile</tt> and <tt>duration</tt>.</p>
+    <example caption='Group call history'><![CDATA[
+<message from='room@conference.example.org/romeo'
+         to='room@conference.example.org'
+         type='groupchat'
+         id='group-call-001'>
+  <body>Group video call ended, 22:00</body>
+  <jingle-history xmlns='urn:xmpp:jingle-history:0'
+                  sid='group-abc'
+                  direction='outgoing'
+                  disposition='completed'
+                  media='audio video'
+                  profile='group-call'
+                  duration='1320'/>
+</message>
+]]></example>
+  </section1>
+
+  <section1 topic='Emergency Profile' anchor='emergency'>
+    <p>Emergency call history MAY be represented with <tt>profile='emergency'</tt> or <tt>disposition='emergency'</tt>. This specification is not an emergency-services routing or legal compliance protocol.</p>
+    <example caption='Emergency Total Conversation call'><![CDATA[
+<message type='chat' id='emergency-call-001'>
+  <body>Emergency Total Conversation call started</body>
+  <jingle-history xmlns='urn:xmpp:jingle-history:0'
+                  sid='em-112-001'
+                  direction='outgoing'
+                  disposition='emergency'
+                  media='audio video rtt captions location'
+                  profile='emergency'
+                  started='2026-06-15T17:10:00Z'
+                  recording='policy-based'
+                  transcript='policy-based'/>
+</message>
+]]></example>
+    <p>Precise location MUST NOT be placed directly in <tt>jingle-history</tt>. If location is needed, it should be represented using a secure location protocol or a separate call-scoped location event.</p>
+  </section1>
+
+  <section1 topic='Business Rules' anchor='rules'>
+    <ol>
+      <li>A fallback message body is REQUIRED.</li>
+      <li>Receivers MUST ignore malformed or unknown optional values instead of failing the whole message.</li>
+      <li>Clients MUST NOT automatically record calls because this extension is present.</li>
+      <li>Clients MUST NOT automatically upload transcripts because this extension is present.</li>
+      <li>Clients SHOULD use stable message IDs when possible so related reactions, corrections or display markers can refer to call-history events.</li>
+    </ol>
+  </section1>
+
+  <section1 topic='Accessibility Considerations' anchor='access'>
+    <p>This specification is motivated by accessibility and Total Conversation use cases. Clients SHOULD expose the media list and profile to assistive technologies, including whether real-time text or captions were part of the call.</p>
+    <p>Clients SHOULD avoid using color alone to represent missed, failed, emergency, recorded or transcript-available states.</p>
+  </section1>
+
+  <section1 topic='Security Considerations' anchor='security'>
+    <p>Remote <tt>jingle-history</tt> elements are untrusted input. Clients MUST validate required attributes, ignore invalid enum values and avoid allocating excessive memory for unusually large attributes.</p>
+    <p>Recording URLs and transcript URLs, if any, are outside this specification. Clients MUST treat any related file references as untrusted until verified by the file-sharing and encryption layer.</p>
+    <p>This specification does not provide end-to-end encryption. Deployments SHOULD use encrypted transport and end-to-end encryption where available.</p>
+  </section1>
+
+  <section1 topic='Privacy Considerations' anchor='privacy'>
+    <p>Call history can reveal sensitive social patterns, accessibility needs, emergency use, contact availability and communication habits. Clients SHOULD offer a local-only mode and retention controls.</p>
+    <p>Default behavior SHOULD store call-log metadata only. Audio or video recording requires explicit consent unless a clearly visible legal, emergency or service policy applies.</p>
+    <p>For group calls, implementations SHOULD support all-participant consent before recording or cloud transcript storage.</p>
+  </section1>
+
+  <section1 topic='IANA Considerations' anchor='iana'>
+    <p>This document requires no interaction with the Internet Assigned Numbers Authority.</p>
+  </section1>
+
+  <section1 topic='XMPP Registrar Considerations' anchor='registrar'>
+    <p>This specification requests registration of the following namespaces.</p>
+    <ul>
+      <li><tt>urn:xmpp:jingle-history:0</tt></li>
+      <li><tt>urn:xmpp:jingle-history:recording:0</tt></li>
+      <li><tt>urn:xmpp:jingle-history:transcript:0</tt></li>
+    </ul>
+    <p>This specification requests registration of the following service discovery features.</p>
+    <ul>
+      <li><tt>urn:xmpp:jingle-history:0</tt></li>
+      <li><tt>urn:xmpp:jingle-history:recording:0</tt></li>
+      <li><tt>urn:xmpp:jingle-history:transcript:0</tt></li>
+      <li><tt>urn:xmpp:jingle-history:emergency:0</tt></li>
+    </ul>
+  </section1>
+
+  <section1 topic='XML Schema' anchor='schema'>
+    <code><![CDATA[
+<?xml version='1.0' encoding='UTF-8'?>
+<xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='urn:xmpp:jingle-history:0'
+    xmlns='urn:xmpp:jingle-history:0'
+    elementFormDefault='qualified'>
+
+  <xs:element name='jingle-history'>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:any namespace='##other' minOccurs='0' maxOccurs='unbounded' processContents='lax'/>
+      </xs:sequence>
+      <xs:attribute name='sid' type='xs:string' use='required'/>
+      <xs:attribute name='direction' use='required'>
+        <xs:simpleType>
+          <xs:restriction base='xs:string'>
+            <xs:enumeration value='incoming'/>
+            <xs:enumeration value='outgoing'/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name='disposition' use='required'>
+        <xs:simpleType>
+          <xs:restriction base='xs:string'>
+            <xs:enumeration value='completed'/>
+            <xs:enumeration value='missed'/>
+            <xs:enumeration value='declined'/>
+            <xs:enumeration value='cancelled'/>
+            <xs:enumeration value='failed'/>
+            <xs:enumeration value='busy'/>
+            <xs:enumeration value='timeout'/>
+            <xs:enumeration value='replaced'/>
+            <xs:enumeration value='emergency'/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name='media' type='xs:string' use='required'/>
+      <xs:attribute name='profile' type='xs:string' use='optional'/>
+      <xs:attribute name='started' type='xs:dateTime' use='optional'/>
+      <xs:attribute name='ended' type='xs:dateTime' use='optional'/>
+      <xs:attribute name='duration' type='xs:nonNegativeInteger' use='optional'/>
+      <xs:attribute name='recording' type='xs:string' use='optional'/>
+      <xs:attribute name='transcript' type='xs:string' use='optional'/>
+      <xs:attribute name='encrypted' type='xs:boolean' use='optional'/>
+      <xs:attribute name='consent' type='xs:string' use='optional'/>
+      <xs:attribute name='retention' type='xs:string' use='optional'/>
+      <xs:anyAttribute namespace='##other' processContents='lax'/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+]]></code>
+  </section1>
+</xep>

--- a/inbox/total-conversation-profile.xml
+++ b/inbox/total-conversation-profile.xml
@@ -1,0 +1,323 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE xep SYSTEM 'xep.dtd' [
+  <!ENTITY % ents SYSTEM 'xep.ent'>
+%ents;
+]>
+<?xml-stylesheet type='text/xsl' href='xep.xsl'?>
+<xep>
+  <header>
+    <title>Total Conversation Profile</title>
+    <abstract>This specification defines a profile for XMPP clients that present audio, video, real-time text, captions, files and optional call-scoped context as one Total Conversation experience.</abstract>
+    &LEGALNOTICE;
+    <number>xxxx</number>
+    <status>ProtoXEP</status>
+    <type>Standards Track</type>
+    <sig>Standards</sig>
+    <approver>Council</approver>
+    <dependencies>
+      <spec>XMPP Core</spec>
+      <spec>XEP-0030</spec>
+      <spec>XEP-0080</spec>
+      <spec>XEP-0166</spec>
+      <spec>XEP-0167</spec>
+      <spec>XEP-0176</spec>
+      <spec>XEP-0215</spec>
+      <spec>XEP-0301</spec>
+      <spec>XEP-0313</spec>
+      <spec>XEP-0343</spec>
+      <spec>XEP-0353</spec>
+      <spec>XEP-0363</spec>
+      <spec>XEP-0479</spec>
+    </dependencies>
+    <supersedes/>
+    <supersededby/>
+    <shortname>total-conversation-profile</shortname>
+    <tags>
+      <tag>accessibility</tag>
+      <tag>jingle</tag>
+      <tag>rtt</tag>
+      <tag>webrtc</tag>
+      <tag>profile</tag>
+    </tags>
+    <author>
+      <firstname>Edward</firstname>
+      <surname>Tie</surname>
+      <email>info@tiedragon.com</email>
+    </author>
+    <revision>
+      <version>0.0.1</version>
+      <date>2026-06-15</date>
+      <initials>et</initials>
+      <remark><p>Initial ProtoXEP submission.</p></remark>
+    </revision>
+  </header>
+
+  <section1 topic='Introduction' anchor='intro'>
+    <p>Total Conversation is a user experience where real-time text, audio and video are available together as one conversation. XMPP already contains many of the necessary building blocks: &xep0301; for real-time text, &xep0166; and &xep0167; for Jingle calls, &xep0176; and &xep0215; for connectivity, and &xep0313; for archive retrieval.</p>
+    <p>However, an implementation can support several of these pieces and still fail to provide a coherent Total Conversation. The user may see audio and video in one call surface, while real-time text is sent as unrelated chat messages. Captions may be indistinguishable from typed text. Location may be global presence instead of call-scoped consent. Archives may not show whether text was synchronized with the call or merely a fallback.</p>
+    <p>This specification defines a profile claim and conformance model for XMPP Total Conversation clients. It composes existing XMPP RFCs and XEPs and references Jingle extensions for synchronized real-time text and call-scoped location.</p>
+  </section1>
+
+  <section1 topic='Requirements' anchor='reqs'>
+    <p>This specification is designed to meet the following requirements.</p>
+    <ol>
+      <li>Define what a client means when it claims Total Conversation support.</li>
+      <li>Keep normal XMPP messaging, real-time text and Jingle calls interoperable with existing XEPs.</li>
+      <li>Define progressive conformance levels from ordinary chat to synchronized Total Conversation.</li>
+      <li>Make fallback paths visible to users and assistive technologies.</li>
+      <li>Allow clients to discover supported modalities without inventing a new account or media system.</li>
+      <li>Describe how archives preserve the difference between synchronized text and fallback text.</li>
+      <li>Support accessibility, relay, interpreter, captioning and emergency-readiness experiments without claiming to be an emergency-services standard.</li>
+    </ol>
+  </section1>
+
+  <section1 topic='Glossary' anchor='glossary'>
+    <dl>
+      <di>
+        <dt>Total Conversation</dt>
+        <dd>A conversation containing simultaneous audio, video and real-time text.</dd>
+      </di>
+      <di>
+        <dt>Synchronized text</dt>
+        <dd>Real-time text, captions, translation or interpreter text bound to the same Jingle session as audio or video.</dd>
+      </di>
+      <di>
+        <dt>Fallback text</dt>
+        <dd>Real-time text sent outside the Jingle session, for example using &xep0301; in normal message stanzas.</dd>
+      </di>
+      <di>
+        <dt>Assistive context</dt>
+        <dd>Conversation metadata such as caption source, call-scoped location, interpreter state, language, fallback state and consent state.</dd>
+      </di>
+    </dl>
+  </section1>
+
+  <section1 topic='Relationship to Existing XEPs' anchor='relationship'>
+    <p>This specification does not replace audio, video, message, archive, file-transfer or encryption specifications. It defines how those specifications fit together when the user-visible product claims Total Conversation support.</p>
+    <table caption='Important building blocks'>
+      <tr>
+        <th>Protocol</th>
+        <th>Role in this profile</th>
+      </tr>
+      <tr>
+        <td>&xep0301;</td>
+        <td>Live text and fallback RTT outside Jingle.</td>
+      </tr>
+      <tr>
+        <td>&xep0166; and &xep0167;</td>
+        <td>Jingle signalling and RTP audio/video descriptions.</td>
+      </tr>
+      <tr>
+        <td>&xep0176;, &xep0215; and &xep0343;</td>
+        <td>Connectivity and WebRTC data channel signalling where applicable.</td>
+      </tr>
+      <tr>
+        <td>&xep0353;</td>
+        <td>Message-based Jingle proposal and ringing flow.</td>
+      </tr>
+      <tr>
+        <td>&xep0313;</td>
+        <td>Archive retrieval for messages, metadata and call-history events.</td>
+      </tr>
+      <tr>
+        <td>&xep0363; and &xep0447;</td>
+        <td>File upload and file metadata for attachments, voice messages, video messages or optional recordings.</td>
+      </tr>
+      <tr>
+        <td>&xep0479;</td>
+        <td>General XMPP client compliance baseline.</td>
+      </tr>
+    </table>
+    <p>A client MUST NOT claim this profile as a replacement for the underlying protocol support. For example, advertising the profile without supporting Jingle does not imply audio/video calling.</p>
+  </section1>
+
+  <section1 topic='Conformance Levels' anchor='levels'>
+    <p>The profile defines progressive levels. A client MUST NOT advertise a level higher than it can negotiate and present to the user.</p>
+    <table caption='Total Conversation levels'>
+      <tr>
+        <th>Level</th>
+        <th>Name</th>
+        <th>Required behavior</th>
+      </tr>
+      <tr>
+        <td>tc-0</td>
+        <td>Core conversation</td>
+        <td>Authenticated XMPP messaging, presence and service discovery.</td>
+      </tr>
+      <tr>
+        <td>tc-1</td>
+        <td>Live text conversation</td>
+        <td>tc-0 plus &xep0301; real-time text and readable message body fallback.</td>
+      </tr>
+      <tr>
+        <td>tc-2</td>
+        <td>Audio/video conversation</td>
+        <td>tc-1 plus Jingle call proposal and audio/video session signalling.</td>
+      </tr>
+      <tr>
+        <td>tc-3</td>
+        <td>Synchronized Total Conversation</td>
+        <td>tc-2 plus real-time text or captions negotiated as part of the same Jingle session.</td>
+      </tr>
+      <tr>
+        <td>tc-4</td>
+        <td>Assistive context</td>
+        <td>tc-3 plus consent-gated call-scoped context such as location, fallback state, caption source and service metadata.</td>
+      </tr>
+    </table>
+  </section1>
+
+  <section1 topic='Discovery' anchor='disco'>
+    <p>An entity supporting this profile MUST advertise the base profile feature using &xep0030;:</p>
+    <example caption='Base discovery feature'><![CDATA[
+<feature var='urn:xmpp:total-conversation:0'/>
+]]></example>
+    <p>The base feature says that the entity understands the profile family. Actual level and modalities SHOULD be carried in a service discovery extension form.</p>
+    <example caption='Discovery form'><![CDATA[
+<query xmlns='http://jabber.org/protocol/disco#info'>
+  <identity category='client' type='web' name='Example TC Client'/>
+  <feature var='urn:xmpp:total-conversation:0'/>
+  <x xmlns='jabber:x:data' type='result'>
+    <field var='FORM_TYPE' type='hidden'>
+      <value>urn:xmpp:total-conversation:0</value>
+    </field>
+    <field var='tc#level' type='list-single'>
+      <value>tc-3</value>
+    </field>
+    <field var='tc#modalities' type='list-multi'>
+      <value>chat</value>
+      <value>rtt</value>
+      <value>audio</value>
+      <value>video</value>
+      <value>caption</value>
+    </field>
+    <field var='tc#fallbacks' type='list-multi'>
+      <value>xep-0301</value>
+      <value>xep-0363</value>
+    </field>
+  </x>
+</query>
+]]></example>
+    <p>If a client advertises <tt>urn:xmpp:total-conversation:0</tt> but omits one of the underlying features, peers MUST treat that omitted part as unsupported.</p>
+  </section1>
+
+  <section1 topic='Profile Binding Model' anchor='binding'>
+    <p>Call-scoped media and context MUST be bound by at least the peer JID, Jingle session ID and Jingle content name. A peer JID alone is not sufficient because a user can have multiple devices, browser sessions, simultaneous calls or fallback chat paths.</p>
+    <example caption='Total Conversation content set'><![CDATA[
+Jingle sid: call-123
+  content audio     -> RTP audio
+  content video     -> RTP video
+  content text      -> synchronized real-time text or captions
+  content location  -> optional call-scoped location
+  content file      -> optional session-bound file transfer
+]]></example>
+    <p>If synchronized text is not negotiated but fallback &xep0301; is used, the user interface MUST show that the text is fallback text and not synchronized Jingle text.</p>
+  </section1>
+
+  <section1 topic='Use Cases' anchor='usecases'>
+    <section2 topic='Accessible video call' anchor='uc-accessible-call'>
+      <p>A deaf or hard-of-hearing user starts a call where sign-language video, audio and typed real-time text are visible together. The client advertises tc-3 because the text is part of the call session.</p>
+    </section2>
+    <section2 topic='Fallback real-time text' anchor='uc-fallback'>
+      <p>A peer supports audio/video Jingle but not synchronized Jingle text. The client continues the call and uses &xep0301; for fallback RTT. The user interface shows fallback state.</p>
+    </section2>
+    <section2 topic='Relay or interpreter service' anchor='uc-relay'>
+      <p>A user joins a call with a relay, captioner or interpreter service. The client identifies caption source and language when known and keeps the assistive text visibly associated with the call.</p>
+    </section2>
+    <section2 topic='Emergency-readiness experiment' anchor='uc-emergency'>
+      <p>A client can represent an emergency-oriented Total Conversation profile using audio, video, real-time text, captions and call-scoped location. This profile does not define PSAP routing or legal emergency-service requirements.</p>
+    </section2>
+  </section1>
+
+  <section1 topic='Archive and History' anchor='archive'>
+    <p>Archives MUST NOT erase whether text was synchronized, call-bound or fallback. If an archive contains call-bound text or call summaries, clients SHOULD retain enough metadata to show the Jingle session ID, content name, text source and synchronization state.</p>
+    <p>&xep0313; MAY store ordinary messages, real-time text fallback messages and archiveable call-history events. It MUST NOT be used to store raw RTP packets, WebRTC media streams, camera output or microphone output.</p>
+    <p>Optional recordings, video messages, voice messages and transcript files are file/media objects and should use existing file-sharing or upload specifications with appropriate consent, encryption and retention metadata.</p>
+  </section1>
+
+  <section1 topic='User Interface Rules' anchor='ui'>
+    <p>A Total Conversation client MUST make the following states visible to the user and available to assistive technologies where applicable.</p>
+    <ul>
+      <li>Whether live text is active.</li>
+      <li>Whether text is synchronized to the call or is fallback RTT.</li>
+      <li>Whether captions are human, ASR, interpreter, translation or system generated when known.</li>
+      <li>Whether audio and video are active, muted, held or failed.</li>
+      <li>Whether call-scoped location is shared.</li>
+      <li>Whether files or recordings are message attachments, session-bound transfers or external references.</li>
+    </ul>
+    <p>Color alone MUST NOT be the only indicator for fallback, recording, emergency, muted, failed or caption-source state.</p>
+  </section1>
+
+  <section1 topic='Business Rules' anchor='rules'>
+    <ol>
+      <li>A client MUST NOT advertise <tt>tc-3</tt> unless it can bind real-time text or captions to the same Jingle session as audio or video.</li>
+      <li>A client MUST NOT advertise <tt>tc-4</tt> unless it can represent assistive context and user consent state.</li>
+      <li>Fallback paths are allowed but MUST be visible.</li>
+      <li>This profile is not a codec registry. Audio and video codec negotiation remains delegated to the relevant Jingle RTP and WebRTC mechanisms.</li>
+      <li>This profile is not an emergency-services standard.</li>
+    </ol>
+  </section1>
+
+  <section1 topic='Accessibility Considerations' anchor='access'>
+    <p>This profile exists primarily because accessibility requires the conversation to be coherent. Deaf, hard-of-hearing, speech-impaired and mixed-hearing groups need to know whether text is typed by the other person, generated by ASR, entered by a captioner, translated, interpreted, delayed, synchronized to the call or fallback outside the call.</p>
+    <p>Implementations SHOULD provide keyboard-operable call, text, media, file and location controls; accessible names for icon-only controls; focus order that follows the conversation flow; sufficient contrast; and visible fallback warnings that do not rely on color alone.</p>
+  </section1>
+
+  <section1 topic='Security Considerations' anchor='security'>
+    <p>This profile can combine sensitive media, text, files, location and service metadata. Implementations SHOULD use encrypted transport and end-to-end encryption where available.</p>
+    <p>Downgrade attacks are important. If synchronized text falls back to ordinary &xep0301;, or call-scoped location falls back to global PEP location, the user MUST be informed.</p>
+    <p>Received captions, ASR text, translations and location data MUST NOT be treated as verified facts unless additional trust and verification mechanisms exist.</p>
+  </section1>
+
+  <section1 topic='Privacy Considerations' anchor='privacy'>
+    <p>Total Conversation can expose partial text before a message is final, live speech through captions, contact availability, file metadata, location and call participation across multiple devices.</p>
+    <p>Clients MUST ask for user consent before sending live location or enabling assistive services that involve third parties such as ASR, captioning, translation, relay or interpreter providers.</p>
+    <p>Location sharing MUST stop when the call ends, when the user stops sharing, when permission is revoked, or when the source becomes stale.</p>
+  </section1>
+
+  <section1 topic='IANA Considerations' anchor='iana'>
+    <p>This document requires no interaction with the Internet Assigned Numbers Authority.</p>
+  </section1>
+
+  <section1 topic='XMPP Registrar Considerations' anchor='registrar'>
+    <p>This specification requests registration of the following service discovery feature:</p>
+    <example caption='Registered feature'><![CDATA[
+urn:xmpp:total-conversation:0
+]]></example>
+    <p>This specification requests registration of the following XEP-0128 form type:</p>
+    <example caption='Registered form type'><![CDATA[
+FORM_TYPE = urn:xmpp:total-conversation:0
+]]></example>
+    <p>Initial form fields are:</p>
+    <table caption='Total Conversation discovery form fields'>
+      <tr>
+        <th>Field</th>
+        <th>Type</th>
+        <th>Values</th>
+        <th>Meaning</th>
+      </tr>
+      <tr>
+        <td>tc#level</td>
+        <td>list-single</td>
+        <td>tc-0, tc-1, tc-2, tc-3, tc-4</td>
+        <td>Highest Total Conversation level the entity can honestly negotiate.</td>
+      </tr>
+      <tr>
+        <td>tc#modalities</td>
+        <td>list-multi</td>
+        <td>chat, rtt, caption, audio, video, file, location, translation, interpreter</td>
+        <td>Conversation modalities the entity can present or send.</td>
+      </tr>
+      <tr>
+        <td>tc#fallbacks</td>
+        <td>list-multi</td>
+        <td>Protocol identifiers such as xep-0301, xep-0363 and xep-0080-pep</td>
+        <td>Fallback paths the entity can use and expose to users.</td>
+      </tr>
+    </table>
+  </section1>
+
+  <section1 topic='XML Schema' anchor='schema'>
+    <p>This profile defines a discovery feature and XEP-0128 data form, but no standalone XML payload.</p>
+  </section1>
+</xep>

--- a/inbox/total-conversation-profile.xml
+++ b/inbox/total-conversation-profile.xml
@@ -28,6 +28,7 @@
       <spec>XEP-0353</spec>
       <spec>XEP-0363</spec>
       <spec>XEP-0479</spec>
+      <spec>XEP-0517</spec>
     </dependencies>
     <supersedes/>
     <supersededby/>
@@ -45,6 +46,12 @@
       <email>info@tiedragon.com</email>
     </author>
     <revision>
+      <version>0.0.2</version>
+      <date>2026-07-01</date>
+      <initials>et</initials>
+      <remark><p>Update synchronized real-time text references after Jingle Synchronized Real-Time Text was accepted as XEP-0517.</p></remark>
+    </revision>
+    <revision>
       <version>0.0.1</version>
       <date>2026-06-15</date>
       <initials>et</initials>
@@ -53,9 +60,9 @@
   </header>
 
   <section1 topic='Introduction' anchor='intro'>
-    <p>Total Conversation is a user experience where real-time text, audio and video are available together as one conversation. XMPP already contains many of the necessary building blocks: &xep0301; for real-time text, &xep0166; and &xep0167; for Jingle calls, &xep0176; and &xep0215; for connectivity, and &xep0313; for archive retrieval.</p>
+    <p>Total Conversation is a user experience where real-time text, audio and video are available together as one conversation. XMPP already contains many of the necessary building blocks: &xep0301; for chat-oriented real-time text, &xep0166; and &xep0167; for Jingle calls, &xep0517; for Jingle synchronized real-time text, &xep0176; and &xep0215; for connectivity, and &xep0313; for archive retrieval.</p>
     <p>However, an implementation can support several of these pieces and still fail to provide a coherent Total Conversation. The user may see audio and video in one call surface, while real-time text is sent as unrelated chat messages. Captions may be indistinguishable from typed text. Location may be global presence instead of call-scoped consent. Archives may not show whether text was synchronized with the call or merely a fallback.</p>
-    <p>This specification defines a profile claim and conformance model for XMPP Total Conversation clients. It composes existing XMPP RFCs and XEPs and references Jingle extensions for synchronized real-time text and call-scoped location.</p>
+    <p>This specification defines a profile claim and conformance model for XMPP Total Conversation clients. It composes existing XMPP RFCs and XEPs, uses &xep0517; for synchronized real-time text, and references Jingle extensions for call-scoped location.</p>
   </section1>
 
   <section1 topic='Requirements' anchor='reqs'>
@@ -102,6 +109,10 @@
       <tr>
         <td>&xep0301;</td>
         <td>Live text and fallback RTT outside Jingle.</td>
+      </tr>
+      <tr>
+        <td>&xep0517;</td>
+        <td>Real-time text, captions, translation or interpreter text bound to the same Jingle session as audio/video.</td>
       </tr>
       <tr>
         <td>&xep0166; and &xep0167;</td>
@@ -157,7 +168,7 @@
       <tr>
         <td>tc-3</td>
         <td>Synchronized Total Conversation</td>
-        <td>tc-2 plus real-time text or captions negotiated as part of the same Jingle session.</td>
+        <td>tc-2 plus real-time text or captions negotiated as part of the same Jingle session using &xep0517; or a compatible future profile.</td>
       </tr>
       <tr>
         <td>tc-4</td>
@@ -207,11 +218,11 @@
 Jingle sid: call-123
   content audio     -> RTP audio
   content video     -> RTP video
-  content text      -> synchronized real-time text or captions
+  content text      -> XEP-0517 synchronized real-time text or captions
   content location  -> optional call-scoped location
   content file      -> optional session-bound file transfer
 ]]></example>
-    <p>If synchronized text is not negotiated but fallback &xep0301; is used, the user interface MUST show that the text is fallback text and not synchronized Jingle text.</p>
+    <p>If &xep0517; synchronized text is not negotiated but fallback &xep0301; is used, the user interface MUST show that the text is fallback text and not synchronized Jingle text.</p>
   </section1>
 
   <section1 topic='Use Cases' anchor='usecases'>
@@ -250,7 +261,7 @@ Jingle sid: call-123
 
   <section1 topic='Business Rules' anchor='rules'>
     <ol>
-      <li>A client MUST NOT advertise <tt>tc-3</tt> unless it can bind real-time text or captions to the same Jingle session as audio or video.</li>
+      <li>A client MUST NOT advertise <tt>tc-3</tt> unless it can bind real-time text or captions to the same Jingle session as audio or video, for example by negotiating &xep0517;.</li>
       <li>A client MUST NOT advertise <tt>tc-4</tt> unless it can represent assistive context and user consent state.</li>
       <li>Fallback paths are allowed but MUST be visible.</li>
       <li>This profile is not a codec registry. Audio and video codec negotiation remains delegated to the relevant Jingle RTP and WebRTC mechanisms.</li>


### PR DESCRIPTION
This PR adds TeleTypTel ProtoXEP drafts around Total Conversation session behavior.

Current contents:

- `inbox/jingle-session-history.xml`
- `inbox/total-conversation-profile.xml`

Update on 2026-07-01:

`total-conversation-profile` was updated to version `0.0.2` after Jingle Synchronized Real-Time Text was accepted as XEP-0517.

The Total Conversation profile now:

- lists XEP-0517 as a dependency;
- references `&xep0517;` as the synchronized real-time text building block;
- describes `tc-3` as Jingle-session-bound real-time text/captions using XEP-0517 or a compatible future profile;
- clarifies that XEP-0301 remains the fallback RTT path when XEP-0517 is not negotiated.

Local validation:

- `git diff --check`
- WSL build succeeded: `make build/inbox/total-conversation-profile.html`

Note: the local Windows checkout path contains a space, so the XEP Makefile was run from a temporary WSL copy without spaces in the path, with inbox symlinks restored for the build environment.