### PR TITLE
XEP-0143: Add author responsibility to submission process

### DIFF
--- a/xep-0143.xml
+++ b/xep-0143.xml
@@ -23,6 +23,12 @@
   <shortname>N/A</shortname>
   &stpeter;
   <revision>
+    <version>1.1.4</version>
+    <date>2026-07-08</date>
+    <initials>gdk</initials>
+    <remark><p>Add author responsibility to the submission process.</p></remark>
+  </revision>
+  <revision>
     <version>1.1.3</version>
     <date>2024-12-24</date>
     <initials>dwd</initials>
@@ -107,6 +113,7 @@
   <ol>
     <li>Write your proposal following the guidelines described in this document.</li>
     <li>Make sure that you read, understand, and agree to the &XSFIPR; before you submit your proposal.</li>
+    <li>You must understand, verify, and take responsibility for every part of your contribution.</li>
     <li>Ideally: Submit your XEP via a GitHub Pull Request that adds the file (and changes no others) to the "inbox" directory. (See <link url="#maintain">below</link> for a typical working pattern.</li>
     <li>If this cannot be done (perhaps because you have no GitHub account and do not wish to obtain one), send your XML file (or a URL pointing to the file) to the &SSIG; via email to standards@xmpp.org, and request someone to help you. (There are usually people who help the &EDITOR; in this way).</li>
   </ol>


### PR DESCRIPTION
Adds a requirement that authors understand, verify, and take responsibility for every part of their contribution.

Suggested by Ralph Meijer on the standards list, in the context of the discussion on AI-assisted contributions. The wording is deliberately not specific to AI: the obligation applies regardless of the tools an author uses.

This does not attempt to settle the wider discussion about AI use in specification authoring.