### PR TITLE
XEP-0134: Add  guideline against context-dependent elements

### DIFF
--- a/xep-0134.xml
+++ b/xep-0134.xml
@@ -20,6 +20,12 @@
   <shortname>N/A</shortname>
   &stpeter;
   <revision>
+    <version>1.2</version>
+    <date>2026-08-22</date>
+    <initials>fs</initials>
+    <remark>Add guideline against context-dependent elements.</remark>
+  </revision>
+  <revision>
     <version>1.1</version>
     <date>2004-12-09</date>
     <initials>psa</initials>
@@ -120,11 +126,19 @@
   </section2>
   <section2 topic='Privacy and Security Matter' anchor='privacy'>
     <p><em>Background</em></p>
-    <p>Since the beginning, privacy and security have been important priorities within the Jabber community. That must not change.</p>
-    <p><em>Meaning</em></p>
+    <p>Since the beginning, privacy and security have been important priorities within the Jabber community. That must not change.</p> 
+   <p><em>Meaning</em></p>
     <p>Good protocols respect the confidentiality of data generated or communicated by users and applications as well as the security of the system or network as a whole. Although privacy and security considerations have been dealt with at the core XMPP layer, application-level protocols must not compromise privacy and security. Attention to these matters, along with rigorous cross-area review and close scrutiny by protocol designers (in the form of the &COUNCIL; and &SSIG;), will help ensure that the protocols we develop will provide a strong foundation for communication over the Internet.</p>
     <p><em>Examples</em></p>
     <p>As is well-known, the presence subscription model developed by the Jabber community and specified in <cite>XMPP IM</cite> requires approval before a contact can view a user's presence. Similarly, Jabber has always included strong authentication methods, which have been further improved through the use of SASL (&rfc4422;).</p>
+  </section2>
+  <section2 topic='Avoid Context-Dependent Element Definitions' anchor='context-dependent'>
+    <p><em>Background</em></p>
+    <p>XMPP implementations often utilize highly optimized, low-level XML parsers to handle stream processing. These parsers typically lift and evaluate elements based purely on their Qualified Name (QName), i.e., the combination of the element name and its namespace, and generally avoid maintaining deep contextual state or parent-child hierarchical knowledge during the initial validation pass.</p>
+    <p><em>Meaning</em></p>
+    <p>Reusing the identical element QName across different contexts with differing structural requirements is an anti-pattern. For example, allowing a specific child element in one context but strictly forbidding it in another under the same element name unnecessarily prevents early validation. When elements are context-dependent, a parser cannot easily reject invalid structures without carrying additional contextual overhead. To keep client and server parsers simple, robust, and strict, different structural requirements should always map to distinct element names. This ensures that structural mistakes can be caught instantly during initial schema validation.</p>
+    <p><em>Examples</em></p>
+    <p>An example of this anti-pattern is reusing a &lt;foo/&gt; element both as a stream feature announcement and as an active command payload, where the command requires a &lt;tag/&gt; child but the stream feature strictly forbids it. Because the QName is identical, a parser cannot easily reject an invalid &lt;foo/&gt; containing a &lt;tag/&gt; when it appears inside a stream feature. If distinct elements were defined for these different contexts, such validation errors would be caught immediately.</p>
   </section2>
 </section1>
 <section1 topic='Security Considerations' anchor='security'>


### PR DESCRIPTION
Adds a new design guideline advising against the reuse of identical element QNames across different contexts when the structural requirements differ.

XMPP XML parsers typically rely on the QName for early, low-level validation. When a single element has context-dependent schemas, parsers are unable to easily reject invalid structures without maintaining additional contextual state. This commit introduces a section highlighting this anti-pattern and recommends mapping different structural requirements to distinct element names to ensure simple and strict validation.