### PR TITLE
XEP-0084: Fix example with both pubsub and HTTP source

### DIFF
--- a/xep-0084.xml
+++ b/xep-0084.xml
@@ -39,6 +39,12 @@
   &temas;
   &xvirge;
   <revision>
+    <version>1.1.5</version>
+    <date>2026-08-23</date>
+    <initials>nc</initials>
+    <remark><p>Fix inconsistent hash in the example with multiple data sources for the same file.</p></remark>
+  </revision>
+  <revision>
     <version>1.1.4</version>
     <date>2019-09-20</date>
     <initials>egp</initials>
@@ -445,7 +451,7 @@
                 width='64'/>
           <info bytes='12345'
                 height='64'
-                id='e279f80c38f99c1e7e53e262b440993b2f7eea57'
+                id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'
                 type='image/png'
                 url='http://avatars.example.org/happy.png'
                 width='64'/>


### PR DESCRIPTION
> the image encapsulated in the "image/png" content type is available both at a pubsub data node and at an HTTP URL; therefore it is included twice (the second time with a 'url' attribute).

Given that this is the same file, and that the id attribute value is the SHA1 sum of that file, then both `<info>` elements should have the same id. Unless I misunderstood something.